### PR TITLE
Rename z_owned_reply_data_t.data as z_owned_reply_data_t.sample

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -2357,7 +2357,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-std",
  "bincode",
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "zenoh-cfg-properties"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2415,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "flume",
  "json5",
@@ -2432,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -2441,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "aes",
  "hmac",
@@ -2454,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2473,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2488,7 +2488,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2560,7 +2560,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "libloading",
  "log",
@@ -2601,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "log",
  "uhlc",
@@ -2613,7 +2613,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "hex",
  "lazy_static",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-std",
  "event-listener",
@@ -2639,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e5111a75cf192bccdde3c633db267b7612202543"
+source = "git+https://github.com/eclipse-zenoh/zenoh#d661dbdaced3c6d5d19682b191b80ba24e0790f6"
 dependencies = [
  "async-std",
  "clap",

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -81,8 +81,8 @@ Query
 
       for(unsigned int i = 0; i < replies.len; ++i) {
           printf(">> Received (%.*s, %.*s)\n",
-            (int)replies.val[i].data.key.suffix.len, replies.val[i].data.key.suffix.start,
-            (int)replies.val[i].data.value.len, replies.val[i].data.value.start);
+            (int)replies.val[i].sample.key.suffix.len, replies.val[i].sample.key.suffix.start,
+            (int)replies.val[i].sample.value.len, replies.val[i].sample.value.start);
       }
       z_reply_data_array_free(z_move(replies));
 

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -52,8 +52,8 @@ int main(int argc, char **argv)
     for (unsigned int i = 0; i < replies.len; ++i)
     {
         printf(">> Received ('%.*s': '%.*s')\n",
-               (int)replies.val[i].data.key.suffix.len, replies.val[i].data.key.suffix.start,
-               (int)replies.val[i].data.value.len, replies.val[i].data.value.start);
+               (int)replies.val[i].sample.key.suffix.len, replies.val[i].sample.key.suffix.start,
+               (int)replies.val[i].sample.value.len, replies.val[i].sample.value.start);
     }
     z_reply_data_array_free(z_move(replies));
     z_close(z_move(s));

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -254,7 +254,7 @@ typedef struct z_owned_sample_t {
  * An owned reply to a `z_get` (or `z_get_collect`).
  *
  * Members:
- *   `z_owned_sample_t data`: a :c:type:`z_sample_t` containing the key and value of the reply.
+ *   `z_owned_sample_t sample`: a :c:type:`z_sample_t` containing the key and value of the reply.
  *   `unsigned int source_kind`: The kind of the replier that sent this reply.
  *   `z_owned_bytes_t replier_id`: The id of the replier that sent this reply.
  *
@@ -265,7 +265,7 @@ typedef struct z_owned_sample_t {
  * To check if `val` is still valid, you may use `z_X_check(&val)` (or `z_check(val)` if your compiler supports `_Generic`), which will return `true` if `val` is valid.
  */
 typedef struct z_owned_reply_data_t {
-  struct z_owned_sample_t data;
+  struct z_owned_sample_t sample;
   unsigned int source_kind;
   struct z_owned_bytes_t replier_id;
 } z_owned_reply_data_t;

--- a/src/types.rs
+++ b/src/types.rs
@@ -989,7 +989,7 @@ pub extern "C" fn z_subinfo_default() -> z_subinfo_t {
 /// An owned reply to a `z_get` (or `z_get_collect`).
 ///
 /// Members:
-///   `z_owned_sample_t data`: a :c:type:`z_sample_t` containing the key and value of the reply.
+///   `z_owned_sample_t sample`: a :c:type:`z_sample_t` containing the key and value of the reply.
 ///   `unsigned int source_kind`: The kind of the replier that sent this reply.
 ///   `z_owned_bytes_t replier_id`: The id of the replier that sent this reply.
 ///
@@ -1001,7 +1001,7 @@ pub extern "C" fn z_subinfo_default() -> z_subinfo_t {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 pub struct z_owned_reply_data_t {
-    data: z_owned_sample_t,
+    sample: z_owned_sample_t,
     source_kind: c_uint,
     replier_id: z_owned_bytes_t,
 }
@@ -1009,7 +1009,7 @@ impl z_owned_reply_data_t {
     #[inline]
     pub(crate) fn empty() -> Self {
         z_owned_reply_data_t {
-            data: z_owned_sample_t {
+            sample: z_owned_sample_t {
                 key: z_owned_keyexpr_t::default(),
                 value: z_owned_bytes_t::default(),
                 encoding: z_owned_encoding_t {
@@ -1030,7 +1030,7 @@ impl From<Reply> for z_owned_reply_data_t {
     #[inline]
     fn from(r: Reply) -> Self {
         z_owned_reply_data_t {
-            data: r.data.into(),
+            sample: r.sample.into(),
             source_kind: r.replier_kind as c_uint,
             replier_id: r.replier_id.into(),
         }
@@ -1041,14 +1041,14 @@ impl From<Reply> for z_owned_reply_data_t {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_reply_data_free(reply_data: &mut z_owned_reply_data_t) {
-    z_sample_free(&mut reply_data.data);
+    z_sample_free(&mut reply_data.sample);
     z_bytes_free(&mut reply_data.replier_id);
 }
 /// Returns `true` if `reply_data` is valid.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_reply_data_check(reply_data: &z_owned_reply_data_t) -> bool {
-    z_sample_check(&reply_data.data) && z_bytes_check(&reply_data.replier_id)
+    z_sample_check(&reply_data.sample) && z_bytes_check(&reply_data.replier_id)
 }
 
 /// A zenoh-allocated array of :c:type:`z_owned_reply_data_t`.


### PR DESCRIPTION
Following eclipse-zenoh/zenoh#233, in struct:
```C
typedef struct z_owned_reply_data_t {
  struct z_owned_sample_t data;
  unsigned int source_kind;
  struct z_owned_bytes_t replier_id;
} z_owned_reply_data_t;
```
this PR renames the `data` attribute as `sample`.
