### PR TITLE
fix layouts for non x86 platforms

### DIFF
--- a/include/zenoh.h
+++ b/include/zenoh.h
@@ -3,14 +3,27 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include "zenoh_concrete.h"
-//
-#include "zenoh_commons.h"
-#include "zenoh_macros.h"
+
 #define ZENOH_C "0.6.0"
 #define ZENOH_C_MAJOR 0
 #define ZENOH_C_MINOR 6
 #define ZENOH_C_PATCH 0
+
+#define _Z_OWNED_REPLY_N_USIZE 18
+#if defined(__x86_64__) || defined(_M_X64) || defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+#define _Z_OWNED_REPLY_N_U128 1
+#define _Z_OWNED_REPLY_N_U64 3
+#else
+#define _Z_OWNED_REPLY_N_U128 4
+#define _Z_OWNED_REPLY_N_U64 0
+#endif
+
+#define _z_u128 long double  // used for alignment.
+
+#include "zenoh_concrete.h"
+//
+#include "zenoh_commons.h"
+#include "zenoh_macros.h"
 #ifdef __cplusplus
 }
 #endif

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -223,8 +223,9 @@ typedef struct z_owned_closure_query_t {
  * To check if `val` is still valid, you may use `z_X_check(&val)` (or `z_check(val)` if your compiler supports `_Generic`), which will return `true` if `val` is valid.
  */
 typedef struct z_owned_reply_t {
-  uint64_t _align[5];
-  uintptr_t _padding[18];
+  _z_u128 _align[_Z_OWNED_REPLY_N_U128];
+  uint64_t _pad_u64[_Z_OWNED_REPLY_N_U64];
+  uintptr_t _pad_usize[_Z_OWNED_REPLY_N_USIZE];
 } z_owned_reply_t;
 /**
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:


### PR DESCRIPTION
From what I read, the `u128` is aligned to 8 bytes is more of an x86 specificity than the opposite as we thought.