### PR TITLE
Fixed z_info.c PID order

### DIFF
--- a/examples/z_info.c
+++ b/examples/z_info.c
@@ -16,7 +16,7 @@
 #include "zenoh.h"
 
 void print_zid(const z_id_t *id, void *ctx) {
-    for (int i = 0; i < 15; i++) {
+    for (int i = 0; i < 16; i++) {
         printf("%02x", id->id[i]);
     }
     printf("\n");

--- a/examples/z_info.c
+++ b/examples/z_info.c
@@ -16,7 +16,7 @@
 #include "zenoh.h"
 
 void print_zid(const z_id_t *id, void *ctx) {
-    for (int i = 15; i >= 0; i--) {
+    for (int i = 0; i < 15; i++) {
         printf("%02x", id->id[i]);
     }
     printf("\n");


### PR DESCRIPTION
Currently the order of the characters printed is reversed from what is displayed when you start zenoh driver.
This PR fixes the correct order of symbols. 

![image](https://user-images.githubusercontent.com/105135724/192404534-b2695cd6-b88f-4bee-bdf1-34d0c9367ccb.png)
![image](https://user-images.githubusercontent.com/105135724/192404563-b28eeddc-11a9-4f41-8d11-0ca3f9d16067.png)

Please note how the ids are reversed and this PR achieves the correct order.

![image](https://user-images.githubusercontent.com/105135724/192404625-b0597f4c-5d66-4317-8e74-90cd1aabab79.png)
