### PR TITLE
added GLOBAL to 2 add_library functions

### DIFF
--- a/PackageConfig.cmake.in
+++ b/PackageConfig.cmake.in
@@ -14,11 +14,11 @@
 
 @PACKAGE_INIT@
 
-add_library(__zenohc_static STATIC IMPORTED)
+add_library(__zenohc_static STATIC IMPORTED GLOBAL)
 add_library(zenohc::static ALIAS __zenohc_static)
 set_property(TARGET __zenohc_static PROPERTY IMPORTED_LOCATION "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/@libzenohc_static@")
 
-add_library(__zenohc_lib STATIC IMPORTED)
+add_library(__zenohc_lib STATIC IMPORTED GLOBAL)
 add_library(zenohc::lib ALIAS __zenohc_lib)
 set_property(TARGET __zenohc_lib PROPERTY IMPORTED_LOCATION "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/@libzenohc@")
 target_include_directories(__zenohc_lib INTERFACE "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@")


### PR DESCRIPTION
Closes #111, resolves eclipse-zenoh/zenoh-cpp#7.

In short: this enables zenoh-cpp (which depends on files generated by zenoh-c compilation) to be compiled on Ubuntu 20.04 with the default CMake 3.16.