### PR TITLE
replace with_value to just value

### DIFF
--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
     z_owned_reply_channel_t channel = zc_reply_fifo_new(16);
     z_get_options_t opts = z_get_options_default();
     if (value != NULL) {
-        opts.with_value.payload = (z_bytes_t){.len = strlen(value), .start = (uint8_t *)value};
+        opts.value.payload = (z_bytes_t){.len = strlen(value), .start = (uint8_t *)value};
     }
     z_get(z_loan(s), keyexpr, "", z_move(channel.send),
           &opts);  // here, the send is moved and will be dropped by zenoh when adequate

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -522,12 +522,12 @@ typedef struct z_value_t {
  * Members:
  *     z_query_target_t target: The Queryables that should be target of the query.
  *     z_query_consolidation_t consolidation: The replies consolidation strategy to apply on replies to the query.
- *     z_value_t with_value: An optional value to attach to the query.
+ *     z_value_t value: An optional value to attach to the query.
  */
 typedef struct z_get_options_t {
   enum z_query_target_t target;
   struct z_query_consolidation_t consolidation;
-  struct z_value_t with_value;
+  struct z_value_t value;
 } z_get_options_t;
 /**
  * An borrowed array of borrowed, zenoh allocated, NULL terminated strings.

--- a/src/get.rs
+++ b/src/get.rs
@@ -163,19 +163,19 @@ pub extern "C" fn z_reply_null() -> z_owned_reply_t {
 /// Members:
 ///     z_query_target_t target: The Queryables that should be target of the query.
 ///     z_query_consolidation_t consolidation: The replies consolidation strategy to apply on replies to the query.
-///     z_value_t with_value: An optional value to attach to the query.
+///     z_value_t value: An optional value to attach to the query.
 #[repr(C)]
 pub struct z_get_options_t {
     pub target: z_query_target_t,
     pub consolidation: z_query_consolidation_t,
-    pub with_value: z_value_t,
+    pub value: z_value_t,
 }
 #[no_mangle]
 pub extern "C" fn z_get_options_default() -> z_get_options_t {
     z_get_options_t {
         target: QueryTarget::default().into(),
         consolidation: QueryConsolidation::default().into(),
-        with_value: {
+        value: {
             z_value_t {
                 payload: z_bytes_t::empty(),
                 encoding: z_encoding_default(),
@@ -223,7 +223,7 @@ pub unsafe extern "C" fn z_get(
         q = q
             .consolidation(options.consolidation)
             .target(options.target.into())
-            .with_value(&options.with_value);
+            .value(&options.value);
     }
     match q
         .callback(move |response| z_closure_reply_call(&closure, &mut response.into()))

--- a/src/get.rs
+++ b/src/get.rs
@@ -223,7 +223,7 @@ pub unsafe extern "C" fn z_get(
         q = q
             .consolidation(options.consolidation)
             .target(options.target.into())
-            .value(&options.value);
+            .with_value(&options.value);
     }
     match q
         .callback(move |response| z_closure_reply_call(&closure, &mut response.into()))


### PR DESCRIPTION
Field "with_value" in C API was mistakenly named. The name was copied from rust's function 'with_value' which is actually Rust's 'builder pattern' approach to set 'value' property. So the actual property name should be 'value', like in original Rust code.