### PR TITLE
Encoding and config rename

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,22 +35,22 @@ Session
 Session configuration
 ---------------------
 
-.. autocstruct:: zenoh_concrete.h::z_config_t
-.. autocstruct:: zenoh_concrete.h::z_owned_config_t
+.. autocstruct:: zenoh_concrete.h::zc_config_t
+.. autocstruct:: zenoh_concrete.h::zc_owned_config_t
 
-.. autocfunction:: zenoh_commons.h::z_config_new
-.. autocfunction:: zenoh_commons.h::z_config_default
-.. autocfunction:: zenoh_commons.h::z_config_empty
-.. autocfunction:: zenoh_commons.h::z_config_client
-.. autocfunction:: zenoh_commons.h::z_config_peer
-.. autocfunction:: zenoh_commons.h::z_config_from_file
-.. autocfunction:: zenoh_commons.h::z_config_from_str
-.. autocfunction:: zenoh_commons.h::z_config_insert_json
-.. autocfunction:: zenoh_commons.h::z_config_get
-.. autocfunction:: zenoh_commons.h::z_config_to_string
-.. autocfunction:: zenoh_commons.h::z_config_loan
-.. autocfunction:: zenoh_commons.h::z_config_check
-.. autocfunction:: zenoh_commons.h::z_config_drop
+.. autocfunction:: zenoh_commons.h::zc_config_new
+.. autocfunction:: zenoh_commons.h::zc_config_default
+.. autocfunction:: zenoh_commons.h::zc_config_empty
+.. autocfunction:: zenoh_commons.h::zc_config_client
+.. autocfunction:: zenoh_commons.h::zc_config_peer
+.. autocfunction:: zenoh_commons.h::zc_config_from_file
+.. autocfunction:: zenoh_commons.h::zc_config_from_str
+.. autocfunction:: zenoh_commons.h::zc_config_insert_json
+.. autocfunction:: zenoh_commons.h::zc_config_get
+.. autocfunction:: zenoh_commons.h::zc_config_to_string
+.. autocfunction:: zenoh_commons.h::zc_config_loan
+.. autocfunction:: zenoh_commons.h::zc_config_check
+.. autocfunction:: zenoh_commons.h::zc_config_drop
 
 Session management
 ------------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -25,7 +25,7 @@ Publish
   #include "zenoh.h"
 
   int main(int argc, char **argv) {
-      z_owned_config_t config = z_config_default();
+      zc_owned_config_t config = zc_config_default();
       z_owned_session_t s = z_open(z_move(config));
 
       char* value = "value";
@@ -51,7 +51,7 @@ Subscribe
   }
 
   int main(int argc, char **argv) {
-      z_owned_config_t config = z_config_default();
+      zc_owned_config_t config = zc_config_default();
       z_owned_session_t s = z_open(z_move(config));
 
       z_owned_closure_sample_t callback = z_closure(data_handler);
@@ -76,7 +76,7 @@ Query
   #include "zenoh.h"
 
   int main(int argc, char** argv) {
-      z_owned_config_t config = z_config_default();
+      zc_owned_config_t config = zc_config_default();
       z_owned_session_t s = z_open(z_move(config));
 
       z_owned_reply_channel_t channel = z_reply_fifo_new(16);

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -28,9 +28,9 @@ int main(int argc, char **argv) {
         printf("%s is not a valid key expression", expr);
         exit(-1);
     }
-    z_owned_config_t config = z_config_default();
+    zc_owned_config_t config = zc_config_default();
     if (argc > 2) {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2])) {
+        if (!zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2])) {
             printf(
                 "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
                 "JSON-serialized list of strings\n",

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -13,37 +13,35 @@
 
 #include <stdio.h>
 #include <string.h>
+
 #include "zenoh.h"
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     z_init_logger();
 
     char *expr = "demo/example/**";
-    if (argc > 1)
-    {
+    if (argc > 1) {
         expr = argv[1];
     }
     z_keyexpr_t keyexpr = z_keyexpr(expr);
-    if (!z_check(keyexpr))
-    {
+    if (!z_check(keyexpr)) {
         printf("%s is not a valid key expression", expr);
         exit(-1);
     }
     z_owned_config_t config = z_config_default();
-    if (argc > 2)
-    {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2]))
-        {
-            printf("Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a JSON-serialized list of strings\n", argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
+    if (argc > 2) {
+        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2])) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
             exit(-1);
         }
     }
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
-    if (!z_check(s))
-    {
+    if (!z_check(s)) {
         printf("Unable to open session!\n");
         exit(-1);
     }
@@ -52,19 +50,16 @@ int main(int argc, char **argv)
     z_get_options_t opts = z_get_options_default();
     opts.target = Z_QUERY_TARGET_ALL;
     z_owned_reply_channel_t channel = z_reply_fifo_new(16);
-    z_get(z_loan(s), keyexpr, "", z_move(channel.send), &opts); // here, the send is moved and will be dropped by zenoh when adequate
+    z_get(z_loan(s), keyexpr, "", z_move(channel.send),
+          &opts);  // here, the send is moved and will be dropped by zenoh when adequate
     z_owned_reply_t reply = z_reply_null();
-    for (z_call(channel.recv, &reply); z_check(reply); z_call(channel.recv, &reply))
-    {
-        if (z_reply_is_ok(&reply))
-        {
+    for (z_call(channel.recv, &reply); z_check(reply); z_call(channel.recv, &reply)) {
+        if (z_reply_is_ok(&reply)) {
             z_sample_t sample = z_reply_ok(&reply);
             char *keystr = z_keyexpr_to_string(sample.keyexpr);
             printf(">> Received ('%s': '%.*s')\n", keystr, (int)sample.payload.len, sample.payload.start);
             free(keystr);
-        }
-        else
-        {
+        } else {
             printf("Received an error\n");
         }
     }

--- a/examples/z_info.c
+++ b/examples/z_info.c
@@ -12,35 +12,33 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 
 #include <stdio.h>
+
 #include "zenoh.h"
 
-void print_zid(const z_id_t *id, const void *ctx)
-{
-    for (int i = 15; i >= 0; i--)
-    {
+void print_zid(const z_id_t *id, const void *ctx) {
+    for (int i = 15; i >= 0; i--) {
         printf("%02x", id->id[i]);
     }
     printf("\n");
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     z_init_logger();
 
     z_owned_config_t config = z_config_default();
-    if (argc > 1)
-    {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1]))
-        {
-            printf("Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a JSON-serialized list of strings\n", argv[1], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
+    if (argc > 1) {
+        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1])) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[1], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
             exit(-1);
         }
     }
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
-    if (!z_check(s))
-    {
+    if (!z_check(s)) {
         printf("Unable to open session!\n");
         exit(-1);
     }

--- a/examples/z_info.c
+++ b/examples/z_info.c
@@ -25,9 +25,9 @@ void print_zid(const z_id_t *id, const void *ctx) {
 int main(int argc, char **argv) {
     z_init_logger();
 
-    z_owned_config_t config = z_config_default();
+    zc_owned_config_t config = zc_config_default();
     if (argc > 1) {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1])) {
+        if (!zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1])) {
             printf(
                 "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
                 "JSON-serialized list of strings\n",

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -28,9 +28,9 @@ int main(int argc, char **argv) {
         printf("%s is not a valid key expression", expr);
         exit(-1);
     }
-    z_owned_config_t config = z_config_default();
+    zc_owned_config_t config = zc_config_default();
     if (argc > 2) {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2])) {
+        if (!zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2])) {
             printf(
                 "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
                 "JSON-serialized list of strings\n",

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -13,37 +13,35 @@
 
 #include <stdio.h>
 #include <string.h>
+
 #include "zenoh.h"
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     z_init_logger();
 
     char *expr = "demo/example/**";
-    if (argc > 1)
-    {
+    if (argc > 1) {
         expr = argv[1];
     }
     z_keyexpr_t keyexpr = z_keyexpr(expr);
-    if (!z_check(keyexpr))
-    {
+    if (!z_check(keyexpr)) {
         printf("%s is not a valid key expression", expr);
         exit(-1);
     }
     z_owned_config_t config = z_config_default();
-    if (argc > 2)
-    {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2]))
-        {
-            printf("Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a JSON-serialized list of strings\n", argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
+    if (argc > 2) {
+        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2])) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
             exit(-1);
         }
     }
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
-    if (!z_check(s))
-    {
+    if (!z_check(s)) {
         printf("Unable to open session!\n");
         exit(-1);
     }
@@ -52,23 +50,20 @@ int main(int argc, char **argv)
     z_get_options_t opts = z_get_options_default();
     opts.target = Z_QUERY_TARGET_ALL;
     z_owned_reply_channel_t channel = z_reply_non_blocking_fifo_new(16);
-    z_get(z_loan(s), keyexpr, "", z_move(channel.send), &opts); // here, the send is moved and will be dropped by zenoh when adequate
+    z_get(z_loan(s), keyexpr, "", z_move(channel.send),
+          &opts);  // here, the send is moved and will be dropped by zenoh when adequate
     z_owned_reply_t reply = z_reply_null();
-    for (bool call_success = z_call(channel.recv, &reply); !call_success || z_check(reply); call_success = z_call(channel.recv, &reply))
-    {
-        if (!call_success)
-        {
+    for (bool call_success = z_call(channel.recv, &reply); !call_success || z_check(reply);
+         call_success = z_call(channel.recv, &reply)) {
+        if (!call_success) {
             continue;
         }
-        if (z_reply_is_ok(&reply))
-        {
+        if (z_reply_is_ok(&reply)) {
             z_sample_t sample = z_reply_ok(&reply);
             char *keystr = z_keyexpr_to_string(sample.keyexpr);
             printf(">> Received ('%s': '%.*s')\n", keystr, (int)sample.payload.len, sample.payload.start);
             free(keystr);
-        }
-        else
-        {
+        } else {
             printf("Received an error\n");
         }
     }

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -13,6 +13,7 @@
 //
 #include <stdio.h>
 #include <string.h>
+
 #include "zenoh.h"
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
 #include <windows.h>
@@ -21,58 +22,52 @@
 #include <unistd.h>
 #endif
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     char *keyexpr = "demo/example/zenoh-c-pub";
     char *value = "Pub from C!";
 
     z_init_logger();
 
-    if (argc > 1)
-        keyexpr = argv[1];
-    if (argc > 2)
-        value = argv[2];
+    if (argc > 1) keyexpr = argv[1];
+    if (argc > 2) value = argv[2];
 
     z_owned_config_t config = z_config_default();
-    if (argc > 3)
-    {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3]))
-        {
-            printf("Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a JSON-serialized list of strings\n", argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
+    if (argc > 3) {
+        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3])) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
             exit(-1);
         }
     }
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
-    if (!z_check(s))
-    {
+    if (!z_check(s)) {
         printf("Unable to open session!\n");
         exit(-1);
     }
 
-    printf("Declaring key expression '%s'...", keyexpr);
-    z_owned_keyexpr_t ke = z_declare_keyexpr(z_loan(s), z_keyexpr(keyexpr));
-    if (!z_check(ke))
-    {
-        printf("Unable to declare key expression!\n");
+    printf("Declaring publisher for '%s'...\n", keyexpr);
+    z_owned_publisher_t pub = z_declare_publisher(z_session_loan(&s), z_keyexpr(keyexpr), NULL);
+    if (!z_publisher_check(&pub)) {
+        printf("Unable to declare publisher for key expression!\n");
         exit(-1);
     }
 
-    // @TODO: declare publisher
-
     char buf[256];
-    for (int idx = 0; 1; ++idx)
-    {
+    for (int idx = 0; 1; ++idx) {
         sleep(1);
         sprintf(buf, "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
-        z_put(z_loan(s), z_loan(ke), (const uint8_t *)buf, strlen(buf), NULL);
+        z_publisher_put_options_t options = z_publisher_put_options_default();
+        options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN);
+        z_publisher_put(z_loan(pub), (const uint8_t *)buf, strlen(buf), &options);
     }
 
-    // @TODO: undeclare publisher
+    z_undeclare_publisher(z_move(pub));
 
-    z_undeclare_keyexpr(z_loan(s), z_move(ke));
     z_close(z_move(s));
     return 0;
 }

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -31,9 +31,9 @@ int main(int argc, char **argv) {
     if (argc > 1) keyexpr = argv[1];
     if (argc > 2) value = argv[2];
 
-    z_owned_config_t config = z_config_default();
+    zc_owned_config_t config = zc_config_default();
     if (argc > 3) {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3])) {
+        if (!zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3])) {
             printf(
                 "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
                 "JSON-serialized list of strings\n",

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -29,9 +29,9 @@ int main(int argc, char **argv) {
     uint8_t *value = (uint8_t *)malloc(len);
     memset(value, 1, len);
 
-    z_owned_config_t config = z_config_default();
+    zc_owned_config_t config = zc_config_default();
     if (argc > 2) {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2])) {
+        if (!zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2])) {
             printf(
                 "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
                 "JSON-serialized list of strings\n",

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -20,38 +20,34 @@
 #endif
 #include "zenoh.h"
 
-void data_handler(const z_sample_t *sample, const void *arg)
-{
+void data_handler(const z_sample_t *sample, const void *arg) {
     char *keystr = z_keyexpr_to_string(sample->keyexpr);
-    printf(">> [Subscriber] Received ('%s': '%.*s')\n",
-           keystr, (int)sample->payload.len, sample->payload.start);
+    printf(">> [Subscriber] Received ('%s': '%.*s')\n", keystr, (int)sample->payload.len, sample->payload.start);
     free(keystr);
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     z_init_logger();
 
     char *expr = "demo/example/**";
-    if (argc > 1)
-    {
+    if (argc > 1) {
         expr = argv[1];
     }
 
     z_owned_config_t config = z_config_default();
-    if (argc > 2)
-    {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2]))
-        {
-            printf("Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a JSON-serialized list of strings\n", argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
+    if (argc > 2) {
+        if (!z_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2])) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
             exit(-1);
         }
     }
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
-    if (!z_check(s))
-    {
+    if (!z_check(s)) {
         printf("Unable to open session!\n");
         exit(-1);
     }
@@ -59,23 +55,18 @@ int main(int argc, char **argv)
     z_owned_closure_sample_t callback = z_closure(data_handler);
     printf("Declaring Subscriber on '%s'...\n", expr);
     z_owned_pull_subscriber_t sub = z_declare_pull_subscriber(z_loan(s), z_keyexpr(expr), z_move(callback), NULL);
-    if (!z_check(sub))
-    {
+    if (!z_check(sub)) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }
 
     printf("Press <enter> to pull data...\n");
     char c = 0;
-    while (c != 'q')
-    {
+    while (c != 'q') {
         c = getchar();
-        if (c == -1)
-        {
+        if (c == -1) {
             sleep(1);
-        }
-        else
-        {
+        } else {
             z_pull(&sub);
         }
     }

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -34,9 +34,9 @@ int main(int argc, char **argv) {
         expr = argv[1];
     }
 
-    z_owned_config_t config = z_config_default();
+    zc_owned_config_t config = zc_config_default();
     if (argc > 2) {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2])) {
+        if (!zc_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2])) {
             printf(
                 "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
                 "JSON-serialized list of strings\n",

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -25,9 +25,9 @@ int main(int argc, char **argv) {
     if (argc > 1) keyexpr = argv[1];
     if (argc > 2) value = argv[2];
 
-    z_owned_config_t config = z_config_default();
+    zc_owned_config_t config = zc_config_default();
     if (argc > 3) {
-        if (z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3])) {
+        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3])) {
             printf(
                 "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
                 "JSON-serialized list of strings\n",

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -13,42 +13,41 @@
 //
 #include <stdio.h>
 #include <string.h>
+
 #include "zenoh.h"
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     char *keyexpr = "demo/example/zenoh-c-put";
     char *value = "Put from C!";
 
     z_init_logger();
 
-    if (argc > 1)
-        keyexpr = argv[1];
-    if (argc > 2)
-        value = argv[2];
+    if (argc > 1) keyexpr = argv[1];
+    if (argc > 2) value = argv[2];
 
     z_owned_config_t config = z_config_default();
-    if (argc > 3)
-    {
-        if (z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3]))
-        {
-            printf("Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a JSON-serialized list of strings\n", argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
+    if (argc > 3) {
+        if (z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3])) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
             exit(-1);
         }
     }
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
-    if (!z_check(s))
-    {
+    if (!z_check(s)) {
         printf("Unable to open session!\n");
         exit(-1);
     }
 
     printf("Putting Data ('%s': '%s')...\n", keyexpr, value);
-    int res = z_put(z_loan(s), z_keyexpr(keyexpr), (const uint8_t *)value, strlen(value), NULL);
-    if (!res)
-    {
+    z_put_options_t options = z_put_options_default();
+    options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN);
+    int res = z_put(z_loan(s), z_keyexpr(keyexpr), (const uint8_t *)value, strlen(value), &options);
+    if (!res) {
         printf("Oh no! Put has failed...\n");
     }
 

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -41,9 +41,9 @@ int main(int argc, char **argv) {
     if (argc > 1) {
         expr = argv[1];
     }
-    z_owned_config_t config = z_config_default();
+    zc_owned_config_t config = zc_config_default();
     if (argc > 2) {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2])) {
+        if (!zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2])) {
             printf(
                 "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
                 "JSON-serialized list of strings\n",

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -25,43 +25,41 @@ char *expr = "demo/example/zenoh-c-queryable";
 char *value = "Queryable from C!";
 z_keyexpr_t keyexpr;
 
-void query_handler(z_query_t query, const void *context)
-{
+void query_handler(z_query_t query, const void *context) {
     char *keystr = z_keyexpr_to_string(z_query_keyexpr(query));
     z_bytes_t pred = z_query_value_selector(query);
     printf(">> [Queryable ] Received Query '%s%.*s'\n", keystr, (int)pred.len, pred.start);
-    z_query_reply(query, keyexpr, (const unsigned char *)value, strlen(value));
+    z_query_reply_options_t options = z_query_reply_options_default();
+    options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN);
+    z_query_reply(query, z_keyexpr(keystr), (const unsigned char *)value, strlen(value), &options);
     free(keystr);
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     z_init_logger();
 
-    if (argc > 1)
-    {
+    if (argc > 1) {
         expr = argv[1];
     }
     z_owned_config_t config = z_config_default();
-    if (argc > 2)
-    {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2]))
-        {
-            printf("Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a JSON-serialized list of strings\n", argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
+    if (argc > 2) {
+        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2])) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
             exit(-1);
         }
     }
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
-    if (!z_check(s))
-    {
+    if (!z_check(s)) {
         printf("Unable to open session!\n");
         exit(-1);
     }
     keyexpr = z_keyexpr(expr);
-    if (!z_check(keyexpr))
-    {
+    if (!z_check(keyexpr)) {
         printf("%s is not a valid key expression", expr);
         exit(-1);
     }
@@ -69,19 +67,16 @@ int main(int argc, char **argv)
     printf("Creating Queryable on '%s'...\n", expr);
     z_owned_closure_query_t callback = z_closure(query_handler);
     z_owned_queryable_t qable = z_declare_queryable(z_loan(s), keyexpr, z_move(callback), NULL);
-    if (!z_check(qable))
-    {
+    if (!z_check(qable)) {
         printf("Unable to create queryable.\n");
         exit(-1);
     }
 
     printf("Enter 'q' to quit...\n");
     char c = 0;
-    while (c != 'q')
-    {
+    while (c != 'q') {
         c = getchar();
-        if (c == -1)
-        {
+        if (c == -1) {
             sleep(1);
         }
     }

--- a/examples/z_scout.c
+++ b/examples/z_scout.c
@@ -99,8 +99,7 @@
 // }
 
 #include <stdio.h>
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     printf("Unimplemented\n");
     return -1;
 }

--- a/examples/z_scout.c
+++ b/examples/z_scout.c
@@ -78,7 +78,7 @@
 // {
 //     z_init_logger();
 
-//     z_owned_config_t config = z_config_default();
+//     zc_owned_config_t config = zc_config_default();
 
 //     printf("Scouting...\n");
 //     z_owned_hello_array_t hellos = z_scout(Z_ROUTER | Z_PEER, z_move(config), 1000);

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -20,38 +20,34 @@
 #endif
 #include "zenoh.h"
 
-void data_handler(const z_sample_t *sample, const void *arg)
-{
+void data_handler(const z_sample_t *sample, const void *arg) {
     char *keystr = z_keyexpr_to_string(sample->keyexpr);
-    printf(">> [Subscriber] Received ('%s': '%.*s')\n",
-           keystr, (int)sample->payload.len, sample->payload.start);
+    printf(">> [Subscriber] Received ('%s': '%.*s')\n", keystr, (int)sample->payload.len, sample->payload.start);
     free(keystr);
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     z_init_logger();
 
     char *expr = "demo/example/**";
-    if (argc > 1)
-    {
+    if (argc > 1) {
         expr = argv[1];
     }
 
     z_owned_config_t config = z_config_default();
-    if (argc > 2)
-    {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2]))
-        {
-            printf("Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a JSON-serialized list of strings\n", argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
+    if (argc > 2) {
+        if (!z_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2])) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
             exit(-1);
         }
     }
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
-    if (!z_check(s))
-    {
+    if (!z_check(s)) {
         printf("Unable to open session!\n");
         exit(-1);
     }
@@ -59,19 +55,16 @@ int main(int argc, char **argv)
     z_owned_closure_sample_t callback = z_closure(data_handler);
     printf("Declaring Subscriber on '%s'...\n", expr);
     z_owned_subscriber_t sub = z_declare_subscriber(z_loan(s), z_keyexpr(expr), z_move(callback), NULL);
-    if (!z_check(sub))
-    {
+    if (!z_check(sub)) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }
 
     printf("Enter 'q' to quit...\n");
     char c = 0;
-    while (c != 'q')
-    {
+    while (c != 'q') {
         c = getchar();
-        if (c == -1)
-        {
+        if (c == -1) {
             sleep(1);
         }
     }

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -34,9 +34,9 @@ int main(int argc, char **argv) {
         expr = argv[1];
     }
 
-    z_owned_config_t config = z_config_default();
+    zc_owned_config_t config = zc_config_default();
     if (argc > 2) {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2])) {
+        if (!zc_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2])) {
             printf(
                 "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
                 "JSON-serialized list of strings\n",

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -13,12 +13,12 @@
 //
 #include <stdio.h>
 #include <time.h>
+
 #include "zenoh.h"
 
 #define N 1000000
 
-typedef struct
-{
+typedef struct {
     volatile unsigned long count;
     volatile unsigned long finished_rounds;
     volatile clock_t start;
@@ -26,8 +26,7 @@ typedef struct
     volatile clock_t first_start;
 } z_stats_t;
 
-z_stats_t *z_stats_make()
-{
+z_stats_t *z_stats_make() {
     z_stats_t *stats = malloc(sizeof(z_stats_t));
     stats->count = 0;
     stats->finished_rounds = 0;
@@ -35,57 +34,49 @@ z_stats_t *z_stats_make()
     return stats;
 }
 
-void on_sample(const z_sample_t *sample, const void *context)
-{
+void on_sample(const z_sample_t *sample, const void *context) {
     z_stats_t *stats = (z_stats_t *)context;
-    if (stats->count == 0)
-    {
+    if (stats->count == 0) {
         stats->start = clock();
-        if (!stats->first_start)
-        {
+        if (!stats->first_start) {
             stats->first_start = stats->start;
         }
         stats->count++;
-    }
-    else if (stats->count < N)
-    {
+    } else if (stats->count < N) {
         stats->count++;
-    }
-    else
-    {
+    } else {
         stats->stop = clock();
         stats->finished_rounds++;
         printf("%f msg/s\n", N * (double)CLOCKS_PER_SEC / (double)(stats->stop - stats->start));
         stats->count = 0;
     }
 }
-void drop_stats(void *context)
-{
+void drop_stats(void *context) {
     const clock_t end = clock();
     const z_stats_t *stats = (z_stats_t *)context;
     const double elapsed = (double)(end - stats->first_start) / (double)CLOCKS_PER_SEC;
     const unsigned long sent_messages = N * stats->finished_rounds + stats->count;
-    printf("Stats being dropped after unsubscribing: sent %ld messages over %f seconds (%f msg/s)\n", sent_messages, elapsed, (double)sent_messages / elapsed);
+    printf("Stats being dropped after unsubscribing: sent %ld messages over %f seconds (%f msg/s)\n", sent_messages,
+           elapsed, (double)sent_messages / elapsed);
     free(context);
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     z_init_logger();
 
     z_owned_config_t config = z_config_default();
-    if (argc > 1)
-    {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1]))
-        {
-            printf("Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a JSON-serialized list of strings\n", argv[1], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
+    if (argc > 1) {
+        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1])) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[1], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
             exit(-1);
         }
     }
 
     z_owned_session_t s = z_open(z_move(config));
-    if (!z_check(s))
-    {
+    if (!z_check(s)) {
         printf("Unable to open session!\n");
         exit(-1);
     }
@@ -95,15 +86,13 @@ int main(int argc, char **argv)
     z_stats_t *context = z_stats_make();
     z_owned_closure_sample_t callback = z_closure(on_sample, drop_stats, context);
     z_owned_subscriber_t sub = z_declare_subscriber(z_loan(s), z_loan(ke), z_move(callback), NULL);
-    if (!z_check(sub))
-    {
+    if (!z_check(sub)) {
         printf("Unable to create subscriber.\n");
         exit(-1);
     }
 
     char c = 0;
-    while (c != 'q')
-    {
+    while (c != 'q') {
         c = fgetc(stdin);
     }
 

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -64,9 +64,9 @@ void drop_stats(void *context) {
 int main(int argc, char **argv) {
     z_init_logger();
 
-    z_owned_config_t config = z_config_default();
+    zc_owned_config_t config = zc_config_default();
     if (argc > 1) {
-        if (!z_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1])) {
+        if (!zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1])) {
             printf(
                 "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
                 "JSON-serialized list of strings\n",

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -31,27 +31,27 @@ typedef enum z_consolidation_mode_t {
 /**
  * A :c:type:`z_encoding_t` integer `prefix`.
  *
- *     - **Z_ENCODING_EMPTY**
- *     - **Z_ENCODING_APP_OCTET_STREAM**
- *     - **Z_ENCODING_APP_CUSTOM**
- *     - **Z_ENCODING_TEXT_PLAIN**
- *     - **Z_ENCODING_APP_PROPERTIES**
- *     - **Z_ENCODING_APP_JSON**
- *     - **Z_ENCODING_APP_SQL**
- *     - **Z_ENCODING_APP_INTEGER**
- *     - **Z_ENCODING_APP_FLOAT**
- *     - **Z_ENCODING_APP_XML**
- *     - **Z_ENCODING_APP_XHTML_XML**
- *     - **Z_ENCODING_APP_X_WWW_FORM_URLENCODED**
- *     - **Z_ENCODING_TEXT_JSON**
- *     - **Z_ENCODING_TEXT_HTML**
- *     - **Z_ENCODING_TEXT_XML**
- *     - **Z_ENCODING_TEXT_CSS**
- *     - **Z_ENCODING_TEXT_CSV**
- *     - **Z_ENCODING_TEXT_JAVASCRIPT**
- *     - **Z_ENCODING_IMAGE_JPEG**
- *     - **Z_ENCODING_IMAGE_PNG**
- *     - **Z_ENCODING_IMAGE_GIF**
+ *     - **Z_ENCODING_PREFIX_EMPTY**
+ *     - **Z_ENCODING_PREFIX_APP_OCTET_STREAM**
+ *     - **Z_ENCODING_PREFIX_APP_CUSTOM**
+ *     - **Z_ENCODING_PREFIX_TEXT_PLAIN**
+ *     - **Z_ENCODING_PREFIX_APP_PROPERTIES**
+ *     - **Z_ENCODING_PREFIX_APP_JSON**
+ *     - **Z_ENCODING_PREFIX_APP_SQL**
+ *     - **Z_ENCODING_PREFIX_APP_INTEGER**
+ *     - **Z_ENCODING_PREFIX_APP_FLOAT**
+ *     - **Z_ENCODING_PREFIX_APP_XML**
+ *     - **Z_ENCODING_PREFIX_APP_XHTML_XML**
+ *     - **Z_ENCODING_PREFIX_APP_X_WWW_FORM_URLENCODED**
+ *     - **Z_ENCODING_PREFIX_TEXT_JSON**
+ *     - **Z_ENCODING_PREFIX_TEXT_HTML**
+ *     - **Z_ENCODING_PREFIX_TEXT_XML**
+ *     - **Z_ENCODING_PREFIX_TEXT_CSS**
+ *     - **Z_ENCODING_PREFIX_TEXT_CSV**
+ *     - **Z_ENCODING_PREFIX_TEXT_JAVASCRIPT**
+ *     - **Z_ENCODING_PREFIX_IMAGE_JPEG**
+ *     - **Z_ENCODING_PREFIX_IMAGE_PNG**
+ *     - **Z_ENCODING_PREFIX_IMAGE_GIF**
  */
 typedef enum z_encoding_prefix_t {
   Z_ENCODING_PREFIX_EMPTY = 0,
@@ -544,70 +544,6 @@ void z_closure_zid_call(const struct z_owned_closure_zid_t *closure, const struc
  */
 void z_closure_zid_drop(struct z_owned_closure_zid_t *closure);
 /**
- * Returns ``true`` if `config` is valid.
- */
-bool z_config_check(const struct z_owned_config_t *config);
-/**
- * Constructs a default, zenoh-allocated, client mode configuration.
- * If `peer` is not null, it is added to the configuration as remote peer.
- */
-struct z_owned_config_t z_config_client(const char *const *peers, uintptr_t n_peers);
-/**
- * Creates a default, zenoh-allocated, configuration.
- */
-struct z_owned_config_t z_config_default(void);
-/**
- * Frees `config`, invalidating it for double-drop safety.
- */
-void z_config_drop(struct z_owned_config_t *config);
-/**
- * Creates an empty, zenoh-allocated, configuration.
- */
-struct z_owned_config_t z_config_empty(void);
-/**
- * Constructs a configuration by parsing a file at `path`. Currently supported format is JSON5, a superset of JSON.
- */
-struct z_owned_config_t z_config_from_file(const char *path);
-/**
- * Reads a configuration from a JSON-serialized string, such as '{mode:"client",connect:{endpoints:["tcp/127.0.0.1:7447"]}}'.
- */
-struct z_owned_config_t z_config_from_str(const char *s);
-/**
- * Gets the property with the given integer key from the configuration.
- */
-const char *z_config_get(struct z_config_t config, const char *key);
-/**
- * Inserts a JSON-serialized `value` at the `key` position of the configuration.
- *
- * Returns ``true`` if insertion was succesful, `false` otherwise.
- */
-bool z_config_insert_json(struct z_config_t config, const char *key, const char *value);
-/**
- * Returns a :c:type:`z_config_t` loaned from `s`.
- */
-struct z_config_t z_config_loan(const struct z_owned_config_t *s);
-/**
- * Return a new, zenoh-allocated, empty configuration.
- *
- * Like most `z_owned_X_t` types, you may obtain an instance of `z_X_t` by loaning it using `z_X_loan(&val)`.
- * The `z_loan(val)` macro, available if your compiler supports C11's `_Generic`, is equivalent to writing `z_X_loan(&val)`.
- *
- * Like all `z_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.
- * To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.
- * After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.
- *
- * To check if `val` is still valid, you may use `z_X_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
- */
-struct z_owned_config_t z_config_new(void);
-/**
- * Constructs a default, zenoh-allocated, peer mode configuration.
- */
-struct z_owned_config_t z_config_peer(void);
-/**
- * Converts `config` into a JSON-serialized string, such as '{"mode":"client","connect":{"endpoints":["tcp/127.0.0.1:7447"]}}'.
- */
-char *z_config_to_string(struct z_config_t config);
-/**
  * Declare a key expression. The id is returned as a :c:type:`z_keyexpr_t` with a nullptr suffix.
  *
  * This numerical id will be used on the network to save bandwidth and
@@ -965,7 +901,7 @@ struct z_keyexpr_t z_keyexpr_unchecked(const char *name);
 /**
  * Opens a zenoh session. Should the session opening fail, `z_check` ing the returned value will return `false`.
  */
-struct z_owned_session_t z_open(struct z_owned_config_t *config);
+struct z_owned_session_t z_open(struct zc_owned_config_t *config);
 /**
  * Returns ``true`` if `pub` is valid.
  */
@@ -1231,6 +1167,70 @@ void z_undeclare_queryable(struct z_owned_queryable_t *qable);
  * Undeclares the given :c:type:`z_owned_subscriber_t`, droping it and invalidating it for double-drop safety.
  */
 void z_undeclare_subscriber(struct z_owned_subscriber_t *sub);
+/**
+ * Returns ``true`` if `config` is valid.
+ */
+bool zc_config_check(const struct zc_owned_config_t *config);
+/**
+ * Constructs a default, zenoh-allocated, client mode configuration.
+ * If `peer` is not null, it is added to the configuration as remote peer.
+ */
+struct zc_owned_config_t zc_config_client(const char *const *peers, uintptr_t n_peers);
+/**
+ * Creates a default, zenoh-allocated, configuration.
+ */
+struct zc_owned_config_t zc_config_default(void);
+/**
+ * Frees `config`, invalidating it for double-drop safety.
+ */
+void zc_config_drop(struct zc_owned_config_t *config);
+/**
+ * Creates an empty, zenoh-allocated, configuration.
+ */
+struct zc_owned_config_t zc_config_empty(void);
+/**
+ * Constructs a configuration by parsing a file at `path`. Currently supported format is JSON5, a superset of JSON.
+ */
+struct zc_owned_config_t zc_config_from_file(const char *path);
+/**
+ * Reads a configuration from a JSON-serialized string, such as '{mode:"client",connect:{endpoints:["tcp/127.0.0.1:7447"]}}'.
+ */
+struct zc_owned_config_t zc_config_from_str(const char *s);
+/**
+ * Gets the property with the given integer key from the configuration.
+ */
+const char *zc_config_get(struct zc_config_t config, const char *key);
+/**
+ * Inserts a JSON-serialized `value` at the `key` position of the configuration.
+ *
+ * Returns ``true`` if insertion was succesful, `false` otherwise.
+ */
+bool zc_config_insert_json(struct zc_config_t config, const char *key, const char *value);
+/**
+ * Returns a :c:type:`zc_config_t` loaned from `s`.
+ */
+struct zc_config_t zc_config_loan(const struct zc_owned_config_t *s);
+/**
+ * Return a new, zenoh-allocated, empty configuration.
+ *
+ * Like most `z_owned_X_t` types, you may obtain an instance of `z_X_t` by loaning it using `z_X_loan(&val)`.
+ * The `z_loan(val)` macro, available if your compiler supports C11's `_Generic`, is equivalent to writing `z_X_loan(&val)`.
+ *
+ * Like all `z_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.
+ * To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.
+ * After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.
+ *
+ * To check if `val` is still valid, you may use `z_X_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
+ */
+struct zc_owned_config_t zc_config_new(void);
+/**
+ * Constructs a default, zenoh-allocated, peer mode configuration.
+ */
+struct zc_owned_config_t zc_config_peer(void);
+/**
+ * Converts `config` into a JSON-serialized string, such as '{"mode":"client","connect":{"endpoints":["tcp/127.0.0.1:7447"]}}'.
+ */
+char *zc_config_to_string(struct zc_config_t config);
 /**
  * Constructs a :c:type:`z_keyexpr_t` departing from a string.
  * It is a loaned key expression that aliases `name`.

--- a/include/zenoh_concrete.h
+++ b/include/zenoh_concrete.h
@@ -44,27 +44,6 @@ typedef struct z_owned_session_t {
   uintptr_t _0[3];
 } z_owned_session_t;
 /**
- * An owned zenoh configuration.
- *
- * Like most `z_owned_X_t` types, you may obtain an instance of `z_X_t` by loaning it using `z_X_loan(&val)`.
- * The `z_loan(val)` macro, available if your compiler supports C11's `_Generic`, is equivalent to writing `z_X_loan(&val)`.
- *
- * Like all `z_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.
- * To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.
- * After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.
- *
- * To check if `val` is still valid, you may use `z_X_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
- */
-typedef struct z_owned_config_t {
-  void *_0;
-} z_owned_config_t;
-/**
- * A loaned zenoh config.
- */
-typedef struct z_config_t {
-  const struct z_owned_config_t *_0;
-} z_config_t;
-/**
  * A loaned zenoh session.
  */
 typedef struct z_session_t {
@@ -100,3 +79,24 @@ typedef struct z_owned_queryable_t {
 typedef struct z_owned_subscriber_t {
   uintptr_t _0[1];
 } z_owned_subscriber_t;
+/**
+ * An owned zenoh configuration.
+ *
+ * Like most `z_owned_X_t` types, you may obtain an instance of `z_X_t` by loaning it using `z_X_loan(&val)`.
+ * The `z_loan(val)` macro, available if your compiler supports C11's `_Generic`, is equivalent to writing `z_X_loan(&val)`.
+ *
+ * Like all `z_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.
+ * To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.
+ * After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.
+ *
+ * To check if `val` is still valid, you may use `z_X_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
+ */
+typedef struct zc_owned_config_t {
+  void *_0;
+} zc_owned_config_t;
+/**
+ * A loaned zenoh config.
+ */
+typedef struct zc_config_t {
+  const struct zc_owned_config_t *_0;
+} zc_config_t;

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -1,62 +1,47 @@
-#define z_loan(x) _Generic((x), z_owned_session_t \
-                           : z_session_loan,      \
-                             z_owned_keyexpr_t    \
-                           : z_keyexpr_loan,      \
-                             z_owned_config_t     \
-                           : z_config_loan,       \
-                             z_owned_encoding_t   \
-                           : z_encoding_loan)(&x)
-#define z_drop(x) _Generic((x), z_owned_session_t                                  \
-                           : z_close,                                              \
-                             z_owned_keyexpr_t                                     \
-                           : z_keyexpr_drop,                                       \
-                             z_owned_config_t                                      \
-                           : z_config_drop,                                        \
-                             z_owned_pull_subscriber_t                             \
-                           : z_undeclare_pull_subscriber,                          \
-                             z_owned_subscriber_t                                  \
-                           : z_undeclare_subscriber,                               \
-                             z_owned_queryable_t                                   \
-                           : z_undeclare_queryable,                                \
-                             z_owned_encoding_t                                    \
-                           : z_encoding_drop,                                      \
-                             z_owned_reply_t                                       \
-                           : z_reply_drop, z_owned_closure_sample_t                \
-                           : z_closure_sample_drop, z_owned_closure_query_t        \
-                           : z_closure_query_drop, z_owned_closure_reply_t         \
-                           : z_closure_reply_drop, z_owned_reply_channel_closure_t \
-                           : z_reply_channel_closure_drop, z_owned_reply_channel_t \
-                           : z_reply_channel_drop)(&x)
-#define z_check(x) _Generic((x), z_owned_session_t      \
-                            : z_session_check,          \
-                              z_owned_keyexpr_t         \
-                            : z_keyexpr_check,          \
-                              z_keyexpr_t               \
-                            : z_keyexpr_is_valid,       \
-                              z_owned_config_t          \
-                            : z_config_check,           \
-                              z_bytes_t                 \
-                            : z_bytes_check,            \
-                              z_owned_subscriber_t      \
-                            : z_subscriber_check,       \
-                              z_owned_pull_subscriber_t \
-                            : z_pull_subscriber_check,  \
-                              z_owned_queryable_t       \
-                            : z_queryable_check,        \
-                              z_owned_encoding_t        \
-                            : z_encoding_check,         \
-                              z_owned_reply_t           \
-                            : z_reply_check)(&x)
+#define z_loan(x)                                   \
+    _Generic((x), z_owned_session_t                 \
+             : z_session_loan, z_owned_keyexpr_t    \
+             : z_keyexpr_loan, z_owned_config_t     \
+             : z_config_loan, z_owned_publisher_t   \
+             : z_publisher_loan, z_owned_encoding_t \
+             : z_encoding_loan)(&x)
+#define z_drop(x)                                                    \
+    _Generic((x), z_owned_session_t                                  \
+             : z_close, z_owned_keyexpr_t                            \
+             : z_keyexpr_drop, z_owned_config_t                      \
+             : z_config_drop, z_owned_pull_subscriber_t              \
+             : z_undeclare_pull_subscriber, z_owned_subscriber_t     \
+             : z_undeclare_subscriber, z_owned_queryable_t           \
+             : z_undeclare_queryable, z_owned_encoding_t             \
+             : z_encoding_drop, z_owned_reply_t                      \
+             : z_reply_drop, z_owned_closure_sample_t                \
+             : z_closure_sample_drop, z_owned_closure_query_t        \
+             : z_closure_query_drop, z_owned_closure_reply_t         \
+             : z_closure_reply_drop, z_owned_reply_channel_closure_t \
+             : z_reply_channel_closure_drop, z_owned_reply_channel_t \
+             : z_reply_channel_drop)(&x)
+#define z_check(x)                                           \
+    _Generic((x), z_owned_session_t                          \
+             : z_session_check, z_owned_publisher_t          \
+             : z_publisher_check, z_owned_keyexpr_t          \
+             : z_keyexpr_check, z_keyexpr_t                  \
+             : z_keyexpr_is_valid, z_owned_config_t          \
+             : z_config_check, z_bytes_t                     \
+             : z_bytes_check, z_owned_subscriber_t           \
+             : z_subscriber_check, z_owned_pull_subscriber_t \
+             : z_pull_subscriber_check, z_owned_queryable_t  \
+             : z_queryable_check, z_owned_encoding_t         \
+             : z_encoding_check, z_owned_reply_t             \
+             : z_reply_check)(&x)
 
-#define z_call(x, ...) _Generic((x), z_owned_closure_sample_t                           \
-                                : z_closure_sample_call, z_owned_closure_query_t        \
-                                : z_closure_query_call, z_owned_closure_reply_t         \
-                                : z_closure_reply_call, z_owned_reply_channel_closure_t \
-                                : z_reply_channel_closure_call)(&x, __VA_ARGS__)
+#define z_call(x, ...)                                               \
+    _Generic((x), z_owned_closure_sample_t                           \
+             : z_closure_sample_call, z_owned_closure_query_t        \
+             : z_closure_query_call, z_owned_closure_reply_t         \
+             : z_closure_reply_call, z_owned_reply_channel_closure_t \
+             : z_reply_channel_closure_call)(&x, __VA_ARGS__)
 
 #define _z_closure_overloader(callback, droper, ctx, ...) \
-  {                                                       \
-    .call = callback, .drop = droper, .context = ctx      \
-  }
+    { .call = callback, .drop = droper, .context = ctx }
 #define z_closure(...) _z_closure_overloader(__VA_ARGS__, NULL, NULL)
 #define z_move(x) (&x)

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -1,15 +1,15 @@
 #define z_loan(x)                                   \
     _Generic((x), z_owned_session_t                 \
              : z_session_loan, z_owned_keyexpr_t    \
-             : z_keyexpr_loan, z_owned_config_t     \
-             : z_config_loan, z_owned_publisher_t   \
+             : z_keyexpr_loan, zc_owned_config_t    \
+             : zc_config_loan, z_owned_publisher_t  \
              : z_publisher_loan, z_owned_encoding_t \
              : z_encoding_loan)(&x)
 #define z_drop(x)                                                    \
     _Generic((x), z_owned_session_t                                  \
              : z_close, z_owned_keyexpr_t                            \
-             : z_keyexpr_drop, z_owned_config_t                      \
-             : z_config_drop, z_owned_pull_subscriber_t              \
+             : z_keyexpr_drop, zc_owned_config_t                     \
+             : zc_config_drop, z_owned_pull_subscriber_t             \
              : z_undeclare_pull_subscriber, z_owned_subscriber_t     \
              : z_undeclare_subscriber, z_owned_queryable_t           \
              : z_undeclare_queryable, z_owned_encoding_t             \
@@ -25,8 +25,8 @@
              : z_session_check, z_owned_publisher_t          \
              : z_publisher_check, z_owned_keyexpr_t          \
              : z_keyexpr_check, z_keyexpr_t                  \
-             : z_keyexpr_is_valid, z_owned_config_t          \
-             : z_config_check, z_bytes_t                     \
+             : z_keyexpr_is_valid, zc_owned_config_t         \
+             : zc_config_check, z_bytes_t                    \
              : z_bytes_check, z_owned_subscriber_t           \
              : z_subscriber_check, z_owned_pull_subscriber_t \
              : z_pull_subscriber_check, z_owned_queryable_t  \

--- a/splitguide.yaml
+++ b/splitguide.yaml
@@ -8,6 +8,6 @@ zenoh_concrete.h:
   - z_owned_session_t!
   - z_session_t!
   - z_owned_subscriber_t!
-  - z_owned_config_t!
-  - z_config_t!
+  - zc_owned_config_t!
+  - zc_config_t!
   - z_owned_queryable_t!

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -103,27 +103,27 @@ pub struct z_sample_t {
 
 /// A :c:type:`z_encoding_t` integer `prefix`.
 ///
-///     - **Z_ENCODING_PREFIX_EMPTY**
-///     - **Z_ENCODING_PREFIX_APP_OCTET_STREAM**
-///     - **Z_ENCODING_PREFIX_APP_CUSTOM**
-///     - **Z_ENCODING_PREFIX_TEXT_PLAIN**
-///     - **Z_ENCODING_PREFIX_APP_PROPERTIES**
-///     - **Z_ENCODING_PREFIX_APP_JSON**
-///     - **Z_ENCODING_PREFIX_APP_SQL**
-///     - **Z_ENCODING_PREFIX_APP_INTEGER**
-///     - **Z_ENCODING_PREFIX_APP_FLOAT**
-///     - **Z_ENCODING_PREFIX_APP_XML**
-///     - **Z_ENCODING_PREFIX_APP_XHTML_XML**
-///     - **Z_ENCODING_PREFIX_APP_X_WWW_FORM_URLENCODED**
-///     - **Z_ENCODING_PREFIX_TEXT_JSON**
-///     - **Z_ENCODING_PREFIX_TEXT_HTML**
-///     - **Z_ENCODING_PREFIX_TEXT_XML**
-///     - **Z_ENCODING_PREFIX_TEXT_CSS**
-///     - **Z_ENCODING_PREFIX_TEXT_CSV**
-///     - **Z_ENCODING_PREFIX_TEXT_JAVASCRIPT**
-///     - **Z_ENCODING_PREFIX_IMAGE_JPEG**
-///     - **Z_ENCODING_PREFIX_IMAGE_PNG**
-///     - **Z_ENCODING_PREFIX_IMAGE_GIF**
+///     - **Z_ENCODING_EMPTY**
+///     - **Z_ENCODING_APP_OCTET_STREAM**
+///     - **Z_ENCODING_APP_CUSTOM**
+///     - **Z_ENCODING_TEXT_PLAIN**
+///     - **Z_ENCODING_APP_PROPERTIES**
+///     - **Z_ENCODING_APP_JSON**
+///     - **Z_ENCODING_APP_SQL**
+///     - **Z_ENCODING_APP_INTEGER**
+///     - **Z_ENCODING_APP_FLOAT**
+///     - **Z_ENCODING_APP_XML**
+///     - **Z_ENCODING_APP_XHTML_XML**
+///     - **Z_ENCODING_APP_X_WWW_FORM_URLENCODED**
+///     - **Z_ENCODING_TEXT_JSON**
+///     - **Z_ENCODING_TEXT_HTML**
+///     - **Z_ENCODING_TEXT_XML**
+///     - **Z_ENCODING_TEXT_CSS**
+///     - **Z_ENCODING_TEXT_CSV**
+///     - **Z_ENCODING_TEXT_JAVASCRIPT**
+///     - **Z_ENCODING_IMAGE_JPEG**
+///     - **Z_ENCODING_IMAGE_PNG**
+///     - **Z_ENCODING_IMAGE_GIF**
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub enum z_encoding_prefix_t {
@@ -288,6 +288,16 @@ pub struct z_owned_encoding_t {
     pub prefix: z_encoding_prefix_t,
     pub suffix: z_bytes_t,
     pub _dropped: bool,
+}
+
+/// Constructs a specific :c:type:`z_encoding_t`.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn z_encoding(prefix: z_encoding_prefix_t) -> z_encoding_t {
+    z_encoding_t {
+        prefix,
+        suffix: z_bytes_t::empty(),
+    }
 }
 
 /// Constructs a default :c:type:`z_encoding_t`.

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -103,27 +103,27 @@ pub struct z_sample_t {
 
 /// A :c:type:`z_encoding_t` integer `prefix`.
 ///
-///     - **Z_ENCODING_EMPTY**
-///     - **Z_ENCODING_APP_OCTET_STREAM**
-///     - **Z_ENCODING_APP_CUSTOM**
-///     - **Z_ENCODING_TEXT_PLAIN**
-///     - **Z_ENCODING_APP_PROPERTIES**
-///     - **Z_ENCODING_APP_JSON**
-///     - **Z_ENCODING_APP_SQL**
-///     - **Z_ENCODING_APP_INTEGER**
-///     - **Z_ENCODING_APP_FLOAT**
-///     - **Z_ENCODING_APP_XML**
-///     - **Z_ENCODING_APP_XHTML_XML**
-///     - **Z_ENCODING_APP_X_WWW_FORM_URLENCODED**
-///     - **Z_ENCODING_TEXT_JSON**
-///     - **Z_ENCODING_TEXT_HTML**
-///     - **Z_ENCODING_TEXT_XML**
-///     - **Z_ENCODING_TEXT_CSS**
-///     - **Z_ENCODING_TEXT_CSV**
-///     - **Z_ENCODING_TEXT_JAVASCRIPT**
-///     - **Z_ENCODING_IMAGE_JPEG**
-///     - **Z_ENCODING_IMAGE_PNG**
-///     - **Z_ENCODING_IMAGE_GIF**
+///     - **Z_ENCODING_PREFIX_EMPTY**
+///     - **Z_ENCODING_PREFIX_APP_OCTET_STREAM**
+///     - **Z_ENCODING_PREFIX_APP_CUSTOM**
+///     - **Z_ENCODING_PREFIX_TEXT_PLAIN**
+///     - **Z_ENCODING_PREFIX_APP_PROPERTIES**
+///     - **Z_ENCODING_PREFIX_APP_JSON**
+///     - **Z_ENCODING_PREFIX_APP_SQL**
+///     - **Z_ENCODING_PREFIX_APP_INTEGER**
+///     - **Z_ENCODING_PREFIX_APP_FLOAT**
+///     - **Z_ENCODING_PREFIX_APP_XML**
+///     - **Z_ENCODING_PREFIX_APP_XHTML_XML**
+///     - **Z_ENCODING_PREFIX_APP_X_WWW_FORM_URLENCODED**
+///     - **Z_ENCODING_PREFIX_TEXT_JSON**
+///     - **Z_ENCODING_PREFIX_TEXT_HTML**
+///     - **Z_ENCODING_PREFIX_TEXT_XML**
+///     - **Z_ENCODING_PREFIX_TEXT_CSS**
+///     - **Z_ENCODING_PREFIX_TEXT_CSV**
+///     - **Z_ENCODING_PREFIX_TEXT_JAVASCRIPT**
+///     - **Z_ENCODING_PREFIX_IMAGE_JPEG**
+///     - **Z_ENCODING_PREFIX_IMAGE_PNG**
+///     - **Z_ENCODING_PREFIX_IMAGE_GIF**
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub enum z_encoding_prefix_t {

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,7 +63,7 @@ pub static Z_CONFIG_LOCAL_ROUTING_KEY: &c_char =
 /// A loaned zenoh config.
 #[repr(C)]
 #[allow(non_camel_case_types)]
-pub struct z_config_t(*const z_owned_config_t);
+pub struct zc_config_t(*const zc_owned_config_t);
 
 /// An owned zenoh configuration.
 ///
@@ -77,29 +77,29 @@ pub struct z_config_t(*const z_owned_config_t);
 /// To check if `val` is still valid, you may use `z_X_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
 #[repr(C)]
 #[allow(non_camel_case_types)]
-pub struct z_owned_config_t(*mut ());
+pub struct zc_owned_config_t(*mut ());
 
-/// Returns a :c:type:`z_config_t` loaned from `s`.
+/// Returns a :c:type:`zc_config_t` loaned from `s`.
 #[no_mangle]
-pub extern "C" fn z_config_loan(s: &z_owned_config_t) -> z_config_t {
-    z_config_t(s)
+pub extern "C" fn zc_config_loan(s: &zc_owned_config_t) -> zc_config_t {
+    zc_config_t(s)
 }
-impl AsRef<Option<Box<Config>>> for z_config_t {
+impl AsRef<Option<Box<Config>>> for zc_config_t {
     fn as_ref(&self) -> &Option<Box<Config>> {
         unsafe { (&*self.0).as_ref() }
     }
 }
-impl AsMut<Option<Box<Config>>> for z_config_t {
+impl AsMut<Option<Box<Config>>> for zc_config_t {
     fn as_mut(&mut self) -> &mut Option<Box<Config>> {
-        unsafe { (&mut *(self.0 as *mut z_owned_config_t)).as_mut() }
+        unsafe { (&mut *(self.0 as *mut zc_owned_config_t)).as_mut() }
     }
 }
-impl AsRef<Option<Box<Config>>> for z_owned_config_t {
+impl AsRef<Option<Box<Config>>> for zc_owned_config_t {
     fn as_ref(&self) -> &Option<Box<Config>> {
         unsafe { std::mem::transmute(self) }
     }
 }
-impl AsMut<Option<Box<Config>>> for z_owned_config_t {
+impl AsMut<Option<Box<Config>>> for zc_owned_config_t {
     fn as_mut(&mut self) -> &mut Option<Box<Config>> {
         unsafe { std::mem::transmute(self) }
     }
@@ -116,14 +116,14 @@ impl AsMut<Option<Box<Config>>> for z_owned_config_t {
 ///
 /// To check if `val` is still valid, you may use `z_X_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
 #[no_mangle]
-pub extern "C" fn z_config_new() -> z_owned_config_t {
-    unsafe { z_owned_config_t(std::mem::transmute(Some(Box::new(Config::default())))) }
+pub extern "C" fn zc_config_new() -> zc_owned_config_t {
+    unsafe { zc_owned_config_t(std::mem::transmute(Some(Box::new(Config::default())))) }
 }
 
 /// Gets the property with the given integer key from the configuration.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_config_get(config: z_config_t, key: *const c_char) -> *const c_char {
+pub unsafe extern "C" fn zc_config_get(config: zc_config_t, key: *const c_char) -> *const c_char {
     let key = match CStr::from_ptr(key).to_str() {
         Ok(s) => s,
         Err(_) => return std::ptr::null_mut(),
@@ -141,8 +141,8 @@ pub unsafe extern "C" fn z_config_get(config: z_config_t, key: *const c_char) ->
 /// Returns ``true`` if insertion was succesful, `false` otherwise.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc, unused_must_use)]
-pub unsafe extern "C" fn z_config_insert_json(
-    mut config: z_config_t,
+pub unsafe extern "C" fn zc_config_insert_json(
+    mut config: zc_config_t,
     key: *const c_char,
     value: *const c_char,
 ) -> bool {
@@ -159,47 +159,47 @@ pub unsafe extern "C" fn z_config_insert_json(
 /// Frees `config`, invalidating it for double-drop safety.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_config_drop(config: &mut z_owned_config_t) {
+pub unsafe extern "C" fn zc_config_drop(config: &mut zc_owned_config_t) {
     std::mem::drop(config.as_mut().take())
 }
 /// Returns ``true`` if `config` is valid.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_config_check(config: &z_owned_config_t) -> bool {
+pub unsafe extern "C" fn zc_config_check(config: &zc_owned_config_t) -> bool {
     config.as_ref().is_some()
 }
 
 /// Creates an empty, zenoh-allocated, configuration.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_config_empty() -> z_owned_config_t {
-    z_config_new()
+pub extern "C" fn zc_config_empty() -> zc_owned_config_t {
+    zc_config_new()
 }
 
 /// Creates a default, zenoh-allocated, configuration.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_config_default() -> z_owned_config_t {
-    z_config_new()
+pub extern "C" fn zc_config_default() -> zc_owned_config_t {
+    zc_config_new()
 }
 
 /// Reads a configuration from a JSON-serialized string, such as '{mode:"client",connect:{endpoints:["tcp/127.0.0.1:7447"]}}'.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_config_from_str(s: *const c_char) -> z_owned_config_t {
+pub unsafe extern "C" fn zc_config_from_str(s: *const c_char) -> zc_owned_config_t {
     if s.is_null() {
-        z_config_empty()
+        zc_config_empty()
     } else {
         let conf_str = CStr::from_ptr(s);
         let props: Option<Config> = json5::from_str(&conf_str.to_string_lossy()).ok();
-        z_owned_config_t(std::mem::transmute(props.map(Box::new)))
+        zc_owned_config_t(std::mem::transmute(props.map(Box::new)))
     }
 }
 
 /// Converts `config` into a JSON-serialized string, such as '{"mode":"client","connect":{"endpoints":["tcp/127.0.0.1:7447"]}}'.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_config_to_string(config: z_config_t) -> *mut c_char {
+pub extern "C" fn zc_config_to_string(config: zc_config_t) -> *mut c_char {
     let config: &Config = match config.as_ref() {
         Some(c) => c,
         None => return std::ptr::null_mut(),
@@ -213,9 +213,9 @@ pub extern "C" fn z_config_to_string(config: z_config_t) -> *mut c_char {
 /// Constructs a configuration by parsing a file at `path`. Currently supported format is JSON5, a superset of JSON.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_config_from_file(path: *const c_char) -> z_owned_config_t {
+pub unsafe extern "C" fn zc_config_from_file(path: *const c_char) -> zc_owned_config_t {
     let path_str = CStr::from_ptr(path);
-    z_owned_config_t(std::mem::transmute(match path_str.to_str() {
+    zc_owned_config_t(std::mem::transmute(match path_str.to_str() {
         Ok(path) => match zenoh::config::Config::from_file(path) {
             Ok(c) => Some(Box::new(c)),
             Err(e) => {
@@ -233,18 +233,18 @@ pub unsafe extern "C" fn z_config_from_file(path: *const c_char) -> z_owned_conf
 /// Constructs a default, zenoh-allocated, peer mode configuration.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_config_peer() -> z_owned_config_t {
-    unsafe { z_owned_config_t(std::mem::transmute(Some(Box::new(zenoh::config::peer())))) }
+pub extern "C" fn zc_config_peer() -> zc_owned_config_t {
+    unsafe { zc_owned_config_t(std::mem::transmute(Some(Box::new(zenoh::config::peer())))) }
 }
 
 /// Constructs a default, zenoh-allocated, client mode configuration.
 /// If `peer` is not null, it is added to the configuration as remote peer.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_config_client(
+pub unsafe extern "C" fn zc_config_client(
     peers: *const *const c_char,
     n_peers: usize,
-) -> z_owned_config_t {
+) -> zc_owned_config_t {
     let locators = if peers.is_null() {
         Vec::new()
     } else if let Ok(locators) = std::slice::from_raw_parts(peers, n_peers)
@@ -263,9 +263,9 @@ pub unsafe extern "C" fn z_config_client(
     {
         locators
     } else {
-        return z_owned_config_t(std::mem::transmute(None::<Box<Config>>));
+        return zc_owned_config_t(std::mem::transmute(None::<Box<Config>>));
     };
-    z_owned_config_t(std::mem::transmute(Some(Box::new(zenoh::config::client(
+    zc_owned_config_t(std::mem::transmute(Some(Box::new(zenoh::config::client(
         locators,
     )))))
 }

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -222,7 +222,7 @@
 // #[no_mangle]
 // pub unsafe extern "C" fn z_scout(
 //     what: c_uint,
-//     config: &mut z_owned_config_t,
+//     config: &mut zc_owned_config_t,
 //     scout_period: c_ulong,
 // ) -> z_owned_hello_array_t {
 //     let what = WhatAmIMatcher::try_from(what as ZInt).unwrap_or(WhatAmI::Router | WhatAmI::Peer);

--- a/src/session.rs
+++ b/src/session.rs
@@ -62,7 +62,7 @@ pub extern "C" fn z_session_loan(s: &z_owned_session_t) -> z_session_t {
 /// Opens a zenoh session. Should the session opening fail, `z_check` ing the returned value will return `false`.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_open(config: &mut z_owned_config_t) -> z_owned_session_t {
+pub unsafe extern "C" fn z_open(config: &mut zc_owned_config_t) -> z_owned_session_t {
     fn ok(session: Session) -> z_owned_session_t {
         unsafe { std::mem::transmute(Some(session)) }
     }


### PR DESCRIPTION
This PR introduces encoding for `query_reply` and `publisher` and rename `z_config` to `zc_config`.