### PR TITLE
add --no-strip to cargo-deb so that it doesn't try (and fail) to strip cross-compiled artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: deb
-          args: --no-build --target=${{ matrix.job.target }} --variant=libzenohc
+          args: --no-build --no-strip --target=${{ matrix.job.target }} --variant=libzenohc
 
       - name: Debian package - libzenohc-dev
         if: contains(matrix.job.target, '-linux-gnu')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: deb
-          args: --no-build --target=${{ matrix.job.target }} --variant=libzenohc-dev
+          args: --no-build --no-strip --target=${{ matrix.job.target }} --variant=libzenohc-dev
 
       - name: Packaging
         id: package


### PR DESCRIPTION
Cross-platform release was failing because cargo-deb couldn't find the appropriate strip command.

I guess this stripping was added (somewhat) recently, breaking our releases. For now I disabled stripping (it wasn't happening before anyway), and we can try to strip again later if we find it relevant.