### PR TITLE
Introduce shared memory to Zenoh-C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(
 
 include(cmake/helpers.cmake)
 set_default_build_type(Release)
-enable_testing()	
+enable_testing()
 
 #
 # Build zenohc library from rust sources
@@ -23,28 +23,30 @@ enable_testing()
 #
 declare_cache_var_true_if_vscode(ZENOHC_BUILD_IN_SOURCE_TREE "Do build inside source tree")
 declare_cache_var(ZENOHC_BUILD_WITH_LOGGER_AUTOINIT TRUE BOOL "Enable logger-autoinit zenoh-c feature")
+declare_cache_var(ZENOHC_BUILD_WITH_SHARED_MEMORY TRUE BOOL "Enable shared-memory zenoh-c feature")
 declare_cache_var(ZENOHC_CUSTOM_TARGET "" STRING "Rust target for cross compilation, 'aarch64-unknown-linux-gnu' for example")
 declare_cache_var(ZENOHC_CARGO_CHANNEL "stable" STRING "Cargo channel selected: stable or nightly")
 declare_cache_var(ZENOHC_CARGO_FLAGS "" STRING "Additional cargo flags")
 
 #
 # Prepare to build rust sources:
-# configure Cargo.toml, copy files necessary for cargo, 
+# configure Cargo.toml, copy files necessary for cargo,
 # create variables with path to cargo target directory
 #
-if(ZENOHC_BUILD_IN_SOURCE_TREE AND (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}))
+if(ZENOHC_BUILD_IN_SOURCE_TREE AND(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}))
 	set(cargo_toml_dir ${CMAKE_SOURCE_DIR})
 	set(CARGO_PROJECT_DIR "") # do not put absoulte path into Cargo.toml if Cargo.toml is it's normal place
 else()
 	set(cargo_toml_dir ${CMAKE_CURRENT_BINARY_DIR})
 	set(CARGO_PROJECT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/")
-	file(COPY 
-		${CARGO_PROJECT_DIR}/splitguide.yaml 
+	file(COPY
+		${CARGO_PROJECT_DIR}/splitguide.yaml
 		${CARGO_PROJECT_DIR}/cbindgen.toml
-		${CARGO_PROJECT_DIR}/rust-toolchain 
+		${CARGO_PROJECT_DIR}/rust-toolchain
 		DESTINATION ${cargo_toml_dir})
 	set(cargo_generated_include_dir ${cargo_toml_dir}/include)
 endif()
+
 set(source_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(cargo_target_dir ${cargo_toml_dir}/target)
 cmake_path(APPEND cargo_target_dir ${ZENOHC_CUSTOM_TARGET})
@@ -56,11 +58,13 @@ set(cargo_binary_dir ${cargo_target_dir}/$<IF:$<CONFIG:Debug>,debug,release>)
 # Configure Cargo.toml
 #
 set(CARGO_PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+
 if(NOT PROJECT_VERSION_TWEAK)
 	set(CARGO_PROJECT_VERSION "${CARGO_PROJECT_VERSION}-dev")
 elseif(PROJECT_VERSION_TWEAK LESS 255)
 	set(CARGO_PROJECT_VERSION "${CARGO_PROJECT_VERSION}-rc.${PROJECT_VERSION_TWEAK}")
 endif()
+
 status_print(CARGO_PROJECT_VERSION)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml.in" "${cargo_toml_dir}/Cargo.toml" @ONLY)
 
@@ -68,7 +72,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml.in" "${cargo_toml_dir}/Ca
 # Configure result library names
 #
 macro(set_lib list var value)
-	set(${var} ${value}) 
+	set(${var} ${value})
 	list(APPEND ${list} ${value})
 endmacro()
 
@@ -88,6 +92,7 @@ elseif(WIN32)
 	set_lib(dylibs dylib "zenohc.dll")
 	set_lib(staticlibs staticlib "zenohc.lib")
 endif()
+
 list(APPEND libs ${dylibs})
 list(APPEND libs ${staticlibs})
 list(TRANSFORM libs PREPEND "${cargo_binary_dir}/")
@@ -96,12 +101,19 @@ list(TRANSFORM libs PREPEND "${cargo_binary_dir}/")
 # Build rust sources
 #
 set(cargo_flags ${ZENOHC_CARGO_FLAGS} $<$<NOT:$<CONFIG:Debug>>:--release>)
+
 if(ZENOHC_BUILD_WITH_LOGGER_AUTOINIT)
 	set(cargo_flags ${cargo_flags} --features=logger-autoinit)
 endif()
+
+if(ZENOHC_BUILD_WITH_SHARED_MEMORY)
+	set(cargo_flags ${cargo_flags} --features=shared-memory)
+endif()
+
 if(NOT(ZENOHC_CUSTOM_TARGET STREQUAL ""))
 	set(cargo_flags ${cargo_flags} --target=${ZENOHC_CUSTOM_TARGET})
 endif()
+
 status_print(cargo_flags)
 add_custom_command(
 	OUTPUT ${libs}
@@ -128,7 +140,7 @@ set_target_properties(zenohc PROPERTIES IMPORTED_NO_SONAME TRUE)
 
 function(set_target_imported_locations target libname)
 	set_target_properties(${target}
-		PROPERTIES 
+		PROPERTIES
 		IMPORTED_GLOBAL TRUE
 		IMPORTED_LOCATION ${cargo_binary_dir}/${libname}
 		IMPORTED_LOCATION_DEBUG ${cargo_binary_dir_debug}/${libname}
@@ -140,7 +152,7 @@ endfunction()
 
 function(set_target_imported_implib target libname)
 	set_target_properties(${target}
-		PROPERTIES 
+		PROPERTIES
 		IMPORTED_GLOBAL TRUE
 		IMPORTED_IMPLIB ${cargo_binary_dir}/${libname}
 		IMPORTED_IMPLIB_DEBUG ${cargo_binary_dir_debug}/${libname}
@@ -152,6 +164,7 @@ endfunction()
 
 set_target_imported_locations(zenohc_static ${staticlib})
 set_target_imported_locations(zenohc ${dylib})
+
 if(DEFINED implib)
 	set_target_imported_implib(zenohc ${implib})
 endif()
@@ -161,6 +174,7 @@ status_print(source_include_dir)
 status_print(cargo_generated_include_dir)
 target_include_directories(zenohc_static INTERFACE ${source_include_dir})
 target_include_directories(zenohc INTERFACE ${source_include_dir})
+
 if(DEFINED cargo_generated_include_dir)
 	file(MAKE_DIRECTORY ${cargo_generated_include_dir})
 	target_include_directories(zenohc_static INTERFACE ${cargo_generated_include_dir})

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1019,15 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -1040,6 +1058,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
@@ -1047,7 +1078,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
 ]
@@ -1807,6 +1838,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_memory"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8593196da75d9dc4f69349682bd4c2099f8cde114257d1ef7ef1b33d1aba54"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "nix 0.23.2",
+ "rand",
+ "win-sys",
+]
+
+[[package]]
 name = "shellexpand"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2422,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "win-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7b128a98c1cfa201b09eb49ba285887deb3cbe7466a98850eb1adabb452be5"
+dependencies = [
+ "windows",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,6 +2460,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45296b64204227616fdbf2614cefa4c236b98ee64dfaaaa435207ed99fe7829f"
+dependencies = [
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2485,6 +2551,12 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
@@ -2494,6 +2566,12 @@ name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2509,6 +2587,12 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
@@ -2518,6 +2602,12 @@ name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2542,6 +2632,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2597,6 +2693,7 @@ dependencies = [
  "zenoh-plugin-trait",
  "zenoh-protocol",
  "zenoh-result",
+ "zenoh-shm",
  "zenoh-sync",
  "zenoh-transport",
  "zenoh-util",
@@ -2647,6 +2744,7 @@ dependencies = [
  "uhlc",
  "zenoh-buffers",
  "zenoh-protocol",
+ "zenoh-shm",
 ]
 
 [[package]]
@@ -2837,7 +2935,7 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "nix",
+ "nix 0.26.2",
  "uuid",
  "zenoh-core",
  "zenoh-link-commons",
@@ -2916,6 +3014,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "zenoh-shm"
+version = "0.7.0-rc"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#2027bbd4aaf0b61e8cfa080eca134baf4b5f8232"
+dependencies = [
+ "bincode",
+ "log",
+ "serde",
+ "shared_memory",
+ "zenoh-buffers",
+ "zenoh-result",
+]
+
+[[package]]
 name = "zenoh-sync"
 version = "0.7.0-rc"
 source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#2027bbd4aaf0b61e8cfa080eca134baf4b5f8232"
@@ -2956,6 +3067,7 @@ dependencies = [
  "zenoh-link",
  "zenoh-protocol",
  "zenoh-result",
+ "zenoh-shm",
  "zenoh-sync",
  "zenoh-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ libc = "0.2.139"
 log = "0.4.17"
 rand = "0.8.5"
 spin = "0.9.5"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [ "unstable" ] }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [ "unstable", "shared-memory" ] }
 zenoh-protocol = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ build = "build.rs"
 
 [features]
 logger-autoinit = []
+shared-memory = ["zenoh/shared-memory"]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -46,7 +47,7 @@ libc = "0.2.139"
 log = "0.4.17"
 rand = "0.8.5"
 spin = "0.9.5"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [ "unstable", "shared-memory" ] }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [ "unstable" ] }
 zenoh-protocol = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -46,7 +46,7 @@ libc = "0.2.139"
 log = "0.4.17"
 rand = "0.8.5"
 spin = "0.9.5"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [ "unstable" ] }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [ "unstable", "shared-memory" ] }
 zenoh-protocol = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -32,6 +32,7 @@ build = "@CARGO_PROJECT_DIR@build.rs"
 
 [features]
 logger-autoinit = []
+shared-memory = ["zenoh/shared-memory"]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -46,7 +47,7 @@ libc = "0.2.139"
 log = "0.4.17"
 rand = "0.8.5"
 spin = "0.9.5"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [ "unstable", "shared-memory" ] }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [ "unstable" ] }
 zenoh-protocol = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 

--- a/examples/z_pong.c
+++ b/examples/z_pong.c
@@ -3,7 +3,12 @@
 
 void callback(const z_sample_t* sample, void* context) {
     z_publisher_t pub = z_loan(*(z_owned_publisher_t*)context);
+#ifdef ZENOH_C  // The zc_owned_payload_t API is exclusive to zenoh-c, but allows avoiding some copies.
+    zc_owned_payload_t payload = zc_sample_payload_rcinc(sample);
+    zc_publisher_put_owned(pub, z_move(payload), NULL);
+#else
     z_publisher_put(pub, sample->payload.start, sample->payload.len, NULL);
+#endif
 }
 void drop(void* context) {
     z_owned_publisher_t* pub = (z_owned_publisher_t*)context;

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -11,6 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -64,16 +65,18 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    char buf[256];
     for (int idx = 0; idx < N; ++idx) {
         zc_owned_shmbuf_t shmbuf = zc_shm_alloc(&manager, 256);
         if (!z_check(shmbuf)) {
             printf("Failed to allocate a SHM buffer\n");
             exit(-1);
         }
-        uint8_t *buf = zc_shmbuf_ptr(&shmbuf);
+        char *buf = (char *)zc_shmbuf_ptr(&shmbuf);
+        buf[256] = 0;
+        snprintf(buf, 255, "[%4d] %s", idx, value);
+        size_t len = strlen(buf);
+        zc_shmbuf_set_length(&shmbuf, len);
         sleep(1);
-        sprintf((char *)buf, "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
         z_publisher_put_options_t options = z_publisher_put_options_default();
         options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
         }
         uint8_t *buf = zc_shmbuf_ptr(&shmbuf);
         sleep(1);
-        sprintf(buf, "[%4d] %s", idx, value);
+        sprintf((char *)buf, "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
         z_publisher_put_options_t options = z_publisher_put_options_default();
         options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "zenoh.h"
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+#define sleep(x) Sleep(x * 1000)
+#else
+#include <unistd.h>
+#endif
+
+#define N 10
+
+int main(int argc, char **argv) {
+    char *keyexpr = "demo/example/zenoh-c-pub-shm";
+    char *value = "Pub from C!";
+
+    if (argc > 1) keyexpr = argv[1];
+    if (argc > 2) value = argv[2];
+
+    z_owned_config_t config = z_config_default();
+    if (argc > 3) {
+        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
+            exit(-1);
+        }
+    }
+
+    printf("Opening session...\n");
+    z_owned_session_t s = z_open(z_move(config));
+    z_id_t id = z_info_zid(z_loan(s));
+    char idstr[33];
+    for (int i = 0; i < 16; i++) {
+        sprintf(idstr + 2 * i, "%02x", id.id[i]);
+    }
+    idstr[32] = 0;
+    zc_owned_shm_manager_t manager = zc_shm_manager_new(z_loan(s), idstr, N * 256);
+    if (!z_check(s)) {
+        printf("Unable to open session!\n");
+        exit(-1);
+    }
+
+    printf("Declaring Publisher on '%s'...\n", keyexpr);
+    z_owned_publisher_t pub = z_declare_publisher(z_loan(s), z_keyexpr(keyexpr), NULL);
+    if (!z_check(pub)) {
+        printf("Unable to declare Publisher for key expression!\n");
+        exit(-1);
+    }
+
+    char buf[256];
+    for (int idx = 0; idx < N; ++idx) {
+        zc_owned_shmbuf_t shmbuf = zc_shm_alloc(&manager, 256);
+        if (!z_check(shmbuf)) {
+            printf("Failed to allocate a SHM buffer\n");
+            exit(-1);
+        }
+        uint8_t *buf = zc_shmbuf_ptr(&shmbuf);
+        sleep(1);
+        sprintf(buf, "[%4d] %s", idx, value);
+        printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
+        z_publisher_put_options_t options = z_publisher_put_options_default();
+        options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);
+        zc_owned_payload_t payload = zc_shmbuf_into_payload(z_move(shmbuf));
+        zc_publisher_put_owned(z_loan(pub), z_move(payload), &options);
+    }
+
+    z_undeclare_publisher(z_move(pub));
+
+    z_close(z_move(s));
+    return 0;
+}

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1687,6 +1687,10 @@ struct zc_owned_shm_manager_t zc_shm_manager_new(struct z_session_t session,
  */
 uintptr_t zc_shmbuf_capacity(const struct zc_owned_shmbuf_t *buf);
 /**
+ * Returns `false` if `buf` is in its gravestone state.
+ */
+bool zc_shmbuf_check(const struct zc_owned_shmbuf_t *buf);
+/**
  * Drops the SHM buffer, decrementing its backing reference counter.
  */
 void zc_shmbuf_drop(struct zc_owned_shmbuf_t *buf);
@@ -1703,7 +1707,7 @@ uintptr_t zc_shmbuf_length(const struct zc_owned_shmbuf_t *buf);
 /**
  * Returns the start of the SHM buffer.
  */
-const uint8_t *zc_shmbuf_ptr(const struct zc_owned_shmbuf_t *buf);
+uint8_t *zc_shmbuf_ptr(const struct zc_owned_shmbuf_t *buf);
 /**
  * Sets the length of the SHM buffer.
  *

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -646,6 +646,12 @@ typedef struct zc_owned_payload_t {
   struct z_bytes_t payload;
   uintptr_t _owner[4];
 } zc_owned_payload_t;
+typedef struct zc_owned_shmbuf_t {
+  uintptr_t _0[9];
+} zc_owned_shmbuf_t;
+typedef struct zc_owned_shm_manager_t {
+  UnsafeCell<SharedMemoryManager> *_0;
+} zc_owned_shm_manager_t;
 extern const unsigned int Z_ROUTER;
 extern const unsigned int Z_PEER;
 extern const unsigned int Z_CLIENT;
@@ -1604,3 +1610,7 @@ struct z_owned_reply_channel_t zc_reply_non_blocking_fifo_new(uintptr_t bound);
  * Clones the sample's payload by incrementing its backing refcount (this doesn't imply any copies).
  */
 struct zc_owned_payload_t zc_sample_rcinc(struct z_sample_t sample);
+struct zc_owned_shmbuf_t zc_shm_alloc(const struct zc_owned_shm_manager_t *shm, uintptr_t capacity);
+struct zc_owned_shm_manager_t zc_shm_manager_new(struct z_session_t session,
+                                                 const char *id,
+                                                 uintptr_t size);

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1682,6 +1682,7 @@ void zc_shm_manager_drop(struct zc_owned_shm_manager_t *manager);
 struct zc_owned_shm_manager_t zc_shm_manager_new(struct z_session_t session,
                                                  const char *id,
                                                  uintptr_t size);
+struct zc_owned_shm_manager_t zc_shm_manager_null(void);
 /**
  * Returns the capacity of the SHM buffer.
  */
@@ -1704,6 +1705,10 @@ struct zc_owned_payload_t zc_shmbuf_into_payload(struct zc_owned_shmbuf_t *buf);
  * Note that when constructing an SHM buffer, length is defaulted to its capacity.
  */
 uintptr_t zc_shmbuf_length(const struct zc_owned_shmbuf_t *buf);
+/**
+ * Constructs a null safe-to-drop value of type `zc_owned_shmbuf_t`
+ */
+struct zc_owned_shmbuf_t zc_shmbuf_null(void);
 /**
  * Returns the start of the SHM buffer.
  */

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1586,7 +1586,7 @@ struct zc_owned_payload_t zc_payload_rcinc(const struct zc_owned_payload_t *payl
  * Sends a `PUT` message onto the publisher's key expression, transfering the buffer ownership.
  *
  * This is avoids copies when transfering data that was either:
- * - `zc_sample_rcinc`'d from a sample, when forwarding samples from a subscriber/query to a publisher
+ * - `zc_sample_payload_rcinc`'d from a sample, when forwarding samples from a subscriber/query to a publisher
  * - constructed from a `zc_owned_shmbuf_t`
  *
  * The payload's encoding can be sepcified through the options.
@@ -1606,7 +1606,7 @@ int8_t zc_publisher_put_owned(struct z_publisher_t publisher,
  * Put data, transfering the buffer ownership.
  *
  * This is avoids copies when transfering data that was either:
- * - `zc_sample_rcinc`'d from a sample, when forwarding samples from a subscriber/query to a publisher
+ * - `zc_sample_payload_rcinc`'d from a sample, when forwarding samples from a subscriber/query to a publisher
  * - constructed from a `zc_owned_shmbuf_t`
  *
  * The payload's encoding can be sepcified through the options.
@@ -1650,7 +1650,7 @@ struct z_owned_reply_channel_t zc_reply_non_blocking_fifo_new(uintptr_t bound);
 /**
  * Clones the sample's payload by incrementing its backing refcount (this doesn't imply any copies).
  */
-struct zc_owned_payload_t zc_sample_rcinc(struct z_sample_t sample);
+struct zc_owned_payload_t zc_sample_payload_rcinc(const struct z_sample_t *sample);
 /**
  * Allocates a buffer of size `capacity` in the manager's memory.
  *

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -642,6 +642,18 @@ typedef struct z_owned_scouting_config_t {
   unsigned long zc_timeout_ms;
   unsigned int zc_what;
 } z_owned_scouting_config_t;
+/**
+ * An owned payload, backed by a reference counted owner.
+ *
+ * The `payload` field may be modified, and Zenoh will take the new values into account,
+ * however, assuming `ostart` and `olen` are the respective values of `payload.start` and
+ * `payload.len` when constructing the `zc_owned_payload_t payload` value was created,
+ * then `payload.start` MUST remain within the `[ostart, ostart + olen[` interval, and
+ * `payload.len` must remain within `[0, olen -(payload.start - ostart)]`.
+ *
+ * Should this invariant be broken when the payload is passed to one of zenoh's `put_owned`
+ * functions, then the operation will fail (but the passed value will still be consumed).
+ */
 typedef struct zc_owned_payload_t {
   struct z_bytes_t payload;
   uintptr_t _owner[4];

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -33,7 +33,9 @@
                   z_owned_closure_zid_t * : z_closure_zid_drop,                     \
                   z_owned_reply_channel_closure_t * : z_reply_channel_closure_drop, \
                   z_owned_reply_channel_t * : z_reply_channel_drop,                 \
-                  zc_owned_payload_t * : zc_payload_drop                  \
+                  zc_owned_payload_t * : zc_payload_drop,                           \
+                  zc_owned_shmbuf_t * : zc_shmbuf_drop,                             \
+                  zc_owned_shm_manager_t * : zc_shm_manager_drop                    \
             )(x)
 
 #define z_null(x) (*x = \
@@ -56,7 +58,9 @@
                   z_owned_closure_zid_t * : z_closure_zid_null,                     \
                   z_owned_reply_channel_closure_t * : z_reply_channel_closure_null, \
                   z_owned_reply_channel_t * : z_reply_channel_null,                 \
-                  zc_owned_payload_t * : zc_payload_null                            \
+                  zc_owned_payload_t * : zc_payload_null,                           \
+                  zc_owned_shmbuf_t * : zc_shmbuf_null,                             \
+                  zc_owned_shm_manager_t * : zc_shm_manager_null                    \
             )())
 
 #define z_check(x) \
@@ -75,7 +79,8 @@
                   z_owned_hello_t : z_hello_check,                     \
                   z_owned_str_t : z_str_check,                         \
                   zc_owned_payload_t : zc_payload_check,               \
-                  zc_owned_shmbuf_t : zc_shmbuf_check                  \
+                  zc_owned_shmbuf_t : zc_shmbuf_check,                 \
+                  zc_owned_shm_manager_t : zc_shm_manager_check        \
             )(&x)
 
 #define z_call(x, ...) \
@@ -133,6 +138,8 @@ template<> struct zenoh_drop_type<z_owned_reply_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_hello_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_str_t> { typedef void type; };
 template<> struct zenoh_drop_type<zc_owned_payload_t> { typedef void type; };
+template<> struct zenoh_drop_type<zc_owned_shmbuf_t> { typedef void type; };
+template<> struct zenoh_drop_type<zc_owned_shm_manager_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_closure_sample_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_closure_query_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_closure_reply_t> { typedef void type; };
@@ -154,6 +161,8 @@ template<> inline void z_drop(z_owned_reply_t* v) { z_reply_drop(v); }
 template<> inline void z_drop(z_owned_hello_t* v) { z_hello_drop(v); }
 template<> inline void z_drop(z_owned_str_t* v) { z_str_drop(v); }
 template<> inline void z_drop(zc_owned_payload_t* v) { zc_payload_drop(v); }
+template<> inline void z_drop(zc_owned_shmbuf_t* v) { zc_shmbuf_drop(v); }
+template<> inline void z_drop(zc_owned_shm_manager_t* v) { zc_shm_manager_drop(v); }
 template<> inline void z_drop(z_owned_closure_sample_t* v) { z_closure_sample_drop(v); }
 template<> inline void z_drop(z_owned_closure_query_t* v) { z_closure_query_drop(v); }
 template<> inline void z_drop(z_owned_closure_reply_t* v) { z_closure_reply_drop(v); }
@@ -175,6 +184,8 @@ inline void z_null(z_owned_reply_t& v) { v = z_reply_null(); }
 inline void z_null(z_owned_hello_t& v) { v = z_hello_null(); }
 inline void z_null(z_owned_str_t& v) { v = z_str_null(); }
 inline void z_null(zc_owned_payload_t& v) { v = zc_payload_null(); }
+inline void z_null(zc_owned_shmbuf_t& v) { v = zc_shmbuf_null(); }
+inline void z_null(zc_owned_shm_manager_t& v) { v = zc_shm_manager_null(); }
 inline void z_null(z_owned_closure_sample_t& v) { v = z_closure_sample_null(); }
 inline void z_null(z_owned_closure_query_t& v) { v = z_closure_query_null(); }
 inline void z_null(z_owned_closure_reply_t& v) { v = z_closure_reply_null(); }
@@ -191,6 +202,8 @@ inline bool z_check(const z_owned_config_t& v) { return z_config_check(&v); }
 inline bool z_check(const z_owned_scouting_config_t& v) { return z_scouting_config_check(&v); }
 inline bool z_check(const z_bytes_t& v) { return z_bytes_check(&v); }
 inline bool z_check(const zc_owned_payload_t& v) { return zc_payload_check(&v); }
+inline bool z_check(const zc_owned_shmbuf_t& v) { return zc_shmbuf_check(&v); }
+inline bool z_check(const zc_owned_shm_manager_t& v) { return zc_shm_manager_check(&v); }
 inline bool z_check(const z_owned_subscriber_t& v) { return z_subscriber_check(&v); }
 inline bool z_check(const z_owned_pull_subscriber_t& v) { return z_pull_subscriber_check(&v); }
 inline bool z_check(const z_owned_queryable_t& v) { return z_queryable_check(&v); }

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -74,7 +74,8 @@
                   z_owned_reply_t : z_reply_check,                     \
                   z_owned_hello_t : z_hello_check,                     \
                   z_owned_str_t : z_str_check,                         \
-                  zc_owned_payload_t : zc_payload_check                \
+                  zc_owned_payload_t : zc_payload_check,               \
+                  zc_owned_shmbuf_t : zc_shmbuf_check                  \
             )(&x)
 
 #define z_call(x, ...) \

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -32,7 +32,8 @@
                   z_owned_closure_hello_t * : z_closure_hello_drop,                 \
                   z_owned_closure_zid_t * : z_closure_zid_drop,                     \
                   z_owned_reply_channel_closure_t * : z_reply_channel_closure_drop, \
-                  z_owned_reply_channel_t * : z_reply_channel_drop                  \
+                  z_owned_reply_channel_t * : z_reply_channel_drop,                 \
+                  zc_owned_payload_t * : zc_payload_drop                  \
             )(x)
 
 #define z_null(x) (*x = \
@@ -54,7 +55,8 @@
                   z_owned_closure_hello_t * : z_closure_hello_null,                 \
                   z_owned_closure_zid_t * : z_closure_zid_null,                     \
                   z_owned_reply_channel_closure_t * : z_reply_channel_closure_null, \
-                  z_owned_reply_channel_t * : z_reply_channel_null                  \
+                  z_owned_reply_channel_t * : z_reply_channel_null,                 \
+                  zc_owned_payload_t * : zc_payload_null                            \
             )())
 
 #define z_check(x) \
@@ -71,7 +73,8 @@
                   z_owned_encoding_t : z_encoding_check,               \
                   z_owned_reply_t : z_reply_check,                     \
                   z_owned_hello_t : z_hello_check,                     \
-                  z_owned_str_t : z_str_check                          \
+                  z_owned_str_t : z_str_check,                         \
+                  zc_owned_payload_t : zc_payload_check                \
             )(&x)
 
 #define z_call(x, ...) \
@@ -128,6 +131,7 @@ template<> struct zenoh_drop_type<z_owned_encoding_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_reply_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_hello_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_str_t> { typedef void type; };
+template<> struct zenoh_drop_type<zc_owned_payload_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_closure_sample_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_closure_query_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_closure_reply_t> { typedef void type; };
@@ -148,6 +152,7 @@ template<> inline void z_drop(z_owned_encoding_t* v) { z_encoding_drop(v); }
 template<> inline void z_drop(z_owned_reply_t* v) { z_reply_drop(v); }
 template<> inline void z_drop(z_owned_hello_t* v) { z_hello_drop(v); }
 template<> inline void z_drop(z_owned_str_t* v) { z_str_drop(v); }
+template<> inline void z_drop(zc_owned_payload_t* v) { zc_payload_drop(v); }
 template<> inline void z_drop(z_owned_closure_sample_t* v) { z_closure_sample_drop(v); }
 template<> inline void z_drop(z_owned_closure_query_t* v) { z_closure_query_drop(v); }
 template<> inline void z_drop(z_owned_closure_reply_t* v) { z_closure_reply_drop(v); }
@@ -168,6 +173,7 @@ inline void z_null(z_owned_encoding_t& v) { v = z_encoding_null(); }
 inline void z_null(z_owned_reply_t& v) { v = z_reply_null(); }
 inline void z_null(z_owned_hello_t& v) { v = z_hello_null(); }
 inline void z_null(z_owned_str_t& v) { v = z_str_null(); }
+inline void z_null(zc_owned_payload_t& v) { v = zc_payload_null(); }
 inline void z_null(z_owned_closure_sample_t& v) { v = z_closure_sample_null(); }
 inline void z_null(z_owned_closure_query_t& v) { v = z_closure_query_null(); }
 inline void z_null(z_owned_closure_reply_t& v) { v = z_closure_reply_null(); }
@@ -183,6 +189,7 @@ inline bool z_check(const z_keyexpr_t& v) { return z_keyexpr_is_initialized(&v);
 inline bool z_check(const z_owned_config_t& v) { return z_config_check(&v); }
 inline bool z_check(const z_owned_scouting_config_t& v) { return z_scouting_config_check(&v); }
 inline bool z_check(const z_bytes_t& v) { return z_bytes_check(&v); }
+inline bool z_check(const zc_owned_payload_t& v) { return zc_payload_check(&v); }
 inline bool z_check(const z_owned_subscriber_t& v) { return z_subscriber_check(&v); }
 inline bool z_check(const z_owned_pull_subscriber_t& v) { return z_pull_subscriber_check(&v); }
 inline bool z_check(const z_owned_queryable_t& v) { return z_queryable_check(&v); }

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -195,7 +195,8 @@ impl<'a> z_sample_t<'a> {
 
 /// Clones the sample's payload by incrementing its backing refcount (this doesn't imply any copies).
 #[no_mangle]
-pub extern "C" fn zc_sample_rcinc(sample: z_sample_t) -> zc_owned_payload_t {
+pub extern "C" fn zc_sample_payload_rcinc(sample: Option<&z_sample_t>) -> zc_owned_payload_t {
+    let Some(sample) = sample else {return zc_payload_null()};
     let buf = unsafe { std::mem::transmute::<_, &ZBuf>(sample._zc_buf).clone() };
     zc_owned_payload_t {
         payload: sample.payload,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ macro_rules! impl_guarded_transmute {
     ($src_type:ty, $dst_type:ty) => {
         const _: () =
             assert!(std::mem::align_of::<$src_type>() == std::mem::align_of::<$dst_type>());
-        impl GuardedTransmute<$dst_type> for $src_type {
+        impl $crate::GuardedTransmute<$dst_type> for $src_type {
             fn transmute(self) -> $dst_type {
                 unsafe { std::mem::transmute::<$src_type, $dst_type>(self) }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ mod publisher;
 pub use crate::publisher::*;
 mod closures;
 pub use closures::*;
+#[cfg(feature = "shared-memory")]
+mod shm;
 
 trait GuardedTransmute<D> {
     fn transmute(self) -> D;

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -253,7 +253,7 @@ pub unsafe extern "C" fn z_publisher_put(
 /// Sends a `PUT` message onto the publisher's key expression, transfering the buffer ownership.
 ///
 /// This is avoids copies when transfering data that was either:
-/// - `zc_sample_rcinc`'d from a sample, when forwarding samples from a subscriber/query to a publisher
+/// - `zc_sample_payload_rcinc`'d from a sample, when forwarding samples from a subscriber/query to a publisher
 /// - constructed from a `zc_owned_shmbuf_t`
 ///
 /// The payload's encoding can be sepcified through the options.

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -23,7 +23,7 @@ use zenoh_util::core::{zresult::ErrNo, SyncResolve};
 
 use crate::{
     impl_guarded_transmute, z_congestion_control_t, z_encoding_default, z_encoding_t, z_keyexpr_t,
-    z_priority_t, z_session_t, GuardedTransmute, LOG_INVALID_SESSION,
+    z_priority_t, z_session_t, zc_owned_payload_t, GuardedTransmute, LOG_INVALID_SESSION,
 };
 
 /// Options passed to the :c:func:`z_declare_publisher` function.
@@ -235,6 +235,49 @@ pub unsafe extern "C" fn z_publisher_put(
 ) -> i8 {
     if let Some(p) = publisher.as_ref() {
         let value: Value = std::slice::from_raw_parts(payload, len).into();
+        let put = match options {
+            Some(options) => p.put(value.encoding(options.encoding.into())),
+            None => p.put(value),
+        };
+        if let Err(e) = put.res_sync() {
+            log::error!("{}", e);
+            e.errno().get()
+        } else {
+            0
+        }
+    } else {
+        i8::MIN
+    }
+}
+
+/// Sends a `PUT` message onto the publisher's key expression, transfering the buffer ownership.
+///
+/// This is avoids copies when transfering data that was either:
+/// - `zc_sample_rcinc`'d from a sample, when forwarding samples from a subscriber/query to a publisher
+/// - constructed from a `zc_owned_shmbuf_t`
+///
+/// The payload's encoding can be sepcified through the options.
+///
+/// Parameters:
+///     session: The zenoh session.
+///     payload: The value to put.
+///     len: The length of the value to put.
+///     options: The publisher put options.
+/// Returns:
+///     ``0`` in case of success, negative values in case of failure.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn zc_publisher_put_owned(
+    publisher: z_publisher_t,
+    payload: Option<&mut zc_owned_payload_t>,
+    options: Option<&z_publisher_put_options_t>,
+) -> i8 {
+    if let Some(p) = publisher.as_ref() {
+        let Some(payload) = payload.and_then(|p| p.take()) else {
+            log::debug!("Attempted to put without a payload");
+            return i8::MIN;
+        };
+        let value: Value = payload.into();
         let put = match options {
             Some(options) => p.put(value.encoding(options.encoding.into())),
             None => p.put(value),

--- a/src/pull_subscriber.rs
+++ b/src/pull_subscriber.rs
@@ -12,7 +12,7 @@ use crate::GuardedTransmute;
 // Contributors:
 //   ZettaScale Zenoh team, <zenoh@zettascale.tech>
 //
-use crate::collections::*;
+
 use crate::commons::*;
 use crate::impl_guarded_transmute;
 use crate::keyexpr::*;
@@ -189,17 +189,11 @@ pub unsafe extern "C" fn z_declare_pull_subscriber(
                 .declare_subscriber(keyexpr)
                 .callback(move |sample| {
                     let payload = sample.payload.contiguous();
-                    let bytes = z_bytes_t {
-                        start: payload.as_ptr(),
-                        len: payload.len(),
+                    let owner = match payload {
+                        std::borrow::Cow::Owned(v) => zenoh::buffers::ZBuf::from(v),
+                        _ => sample.payload.clone(),
                     };
-                    let sample = z_sample_t {
-                        keyexpr: (&sample.key_expr).into(),
-                        payload: bytes,
-                        encoding: (&sample.encoding).into(),
-                        kind: sample.kind.into(),
-                        timestamp: sample.timestamp.as_ref().into(),
-                    };
+                    let sample = z_sample_t::new(&sample, &owner);
                     z_closure_sample_call(&closure, &sample)
                 })
                 .reliability(reliability)

--- a/src/put.rs
+++ b/src/put.rs
@@ -177,7 +177,7 @@ pub unsafe extern "C" fn z_put(
 /// Put data, transfering the buffer ownership.
 ///
 /// This is avoids copies when transfering data that was either:
-/// - `zc_sample_rcinc`'d from a sample, when forwarding samples from a subscriber/query to a publisher
+/// - `zc_sample_payload_rcinc`'d from a sample, when forwarding samples from a subscriber/query to a publisher
 /// - constructed from a `zc_owned_shmbuf_t`
 ///
 /// The payload's encoding can be sepcified through the options.

--- a/src/put.rs
+++ b/src/put.rs
@@ -174,6 +174,62 @@ pub unsafe extern "C" fn z_put(
     }
 }
 
+/// Put data, transfering the buffer ownership.
+///
+/// This is avoids copies when transfering data that was either:
+/// - `zc_sample_rcinc`'d from a sample, when forwarding samples from a subscriber/query to a publisher
+/// - constructed from a `zc_owned_shmbuf_t`
+///
+/// The payload's encoding can be sepcified through the options.
+///
+/// Parameters:
+///     session: The zenoh session.
+///     keyexpr: The key expression to put.
+///     payload: The value to put.
+///     options: The put options.
+/// Returns:
+///     ``0`` in case of success, negative values in case of failure.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn zc_put_owned(
+    session: z_session_t,
+    keyexpr: z_keyexpr_t,
+    payload: Option<&mut zc_owned_payload_t>,
+    mut opts: *const z_put_options_t,
+) -> i8 {
+    match session.as_ref() {
+        Some(s) => {
+            let default = z_put_options_default();
+            if opts.is_null() {
+                opts = &default;
+            }
+            if let Some(payload) = payload.and_then(|p| p.take()) {
+                match s
+                    .put(keyexpr, payload)
+                    .encoding((*opts).encoding)
+                    .kind(SampleKind::Put)
+                    .congestion_control((*opts).congestion_control.into())
+                    .priority((*opts).priority.into())
+                    .res_sync()
+                {
+                    Err(e) => {
+                        log::error!("{}", e);
+                        e.errno().get()
+                    }
+                    Ok(()) => 0,
+                }
+            } else {
+                log::debug!("zc_payload_null was provided as payload for put");
+                i8::MIN
+            }
+        }
+        None => {
+            log::debug!("{}", LOG_INVALID_SESSION);
+            i8::MIN
+        }
+    }
+}
+
 /// Options passed to the :c:func:`z_delete` function.
 #[repr(C)]
 #[allow(non_camel_case_types)]

--- a/src/shm.rs
+++ b/src/shm.rs
@@ -43,6 +43,11 @@ impl DerefMut for zc_owned_shm_manager_t {
         unsafe { std::mem::transmute(self) }
     }
 }
+impl zc_owned_shm_manager_t {
+    pub fn null() -> Self {
+        None::<_>.into()
+    }
+}
 
 #[no_mangle]
 pub extern "C" fn zc_shm_manager_new(
@@ -71,6 +76,11 @@ pub extern "C" fn zc_shm_manager_drop(manager: &mut zc_owned_shm_manager_t) {
 #[no_mangle]
 pub extern "C" fn zc_shm_manager_check(manager: &zc_owned_shm_manager_t) -> bool {
     manager.is_some()
+}
+
+#[no_mangle]
+pub extern "C" fn zc_shm_manager_null() -> zc_owned_shm_manager_t {
+    zc_owned_shm_manager_t::null()
 }
 
 /// Runs a garbage collection pass on the SHM manager.
@@ -123,6 +133,12 @@ impl DerefMut for zc_owned_shmbuf_t {
     }
 }
 
+impl zc_owned_shmbuf_t {
+    pub fn null() -> Self {
+        UnsafeCell::new(None).into()
+    }
+}
+
 /// Allocates a buffer of size `capacity` in the manager's memory.
 ///
 /// # Safety
@@ -153,6 +169,12 @@ pub extern "C" fn zc_shmbuf_drop(buf: &mut zc_owned_shmbuf_t) {
 #[no_mangle]
 pub extern "C" fn zc_shmbuf_check(buf: &zc_owned_shmbuf_t) -> bool {
     unsafe { (*buf.get()).is_some() }
+}
+
+/// Constructs a null safe-to-drop value of type `zc_owned_shmbuf_t`
+#[no_mangle]
+pub extern "C" fn zc_shmbuf_null() -> zc_owned_shmbuf_t {
+    zc_owned_shmbuf_t::null()
 }
 
 /// Constructs an owned payload from an owned SHM buffer.

--- a/src/shm.rs
+++ b/src/shm.rs
@@ -149,6 +149,12 @@ pub extern "C" fn zc_shmbuf_drop(buf: &mut zc_owned_shmbuf_t) {
     buf.get_mut().take();
 }
 
+/// Returns `false` if `buf` is in its gravestone state.
+#[no_mangle]
+pub extern "C" fn zc_shmbuf_check(buf: &zc_owned_shmbuf_t) -> bool {
+    unsafe { (*buf.get()).is_some() }
+}
+
 /// Constructs an owned payload from an owned SHM buffer.
 #[no_mangle]
 pub extern "C" fn zc_shmbuf_into_payload(buf: &mut zc_owned_shmbuf_t) -> zc_owned_payload_t {
@@ -160,10 +166,10 @@ pub extern "C" fn zc_shmbuf_into_payload(buf: &mut zc_owned_shmbuf_t) -> zc_owne
 
 /// Returns the start of the SHM buffer.
 #[no_mangle]
-pub unsafe extern "C" fn zc_shmbuf_ptr(buf: &zc_owned_shmbuf_t) -> *const u8 {
+pub unsafe extern "C" fn zc_shmbuf_ptr(buf: &zc_owned_shmbuf_t) -> *mut u8 {
     match &*buf.get() {
-        None => std::ptr::null(),
-        Some(buf) => buf.as_slice().as_ptr(),
+        None => std::ptr::null_mut(),
+        Some(buf) => buf.as_slice().as_ptr().cast_mut(),
     }
 }
 

--- a/src/shm.rs
+++ b/src/shm.rs
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2017, 2022 ZettaScale Technology.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh team, <zenoh@zettascale.tech>
+//
+
+use std::cell::UnsafeCell;
+
+use libc::c_char;
+use zenoh::shm::SharedMemoryManager;
+
+use crate::z_session_t;
+
+#[repr(C)]
+pub struct zc_owned_shm_manager_t(Option<Box<UnsafeCell<zenoh::shm::SharedMemoryManager>>>);
+
+#[no_mangle]
+pub extern "C" fn zc_shm_manager_new(
+    session: z_session_t,
+    id: *const c_char,
+    size: usize,
+) -> zc_owned_shm_manager_t {
+    let _ = session; // This function will likely need the session in the future, so we start doing the association now
+    zc_owned_shm_manager_t((move || {
+        let len = unsafe { libc::strlen(id) };
+        let id = unsafe { std::str::from_utf8(std::slice::from_raw_parts(id as *const u8, len)) }
+            .ok()?
+            .to_owned();
+        Some(Box::new(UnsafeCell::new(
+            SharedMemoryManager::make(id, size).ok()?,
+        )))
+    })())
+}
+
+#[repr(C)]
+#[derive(Default)]
+pub struct zc_owned_shmbuf_t([usize; 9]);
+
+#[no_mangle]
+pub extern "C" fn zc_shm_alloc(shm: &zc_owned_shm_manager_t, capacity: usize) -> zc_owned_shmbuf_t {
+    shm.0
+        .as_ref()
+        .map(|shm| unsafe {
+            match (*shm.get()).alloc(capacity) {
+                Ok(buf) => std::mem::transmute(buf),
+                Err(_) => Default::default(),
+            }
+        })
+        .unwrap_or_default()
+}

--- a/src/shm.rs
+++ b/src/shm.rs
@@ -12,15 +12,37 @@
 //   ZettaScale Zenoh team, <zenoh@zettascale.tech>
 //
 
-use std::cell::UnsafeCell;
+use std::{
+    cell::UnsafeCell,
+    ops::{Deref, DerefMut},
+};
 
 use libc::c_char;
-use zenoh::shm::SharedMemoryManager;
+use zenoh::{
+    buffers::ZBuf,
+    shm::{SharedMemoryBuf, SharedMemoryManager},
+};
 
-use crate::z_session_t;
+use crate::{z_session_t, zc_owned_payload_t, zc_payload_null};
 
 #[repr(C)]
-pub struct zc_owned_shm_manager_t(Option<Box<UnsafeCell<zenoh::shm::SharedMemoryManager>>>);
+pub struct zc_owned_shm_manager_t(usize);
+impl From<Option<Box<UnsafeCell<zenoh::shm::SharedMemoryManager>>>> for zc_owned_shm_manager_t {
+    fn from(value: Option<Box<UnsafeCell<zenoh::shm::SharedMemoryManager>>>) -> Self {
+        unsafe { std::mem::transmute(value) }
+    }
+}
+impl Deref for zc_owned_shm_manager_t {
+    type Target = Option<Box<UnsafeCell<zenoh::shm::SharedMemoryManager>>>;
+    fn deref(&self) -> &Self::Target {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+impl DerefMut for zc_owned_shm_manager_t {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { std::mem::transmute(self) }
+    }
+}
 
 #[no_mangle]
 pub extern "C" fn zc_shm_manager_new(
@@ -29,7 +51,7 @@ pub extern "C" fn zc_shm_manager_new(
     size: usize,
 ) -> zc_owned_shm_manager_t {
     let _ = session; // This function will likely need the session in the future, so we start doing the association now
-    zc_owned_shm_manager_t((move || {
+    (move || {
         let len = unsafe { libc::strlen(id) };
         let id = unsafe { std::str::from_utf8(std::slice::from_raw_parts(id as *const u8, len)) }
             .ok()?
@@ -37,16 +59,80 @@ pub extern "C" fn zc_shm_manager_new(
         Some(Box::new(UnsafeCell::new(
             SharedMemoryManager::make(id, size).ok()?,
         )))
-    })())
+    })()
+    .into()
+}
+
+#[no_mangle]
+pub extern "C" fn zc_shm_manager_drop(manager: &mut zc_owned_shm_manager_t) {
+    manager.take();
+}
+
+#[no_mangle]
+pub extern "C" fn zc_shm_manager_check(manager: &zc_owned_shm_manager_t) -> bool {
+    manager.is_some()
+}
+
+/// Runs a garbage collection pass on the SHM manager.
+///
+/// Returns the number of bytes that have been freed by the pass.
+///
+/// # Safety
+/// Calling this function concurrently with other shm functions on the same manager is UB.
+#[no_mangle]
+pub unsafe extern "C" fn zc_shm_gc(manager: &zc_owned_shm_manager_t) -> usize {
+    if let Some(shm) = manager.as_ref() {
+        unsafe { (*shm.get()).garbage_collect() }
+    } else {
+        0
+    }
+}
+
+/// Runs a defragmentation pass on the SHM manager.
+///
+/// Note that this doesn't trigger a garbage collection pass, nor does it move currently allocated data.
+///
+/// # Safety
+/// Calling this function concurrently with other shm functions on the same manager is UB.
+#[no_mangle]
+pub unsafe extern "C" fn zc_shm_defrag(manager: &zc_owned_shm_manager_t) -> usize {
+    if let Some(shm) = manager.as_ref() {
+        unsafe { (*shm.get()).defragment() }
+    } else {
+        0
+    }
 }
 
 #[repr(C)]
 #[derive(Default)]
 pub struct zc_owned_shmbuf_t([usize; 9]);
+impl From<UnsafeCell<Option<SharedMemoryBuf>>> for zc_owned_shmbuf_t {
+    fn from(value: UnsafeCell<Option<SharedMemoryBuf>>) -> Self {
+        unsafe { std::mem::transmute(value) }
+    }
+}
+impl Deref for zc_owned_shmbuf_t {
+    type Target = UnsafeCell<Option<SharedMemoryBuf>>;
+    fn deref(&self) -> &Self::Target {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+impl DerefMut for zc_owned_shmbuf_t {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { std::mem::transmute(self) }
+    }
+}
 
+/// Allocates a buffer of size `capacity` in the manager's memory.
+///
+/// # Safety
+/// Calling this function concurrently with other shm functions on the same manager is UB.
 #[no_mangle]
-pub extern "C" fn zc_shm_alloc(shm: &zc_owned_shm_manager_t, capacity: usize) -> zc_owned_shmbuf_t {
-    shm.0
+pub unsafe extern "C" fn zc_shm_alloc(
+    manager: &zc_owned_shm_manager_t,
+    capacity: usize,
+) -> zc_owned_shmbuf_t {
+    manager
         .as_ref()
         .map(|shm| unsafe {
             match (*shm.get()).alloc(capacity) {
@@ -55,4 +141,58 @@ pub extern "C" fn zc_shm_alloc(shm: &zc_owned_shm_manager_t, capacity: usize) ->
             }
         })
         .unwrap_or_default()
+}
+
+/// Drops the SHM buffer, decrementing its backing reference counter.
+#[no_mangle]
+pub extern "C" fn zc_shmbuf_drop(buf: &mut zc_owned_shmbuf_t) {
+    buf.get_mut().take();
+}
+
+/// Constructs an owned payload from an owned SHM buffer.
+#[no_mangle]
+pub extern "C" fn zc_shmbuf_into_payload(buf: &mut zc_owned_shmbuf_t) -> zc_owned_payload_t {
+    match buf.get_mut().take() {
+        Some(buf) => ZBuf::from(buf).try_into().unwrap_or_default(),
+        None => zc_payload_null(),
+    }
+}
+
+/// Returns the start of the SHM buffer.
+#[no_mangle]
+pub unsafe extern "C" fn zc_shmbuf_ptr(buf: &zc_owned_shmbuf_t) -> *const u8 {
+    match &*buf.get() {
+        None => std::ptr::null(),
+        Some(buf) => buf.as_slice().as_ptr(),
+    }
+}
+
+/// Returns the capacity of the SHM buffer.
+#[no_mangle]
+pub unsafe extern "C" fn zc_shmbuf_capacity(buf: &zc_owned_shmbuf_t) -> usize {
+    match &*buf.get() {
+        None => 0,
+        Some(buf) => buf.info.length,
+    }
+}
+
+/// Returns the length of the SHM buffer.
+///
+/// Note that when constructing an SHM buffer, length is defaulted to its capacity.
+#[no_mangle]
+pub unsafe extern "C" fn zc_shmbuf_length(buf: &zc_owned_shmbuf_t) -> usize {
+    match &*buf.get() {
+        None => 0,
+        Some(buf) => buf.len,
+    }
+}
+
+/// Sets the length of the SHM buffer.
+///
+/// This lets Zenoh know how much of the data to write over the network when sending the value to non-SHM-compatible neighboors.
+#[no_mangle]
+pub unsafe extern "C" fn zc_shmbuf_set_length(buf: &zc_owned_shmbuf_t, len: usize) {
+    if let Some(buf) = &mut *buf.get() {
+        buf.len = len
+    }
 }

--- a/tests/z_api_null_drop_test.c
+++ b/tests/z_api_null_drop_test.c
@@ -43,6 +43,9 @@ int main(int argc, char **argv) {
     z_owned_reply_channel_closure_t reply_channel_closure_null_1 = z_reply_channel_closure_null();
     z_owned_reply_channel_t reply_channel_null_1 = z_reply_channel_null();
     z_owned_str_t str_null_1 = z_str_null();
+    zc_owned_payload_t payload_null_1 = zc_payload_null();
+    zc_owned_shmbuf_t shmbuf_null_1 = zc_shmbuf_null();
+    zc_owned_shm_manager_t shm_manager_null_1 = zc_shm_manager_null();
 
     //
     // Test that they actually make invalid value (where applicable)
@@ -59,6 +62,9 @@ int main(int argc, char **argv) {
     assert(!z_check(reply_null_1));
     assert(!z_check(hello_null_1));
     assert(!z_check(str_null_1));
+    assert(!z_check(payload_null_1));
+    assert(!z_check(shmbuf_null_1));
+    assert(!z_check(shm_manager_null_1));
 
     //
     // Test that z_null macro defined for all types
@@ -82,6 +88,9 @@ int main(int argc, char **argv) {
     z_owned_reply_channel_closure_t reply_channel_closure_null_2;
     z_owned_reply_channel_t reply_channel_null_2;
     z_owned_str_t str_null_2;
+    zc_owned_payload_t payload_null_2;
+    zc_owned_shmbuf_t shmbuf_null_2;
+    zc_owned_shm_manager_t shm_manager_null_2;
 
     z_null(&session_null_2);
     z_null(&publisher_null_2);
@@ -102,6 +111,9 @@ int main(int argc, char **argv) {
     z_null(&reply_channel_closure_null_2);
     z_null(&reply_channel_null_2);
     z_null(&str_null_2);
+    z_null(&payload_null_2);
+    z_null(&shmbuf_null_2);
+    z_null(&shm_manager_null_2);
 
     //
     // Test that null macro works the same as direct call
@@ -118,6 +130,9 @@ int main(int argc, char **argv) {
     assert(!z_check(reply_null_2));
     assert(!z_check(hello_null_2));
     assert(!z_check(str_null_2));
+    assert(!z_check(payload_null_2));
+    assert(!z_check(shmbuf_null_2));
+    assert(!z_check(shm_manager_null_2));
 
     //
     // Test drop null and double drop it
@@ -142,6 +157,9 @@ int main(int argc, char **argv) {
         z_drop(z_move(reply_channel_closure_null_1));
         z_drop(z_move(reply_channel_null_1));
         z_drop(z_move(str_null_1));
+        z_drop(z_move(payload_null_1));
+        z_drop(z_move(shmbuf_null_1));
+        z_drop(z_move(shm_manager_null_1));
 
         z_drop(z_move(session_null_2));
         z_drop(z_move(publisher_null_2));
@@ -162,6 +180,9 @@ int main(int argc, char **argv) {
         z_drop(z_move(reply_channel_closure_null_2));
         z_drop(z_move(reply_channel_null_2));
         z_drop(z_move(str_null_2));
+        z_drop(z_move(payload_null_2));
+        z_drop(z_move(shmbuf_null_2));
+        z_drop(z_move(shm_manager_null_2));
     }
 
     return 0;


### PR DESCRIPTION
Zenoh has been SHM-capable for a while. With this, so will Zenoh-C.

Review goals:
- check for bugs, of course
- _evaluate API choices_: I'm very open to better names for `zc_sample_rcinc`, with the goal of keeping the lack of copy explicit