### PR TITLE
z_keyexpr_t guarded transmute, cross-build check in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ add_custom_target(cargo ALL COMMAND cargo build ${CARGO_FLAGS} COMMENT "Running 
 # 
 # rustup target list --installed
 #
-add_custom_target(check_targets)
+add_custom_target(crosscheck)
 
 set(targets
 aarch64-unknown-linux-gnu
@@ -88,7 +88,7 @@ foreach(target ${targets})
 		COMMAND cargo check --target ${target} ${CARGO_FLAGS} 
 		COMMENT "cargo check on ${target}" 
 		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-	add_dependencies(check_targets cargo_check_${target})
+	add_dependencies(crosscheck cargo_check_${target})
 endforeach()
 
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,10 +59,21 @@ add_custom_target(cargo ALL COMMAND cargo build ${CARGO_FLAGS} COMMENT "Running 
 #
 # Rust cross-build check for supported processor architectures
 # This check works on linux only
-# It requires that the following packages are installed:
+# It requires that the following packages are installed for cross compilation:
 #
-# apt install gcc-arm-linux-gnueabi
-# apt install gcc-x86-64-linux-gnu
+# sudo apt install gcc-arm-linux-gnueabi
+# sudo apt install gcc-x86-64-linux-gnu
+# sudo apt install gcc-aarch64-linux-gnu
+#
+# and the following targets in rustup
+#
+# rustup target add arm-unknown-linux-gnueabi
+# rustup target add aarch64-unknown-linux-gnu
+# rustup target add x86_64-unknown-linux-gnu
+# 
+# check which targets are already installed with
+# 
+# rustup target list --installed
 #
 add_custom_target(check_targets)
 
@@ -73,10 +84,11 @@ arm-unknown-linux-gnueabi
 )
 
 foreach(target ${targets})
-	add_custom_target(target_rustup_add_${target} COMMAND rustup target add ${target} COMMENT "rustup add ${target}")
-	add_custom_target(target_cargo_check_${target} COMMAND cargo check --target ${target} ${CARGO_FLAGS} COMMENT "cargo check on ${target}" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-	add_dependencies(check_targets target_cargo_check_${target})
-	add_dependencies(target_cargo_check_${target} target_rustup_add_${target})
+	add_custom_target(cargo_check_${target} 
+		COMMAND cargo check --target ${target} ${CARGO_FLAGS} 
+		COMMENT "cargo check on ${target}" 
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+	add_dependencies(check_targets cargo_check_${target})
 endforeach()
 
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,28 @@ set(CARGO_FLAGS ${CARGO_FLAGS} "--manifest-path=${CMAKE_CURRENT_SOURCE_DIR}/Carg
 set(RUSTFLAGS $ENV{RUSTFLAGS})
 add_custom_target(cargo ALL COMMAND cargo build ${CARGO_FLAGS} COMMENT "Running RUSTFLAGS=${RUSTFLAGS} cargo build ${CARGO_FLAGS}" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
+#
+# Rust cross-build check for supported processor architectures
+#
+add_custom_target(check_proc_arch)
+
+set(supported_targets
+aarch64-apple-darwin
+aarch64-unknown-linux-gnu
+x86_64-apple-darwin
+x86_64-unknown-linux-gnu
+x86_64-pc-windows-msvc
+arm-unknown-linux-gnueabi
+arm-unknown-linux-gnueabihf
+)
+
+foreach(target ${supported_targets})
+	add_custom_target(target_rustup_add_${target} COMMAND rustup target add ${target} "rustup add ${target}")
+	add_custom_target(target_cargo_check_${target} COMMAND cargo check --target ${target} ${CARGO_FLAGS} "cargo check on ${target}" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+	add_dependencies(targets target_cargo_check_${target})
+	add_dependencies(target_cargo_check_${target} target_rustup_add_${target})
+endforeach()
+
 if(APPLE)
 	set(libzenohc "libzenohc.dylib")
 	set(libzenohc_static "libzenohc.a")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,23 +64,24 @@ add_custom_target(cargo ALL COMMAND cargo build ${CARGO_FLAGS} COMMENT "Running 
 
 #
 # Rust cross-build check for supported processor architectures
+# This check works on linux only
+# It requires that the following packages are installed:
 #
-add_custom_target(check_proc_arch)
+# apt install gcc-arm-linux-gnueabi
+# apt install gcc-x86-64-linux-gnu
+#
+add_custom_target(check_targets)
 
-set(supported_targets
-aarch64-apple-darwin
-aarch64-unknown-linux-gnu
-x86_64-apple-darwin
+set(targets
+# aarch64-unknown-linux-gnu
 x86_64-unknown-linux-gnu
-x86_64-pc-windows-msvc
-arm-unknown-linux-gnueabi
-arm-unknown-linux-gnueabihf
+# arm-unknown-linux-gnueabi
 )
 
-foreach(target ${supported_targets})
-	add_custom_target(target_rustup_add_${target} COMMAND rustup target add ${target} "rustup add ${target}")
-	add_custom_target(target_cargo_check_${target} COMMAND cargo check --target ${target} ${CARGO_FLAGS} "cargo check on ${target}" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-	add_dependencies(targets target_cargo_check_${target})
+foreach(target ${targets})
+	add_custom_target(target_rustup_add_${target} COMMAND rustup target add ${target} COMMENT "rustup add ${target}")
+	add_custom_target(target_cargo_check_${target} COMMAND cargo check --target ${target} ${CARGO_FLAGS} COMMENT "cargo check on ${target}" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+	add_dependencies(check_targets target_cargo_check_${target})
 	add_dependencies(target_cargo_check_${target} target_rustup_add_${target})
 endforeach()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,6 @@ endif()
 
 set(CARGO_FLAGS "")
 
-# allow to set cross-compilation cargo target
-set(CARGO_TARGET "" CACHE STRING "Set target triple for cargo or leave empty for default")
-if(${CARGO_TARGET})
-	set(CARGO_FLAGS ${CARGO_FLAGS} "--target ${CARGO_TARGET}")
-endif()
-
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 	set(CMAKE_BINARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/target/debug")
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
@@ -73,9 +67,9 @@ add_custom_target(cargo ALL COMMAND cargo build ${CARGO_FLAGS} COMMENT "Running 
 add_custom_target(check_targets)
 
 set(targets
-# aarch64-unknown-linux-gnu
+aarch64-unknown-linux-gnu
 x86_64-unknown-linux-gnu
-# arm-unknown-linux-gnueabi
+arm-unknown-linux-gnueabi
 )
 
 foreach(target ${targets})

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -268,10 +268,16 @@ typedef struct z_owned_closure_reply_t {
  * Using :c:func:`z_declare_keyexpr` allows zenoh to optimize a key expression,
  * both for local processing and network-wise.
  */
-typedef struct z_keyexpr_t {
-  uint64_t _align[2];
-  uintptr_t _padding[2];
+#if !defined(TARGET_ARCH_ARM)
+typedef struct ALIGN(8) z_keyexpr_t {
+  uint64_t _0[4];
 } z_keyexpr_t;
+#endif
+#if defined(TARGET_ARCH_ARM)
+typedef struct ALIGN(8) z_keyexpr_t {
+  uint64_t _0[3];
+} z_keyexpr_t;
+#endif
 /**
  * The encoding of a payload, in a MIME-like format.
  *


### PR DESCRIPTION
- updated definition of z_keyexpr_t to make it explicitly crossplatform
- added cross compilation test for build on all supported CPU architectures. To run this test:

install necessary packages and rustup targets for cross compilation
```
sudo apt install gcc-arm-linux-gnueabi
sudo apt install gcc-x86-64-linux-gnu
sudo apt install gcc-aarch64-linux-gnu

rustup target add arm-unknown-linux-gnueabi
rustup target add aarch64-unknown-linux-gnu
rustup target add x86_64-unknown-linux-gnu
```

and run test itself
```
mkdir build && cd build && cmake ..
cmake --build . --target crosscheck
```

`crosscheck` test works on Ubuntu at this moment. Need to be investigated how to make this cross compilation in MacOS