### PR TITLE
Select alignment for 128-bit integer for C the same as in Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ Module.symvers
 Mkfile.old
 dkms.conf
 .cache
+
+# Platform dependent generated files
+include/zenoh_configure.h

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,7 @@ fn main() {
         .expect("Unable to generate bindings")
         .write_to_file(GENERATION_PATH);
 
+    configure();
     split_bindings();
     rename_enums();
 
@@ -17,6 +18,17 @@ fn main() {
     println!("cargo:rerun-if-changed=src");
     println!("cargo:rerun-if-changed=splitguide.yaml");
     println!("cargo:rerun-if-changed=cbindgen.toml")
+}
+
+fn configure() {
+    let content = format!(r#"
+#pragma once
+#define RUST_U128_ALIGNMENT {}
+"#, std::mem::align_of::<u128>());
+    let mut file = std::fs::File::options().write(true).append(false).create(true).open("include/zenoh_configure.h").unwrap();
+    file.lock_exclusive().unwrap();
+    file.write_all(content.as_bytes()).unwrap();
+    file.unlock().unwrap();
 }
 
 fn rename_enums() {

--- a/build.rs
+++ b/build.rs
@@ -21,11 +21,19 @@ fn main() {
 }
 
 fn configure() {
-    let content = format!(r#"
+    let content = format!(
+        r#"
 #pragma once
 #define RUST_U128_ALIGNMENT {}
-"#, std::mem::align_of::<u128>());
-    let mut file = std::fs::File::options().write(true).append(false).create(true).open("include/zenoh_configure.h").unwrap();
+"#,
+        std::mem::align_of::<u128>()
+    );
+    let mut file = std::fs::File::options()
+        .write(true)
+        .append(false)
+        .create(true)
+        .open("include/zenoh_configure.h")
+        .unwrap();
     file.lock_exclusive().unwrap();
     file.write_all(content.as_bytes()).unwrap();
     file.unlock().unwrap();

--- a/include/zenoh.h
+++ b/include/zenoh.h
@@ -2,6 +2,7 @@
 #define ZENOH_H
 
 #include <assert.h>
+#include <stdint.h>
 
 #include "zenoh_configure.h"
 
@@ -21,7 +22,7 @@ extern "C" {
 typedef __uint128_t _z_u128;
 #elif _MSC_VER
 typedef __declspec(align(16)) struct _z_u128 {
-    __int64 _0[2];
+    uint64_t _0[2];
 } _z_u128;
 #else
 // Let's hope that long double is 128 bit. If no, the assert below fires
@@ -31,7 +32,7 @@ typedef long double _z_u128;
 #elif RUST_U128_ALIGNMENT == 8
 
 typedef struct _z_u128 {
-    __int64 _0[2];
+    uint64_t _0[2];
 } _z_u128;
 
 #else

--- a/include/zenoh.h
+++ b/include/zenoh.h
@@ -43,10 +43,12 @@ typedef struct _z_u128 {
 
 static_assert(sizeof(_z_u128) == 16, "Size of _z_u128 must be 128 bit");
 
-static_assert(sizeof(struct {
-                  char c;
-                  _z_u128 u;
-              }) == RUST_U128_ALIGNMENT + 16,
+typedef struct _z_u128_align_test {
+    char c;
+    _z_u128 u128;
+} _z_u128_align_test;
+
+static_assert(sizeof(_z_u128_align_test) == RUST_U128_ALIGNMENT + 16,
               "_z_u128 type must be aligned in the same way as in Rust");
 
 #include "zenoh_concrete.h"

--- a/include/zenoh.h
+++ b/include/zenoh.h
@@ -3,6 +3,8 @@
 
 #include <assert.h>
 
+#include "zenoh_configure.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -12,27 +14,39 @@ extern "C" {
 #define ZENOH_C_MINOR 7
 #define ZENOH_C_PATCH 0
 
+#if RUST_U128_ALIGNMENT == 16
+
 // 128-bit type used for alignment.
 #ifdef __SIZEOF_INT128__
-#define _z_u128 __uint128_t
+typedef __uint128_t _z_u128;
 #elif _MSC_VER
-typedef __declspec(align(16)) struct _z_u128_aligned {
+typedef __declspec(align(16)) struct _z_u128 {
     __int64 _0[2];
-} _z_u128_aligned;
-#define _z_u128 _z_u128_aligned
+} _z_u128;
 #else
 // Let's hope that long double is 128 bit. If no, the assert below fires
-#define _z_u128 long double
+typedef long double _z_u128;
+#endif
+
+#elif RUST_U128_ALIGNMENT == 8
+
+typedef struct _z_u128 {
+    __int64 _0[2];
+} _z_u128;
+
+#else
+
+#error "Unexpected or undefined RUST_U128_ALIGNMENT"
+
 #endif
 
 static_assert(sizeof(_z_u128) == 16, "Size of _z_u128 must be 128 bit");
 
-typedef struct _z_u128_align_test {
-    char c;
-    _z_u128 u128;
-} _z_u128_align_test;
-
-static_assert(sizeof(_z_u128_align_test) == 32, "_z_u128 type must be aligned by 16-byte boundary");
+static_assert(sizeof(struct {
+                  char c;
+                  _z_u128 u;
+              }) == RUST_U128_ALIGNMENT + 16,
+              "_z_u128 type must be aligned in the same way as in Rust");
 
 #include "zenoh_concrete.h"
 //


### PR DESCRIPTION
Fix for issue https://github.com/eclipse-zenoh/zenoh-c/issues/116