### PR TITLE
Release Action: add build for aarch64-apple-darwin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,7 @@ jobs:
               use-cross: true,
             }
           - { target: x86_64-apple-darwin, arch: darwin, os: macos-latest }
+          - { target: aarch64-apple-darwin, arch: darwin, os: macos-latest }
           - { target: x86_64-pc-windows-msvc, arch: win64, os: windows-2019 }
           - { target: x86_64-pc-windows-gnu, arch: win64, os: windows-2019 }
     env:


### PR DESCRIPTION
Add a build for ARM64-based MacOS.