### PR TITLE
true source Cargo.toml.in updated

### DIFF
--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -22,10 +22,10 @@ authors = [
     "Olivier Hécart <olivier.hecart@adlinktech.com>",
     "Luca Cominardi <luca.cominardi@gmail.com>",
 ]
-edition = "2018"
-license = " EPL-2.0 OR Apache-2.0"
+edition = "2021"
+license = "EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
-description = "The zenoh C client API"
+description = "The Zenoh C API"
 readme = "README.md"
 build = "@CARGO_PROJECT_DIR@build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -38,14 +38,14 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 async-std = "=1.12.0"
-async-trait = "0.1.60"
+async-trait = "0.1.66"
 env_logger = "0.10.0"
-futures = "0.3.25"
+futures = "0.3.26"
 json5 = "0.4.1"
-libc = "0.2.138"
+libc = "0.2.139"
 log = "0.4.17"
 rand = "0.8.5"
-spin = "0.9.4"
+spin = "0.9.5"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [ "unstable" ] }
 zenoh-protocol = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
@@ -53,7 +53,7 @@ zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "mas
 [build-dependencies]
 cbindgen = "0.24.3"
 fs2 = "0.4.3"
-serde_yaml = "0.9.13"
+serde_yaml = "0.9.19"
 
 [lib]
 path="@CARGO_PROJECT_DIR@src/lib.rs"


### PR DESCRIPTION
The Cargo.toml is being overwritten each time when CMake build is performed from the template file Cargo.toml.in. So both files should be updated.
Maybe we should consider removing Cargo.toml from repository to avoid mistakes. On the other hand immediate availability of it can be convenient if customer wants to make build with Rust tools only