### PR TITLE
fields order made same as zenoh-pico

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p build_examples_findproj && cd build_examples_findproj
-          cmake ../examples -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local -DZENOHC_FORCE_TYPE=PACKAGE
+          cmake ../examples -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local -DZENOHC_SOURCE=PACKAGE
           cmake --build . --config Release
 
       - name: Run tests

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -126,8 +126,8 @@ typedef enum z_sample_kind_t {
  * An array of bytes.
  */
 typedef struct z_bytes_t {
-  const uint8_t *start;
   size_t len;
+  const uint8_t *start;
 } z_bytes_t;
 /**
  * Represents a Zenoh ID.
@@ -536,8 +536,8 @@ typedef struct z_get_options_t {
  * An borrowed array of borrowed, zenoh allocated, NULL terminated strings.
  */
 typedef struct z_str_array_t {
-  const char *const *val;
   size_t len;
+  const char *const *val;
 } z_str_array_t;
 /**
  * A reference-type hello message returned by a zenoh entity to a scout message sent with `z_scout`.

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -18,8 +18,8 @@ use zenoh::prelude::ZenohId;
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct z_bytes_t {
-    pub start: *const u8,
     pub len: size_t,
+    pub start: *const u8,
 }
 
 impl z_bytes_t {

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -57,8 +57,8 @@ pub extern "C" fn z_str_array_check(strs: &z_owned_str_array_t) -> bool {
 /// An borrowed array of borrowed, zenoh allocated, NULL terminated strings.
 #[repr(C)]
 pub struct z_str_array_t {
-    pub val: *const *const c_char,
     pub len: size_t,
+    pub val: *const *const c_char,
 }
 
 /// Returns a :c:type:`z_str_array_t` loaned from :c:type:`z_owned_str_array_t`.


### PR DESCRIPTION
This change is necessary for zenoh-cpp in initializers like { .val = xxx, .len = yyy }, which are sensitive to field order.
Also corrected github .ci test for building examples from installed package