### PR TITLE
removed sring comparison in preprocessor

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,9 +23,11 @@ fn main() {
 fn configure() {
     let content = format!(
         r#"#pragma once
-#define TARGET_ARCH {}
+#define TARGET_ARCH_{}
 "#,
-        std::env::var("CARGO_CFG_TARGET_ARCH").unwrap()
+        std::env::var("CARGO_CFG_TARGET_ARCH")
+            .unwrap()
+            .to_uppercase()
     );
 
     let mut file = std::fs::File::options()

--- a/include/zenoh.h
+++ b/include/zenoh.h
@@ -23,18 +23,6 @@ extern "C" {
 
 #include "zenoh_configure.h"
 
-#if TARGET_ARCH == aarch64
-#define TARGET_ARCH_AARCH64
-#elif TARGET_ARCH == x86_64
-#define TARGET_ARCH_X86_64
-#elif TARGET_ARCH == arm
-#define TARGET_ARCH_ARM
-#elif TARGET_ARCH
-#error TARGET_ARCH = #TARGET_ARCH not supported
-#else
-#error TARGET_ARCH not defined
-#endif
-
 // clang-format off
 // include order is important
 #include "zenoh_concrete.h"


### PR DESCRIPTION
Selection of cpu architecture incorrectly used comparison operator in C preprocessor which actually works for integer values only: https://c-faq.com/cpp/ifstrcmp.html