### PR TITLE
auto-init the logger for easier zc-zp compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,19 @@
 cmake_minimum_required(VERSION 3.10)
 project(
-	zenohc 
+	zenohc
 	VERSION 0.6.0.0
 	DESCRIPTION "The C bindings for Zenoh"
 	HOMEPAGE_URL "https://github.com/eclipse-zenoh/zenoh-c"
 	LANGUAGES C
 )
 set(CARGO_PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
-if (NOT PROJECT_VERSION_TWEAK)
+
+if(NOT PROJECT_VERSION_TWEAK)
 	set(CARGO_PROJECT_VERSION "${CARGO_PROJECT_VERSION}-dev")
 elseif(PROJECT_VERSION_TWEAK LESS 255)
 	set(CARGO_PROJECT_VERSION "${CARGO_PROJECT_VERSION}-beta.${PROJECT_VERSION_TWEAK}")
 endif()
+
 message(STATUS "CARGO_PROJECT_VERSION: ${CARGO_PROJECT_VERSION}")
 configure_file("${CMAKE_SOURCE_DIR}/Cargo.toml.in" "${CMAKE_SOURCE_DIR}/Cargo.toml" @ONLY)
 
@@ -19,13 +21,15 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(default_build_type "RelWithDebInfo")
 	message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
 	set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
-		STRING "Choose the type of build." FORCE)	
+		STRING "Choose the type of build." FORCE)
+
 	# Set the possible values of build type for cmake-gui
 	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
 		"Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
 set(CARGO_FLAGS "")
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 	set(CMAKE_BINARY_DIR "${CMAKE_SOURCE_DIR}/target/debug")
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
@@ -41,10 +45,15 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
 else()
 	message(FATAL_ERROR "Unknown CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 endif()
+
 message(STATUS "CMAKE_BINARY_DIR: ${CMAKE_BINARY_DIR}")
+
+if(NOT DISABLE_LOGGER_AUTOINIT)
+	set(CARGO_FLAGS ${CARGO_FLAGS} "--features=logger-autoinit")
+endif()
+
 set(RUSTFLAGS $ENV{RUSTFLAGS})
 add_custom_target(cargo ALL COMMAND cargo build ${CARGO_FLAGS} COMMENT "Running RUSTFLAGS=${RUSTFLAGS} cargo build ${CARGO_FLAGS}")
-
 
 if(APPLE)
 	set(libzenohc "${CMAKE_BINARY_DIR}/libzenohc.dylib")
@@ -71,6 +80,7 @@ target_include_directories(zenohc INTERFACE "${CMAKE_SOURCE_DIR}/include")
 if(APPLE OR UNIX OR WIN32)
 	file(GLOB files "${CMAKE_SOURCE_DIR}/examples/*.c")
 	add_custom_target(examples)
+
 	foreach(file ${files})
 		get_filename_component(target ${file} NAME_WE)
 		add_executable(${target} EXCLUDE_FROM_ALL ${file})
@@ -80,6 +90,7 @@ if(APPLE OR UNIX OR WIN32)
 		set_property(TARGET ${target} PROPERTY RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
 		target_include_directories(${target} PUBLIC "${CMAKE_SOURCE_DIR}/include")
 		target_link_libraries(${target} PUBLIC ${libzenohc_static})
+
 		if(APPLE)
 			find_library(FFoundation Foundation)
 			find_library(FSecurity Security)
@@ -94,12 +105,12 @@ else()
 	message(WARNING "You platform doesn't seem to support building the examples.")
 endif()
 
-
 include(GNUInstallDirs)
 set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/zenohc")
 install(FILES ${libzenohc} CONFIGURATIONS Release RelWithDebInfo DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY "${CMAKE_SOURCE_DIR}/include/" CONFIGURATIONS Release RelWithDebInfo DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 configure_file("${CMAKE_SOURCE_DIR}/zenohc.pc.in" "${CMAKE_SOURCE_DIR}/zenohc.pc" @ONLY)
+
 if(APPLE OR UNIX)
 	install(FILES "${CMAKE_SOURCE_DIR}/zenohc.pc" CONFIGURATIONS Release RelWithDebInfo DESTINATION "/usr/lib/pkgconfig")
 endif()

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ readme = "README.md"
 
 [features]
 logger-autoinit = []
-default = ["logger-autoinit"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+logger-autoinit = []
+default = ["logger-autoinit"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -31,6 +31,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+logger-autoinit = []
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/README.md
+++ b/README.md
@@ -115,3 +115,6 @@ The examples have been written with C11 in mind, using the conventions we encour
 Finally, we strongly advise that you refrain from using structure field that starts with `_`:
 * We try to maintain a common API between `zenoh-c` and [`zenoh-pico`](https://github.com/eclipse-zenoh/zenoh-pico), such that porting code from one to the other is, ideally, trivial. However, some types must have distinct representations in either library, meaning that using these representations explicitly will get you in trouble when porting.
 * We reserve the right to change the memory layout of any type which has `_`-prefixed fields, so trying to use them might cause your code to break on updates.
+
+## Logging
+By default, zenoh-c enables Zenoh's logging library upon using the `z_open` or `z_scout` functions. This behaviour can be disabled by adding `-DDISABLE_LOGGER_AUTOINIT:bool=true` to the `cmake` configuration command. The logger may then be manually re-enabled with the `zc_init_logger` function.

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -17,8 +17,6 @@
 #include "zenoh.h"
 
 int main(int argc, char **argv) {
-    z_init_logger();
-
     char *expr = "demo/example/**";
     if (argc > 1) {
         expr = argv[1];

--- a/examples/z_info.c
+++ b/examples/z_info.c
@@ -23,8 +23,6 @@ void print_zid(const z_id_t *id, const void *ctx) {
 }
 
 int main(int argc, char **argv) {
-    z_init_logger();
-
     z_owned_config_t config = z_config_default();
     if (argc > 1) {
         if (!zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1])) {

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -17,8 +17,6 @@
 #include "zenoh.h"
 
 int main(int argc, char **argv) {
-    z_init_logger();
-
     char *expr = "demo/example/**";
     if (argc > 1) {
         expr = argv[1];

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -26,8 +26,6 @@ int main(int argc, char **argv) {
     char *keyexpr = "demo/example/zenoh-c-pub";
     char *value = "Pub from C!";
 
-    z_init_logger();
-
     if (argc > 1) keyexpr = argv[1];
     if (argc > 2) value = argv[2];
 

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -17,8 +17,6 @@
 #include "zenoh.h"
 
 int main(int argc, char **argv) {
-    z_init_logger();
-
     if (argc < 2) {
         printf("USAGE:\n\tz_pub_thr <payload-size> [<zenoh-locator>]\n\n");
         exit(-1);

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -27,8 +27,6 @@ void data_handler(const z_sample_t *sample, const void *arg) {
 }
 
 int main(int argc, char **argv) {
-    z_init_logger();
-
     char *expr = "demo/example/**";
     if (argc > 1) {
         expr = argv[1];

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -20,8 +20,6 @@ int main(int argc, char **argv) {
     char *keyexpr = "demo/example/zenoh-c-put";
     char *value = "Put from C!";
 
-    z_init_logger();
-
     if (argc > 1) keyexpr = argv[1];
     if (argc > 2) value = argv[2];
 

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -36,8 +36,6 @@ void query_handler(z_query_t query, const void *context) {
 }
 
 int main(int argc, char **argv) {
-    z_init_logger();
-
     if (argc > 1) {
         expr = argv[1];
     }

--- a/examples/z_scout.c
+++ b/examples/z_scout.c
@@ -89,7 +89,6 @@ void drop(void *context) {
 }
 
 int main(int argc, char **argv) {
-    z_init_logger();
     int *context = malloc(sizeof(int));
     *context = 0;
     z_owned_scouting_config_t config = z_scouting_config_default();

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -27,8 +27,6 @@ void data_handler(const z_sample_t *sample, const void *arg) {
 }
 
 int main(int argc, char **argv) {
-    z_init_logger();
-
     char *expr = "demo/example/**";
     if (argc > 1) {
         expr = argv[1];

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -62,8 +62,6 @@ void drop_stats(void *context) {
 }
 
 int main(int argc, char **argv) {
-    z_init_logger();
-
     z_owned_config_t config = z_config_default();
     if (argc > 1) {
         if (!zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1])) {

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -970,10 +970,6 @@ void z_info_routers_zid(struct z_session_t session, struct z_owned_closure_zid_t
  */
 struct z_id_t z_info_zid(struct z_session_t session);
 /**
- * Initialises the zenoh runtime logger
- */
-void z_init_logger(void);
-/**
  * Constructs a :c:type:`z_keyexpr_t` departing from a string.
  * It is a loaned key expression that aliases `name`.
  */
@@ -1355,6 +1351,13 @@ void z_undeclare_subscriber(struct z_owned_subscriber_t *sub);
  * Returns ``true`` if insertion was succesful, `false` otherwise.
  */
 bool zc_config_insert_json(struct z_config_t config, const char *key, const char *value);
+/**
+ * Initialises the zenoh runtime logger.
+ *
+ * Note that unless you built zenoh-c with the `logger-autoinit` feature disabled,
+ * this will be performed automatically by `z_open` and `z_scout`.
+ */
+void zc_init_logger(void);
 /**
  * Constructs a :c:type:`z_keyexpr_t` departing from a string.
  * It is a loaned key expression that aliases `name`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,12 @@ pub use closures::*;
 
 pub(crate) const LOG_INVALID_SESSION: &str = "Invalid session";
 
-/// Initialises the zenoh runtime logger
+/// Initialises the zenoh runtime logger.
+///
+/// Note that unless you built zenoh-c with the `logger-autoinit` feature disabled,
+/// this will be performed automatically by `z_open` and `z_scout`.
 #[no_mangle]
-pub extern "C" fn z_init_logger() {
+pub extern "C" fn zc_init_logger() {
     let _ = env_logger::try_init();
 }
 

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -210,7 +210,7 @@ pub unsafe extern "C" fn z_scout(
     config: &mut z_owned_scouting_config_t,
     callback: &mut z_owned_closure_hello_t,
 ) {
-    if cfg!(not(feature = "logger-autoinit")) {
+    if cfg!(feature = "logger-autoinit") {
         zc_init_logger();
     }
     let config = std::mem::replace(config, _z_scouting_config_null());

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -21,7 +21,7 @@ use zenoh_util::core::AsyncResolve;
 
 use crate::{
     _z_config_null, z_closure_hello_call, z_config_check, z_config_default, z_config_t, z_id_t,
-    z_owned_closure_hello_t, z_owned_config_t, Z_ROUTER,
+    z_owned_closure_hello_t, z_owned_config_t, zc_init_logger, Z_ROUTER,
 };
 
 /// An owned array of owned, zenoh allocated, NULL terminated strings.
@@ -210,6 +210,9 @@ pub unsafe extern "C" fn z_scout(
     config: &mut z_owned_scouting_config_t,
     callback: &mut z_owned_closure_hello_t,
 ) {
+    if cfg!(not(feature = "logger-autoinit")) {
+        zc_init_logger();
+    }
     let config = std::mem::replace(config, _z_scouting_config_null());
     let what = WhatAmIMatcher::try_from(config.zc_what).unwrap_or(WhatAmI::Router | WhatAmI::Peer);
     let timeout = config.zc_timeout_ms as u64;

--- a/src/session.rs
+++ b/src/session.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh team, <zenoh@zettascale.tech>
 //
-use crate::config::*;
+use crate::{config::*, zc_init_logger};
 use zenoh::prelude::sync::SyncResolve;
 use zenoh::Session;
 
@@ -69,6 +69,9 @@ pub unsafe extern "C" fn z_open(config: &mut z_owned_config_t) -> z_owned_sessio
 
     fn err() -> z_owned_session_t {
         unsafe { std::mem::transmute(None::<Session>) }
+    }
+    if cfg!(feature = "logger-autoinit") {
+        zc_init_logger();
     }
 
     let config = match config.as_mut().take() {


### PR DESCRIPTION
A feature flag allows to build zenoh-c without the auto init.

~WIP: need to expose the feature flag through cmake.~

I think this PR is ready and would be useful to users who want to disable logs, without forcing everyone to enable them manually.