### PR TITLE
make session refcounted

### DIFF
--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
         sprintf(idstr + 2 * i, "%02x", id.id[i]);
     }
     idstr[32] = 0;
-    zc_owned_shm_manager_t manager = zc_shm_manager_new(z_loan(s), "chips", N * 1000000);
+    zc_owned_shm_manager_t manager = zc_shm_manager_new(z_loan(s), idstr, N * 1000000);
     if (!z_check(s)) {
         printf("Unable to open session!\n");
         exit(-1);

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1452,6 +1452,11 @@ bool z_session_check(const struct z_owned_session_t *session);
  * Returns a :c:type:`z_session_t` loaned from `s`.
  *
  * This handle doesn't increase the refcount of the session, but does allow to do so with `z_session_rcinc`.
+ *
+ * # Safety
+ * The returned `z_session_t` aliases `z_owned_session_t`'s internal allocation,
+ * attempting to use it after all owned handles to the session (including publishers, queryables and subscribers)
+ * have been destroyed is UB (likely SEGFAULT)
  */
 struct z_session_t z_session_loan(const struct z_owned_session_t *s);
 /**

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -662,8 +662,8 @@ bool z_bytes_check(const struct z_bytes_t *b);
 /**
  * Closes a zenoh session. This drops and invalidates `session` for double-drop safety.
  *
- * Returns 1 if the session reference count was decremented, but the session wasn't dropped
- * because other handles still exist.
+ * Returns a negative value if an error occured while closing the session.
+ * Returns the remaining reference count of the session otherwise, saturating at i8::MAX.
  */
 int8_t z_close(struct z_owned_session_t *session);
 /**

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -661,6 +661,9 @@ extern const char *Z_CONFIG_ADD_TIMESTAMP_KEY;
 bool z_bytes_check(const struct z_bytes_t *b);
 /**
  * Closes a zenoh session. This drops and invalidates `session` for double-drop safety.
+ *
+ * Returns 1 if the session reference count was decremented, but the session wasn't dropped
+ * because other handles still exist.
  */
 int8_t z_close(struct z_owned_session_t *session);
 /**
@@ -1424,12 +1427,18 @@ struct z_owned_scouting_config_t z_scouting_config_null(void);
 bool z_session_check(const struct z_owned_session_t *session);
 /**
  * Returns a :c:type:`z_session_t` loaned from `s`.
+ *
+ * This handle doesn't increase the refcount of the session, but does allow to do so with `z_session_rcinc`.
  */
 struct z_session_t z_session_loan(const struct z_owned_session_t *s);
 /**
  * Constructs a null safe-to-drop value of 'z_owned_session_t' type
  */
 struct z_owned_session_t z_session_null(void);
+/**
+ * Increments the session's reference count, returning a new owning handle.
+ */
+struct z_owned_session_t z_session_rcinc(struct z_session_t session);
 /**
  * Returns ``true`` if `strs` is valid.
  */

--- a/include/zenoh_concrete.h
+++ b/include/zenoh_concrete.h
@@ -28,16 +28,9 @@
  *
  * To check if `val` is still valid, you may use `z_X_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
  */
-#if !defined(TARGET_ARCH_ARM)
-typedef struct ALIGN(8) z_owned_session_t {
-  uint64_t _0[3];
+typedef struct z_owned_session_t {
+  uintptr_t _0;
 } z_owned_session_t;
-#endif
-#if defined(TARGET_ARCH_ARM)
-typedef struct ALIGN(4) z_owned_session_t {
-  uint32_t _0[3];
-} z_owned_session_t;
-#endif
 /**
  * Structs received by a Queryable.
  */
@@ -48,7 +41,7 @@ typedef struct z_query_t {
  * A loaned zenoh session.
  */
 typedef struct z_session_t {
-  const struct z_owned_session_t *_0;
+  uintptr_t _0;
 } z_session_t;
 /**
  * An owned zenoh pull subscriber. Destroying the subscriber cancels the subscription.

--- a/src/get.rs
+++ b/src/get.rs
@@ -214,11 +214,11 @@ pub unsafe extern "C" fn z_get(
     } else {
         CStr::from_ptr(parameters).to_str().unwrap()
     };
-    let mut q = session
-        .as_ref()
-        .as_ref()
-        .expect(LOG_INVALID_SESSION)
-        .get(KeyExpr::try_from(keyexpr).unwrap().with_parameters(p));
+    let Some(s) = session.upgrade() else {
+        log::error!("{LOG_INVALID_SESSION}");
+        return i8::MIN;
+    };
+    let mut q = s.get(KeyExpr::try_from(keyexpr).unwrap().with_parameters(p));
     if let Some(options) = options {
         q = q
             .consolidation(options.consolidation)

--- a/src/info.rs
+++ b/src/info.rs
@@ -32,7 +32,7 @@ pub struct z_id_t {
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn z_info_zid(session: z_session_t) -> z_id_t {
-    match session.as_ref() {
+    match session.upgrade() {
         Some(s) => std::mem::transmute::<ZenohId, z_id_t>(s.info().zid().res_sync()),
         None => z_id_t { id: [0; 16] },
     }
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn z_info_peers_zid(
 ) -> i8 {
     let mut closure = z_owned_closure_zid_t::empty();
     std::mem::swap(&mut closure, callback);
-    match session.as_ref() {
+    match session.upgrade() {
         Some(s) => {
             for id in s.info().peers_zid().res_sync() {
                 z_closure_zid_call(&closure, &std::mem::transmute(id));
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn z_info_routers_zid(
 ) -> i8 {
     let mut closure = z_owned_closure_zid_t::empty();
     std::mem::swap(&mut closure, callback);
-    match session.as_ref() {
+    match session.upgrade() {
         Some(s) => {
             for id in s.info().routers_zid().res_sync() {
                 z_closure_zid_call(&closure, &std::mem::transmute(id));

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -418,7 +418,7 @@ pub extern "C" fn z_declare_keyexpr(
             return z_owned_keyexpr_t::null();
         }
     };
-    match session.as_ref() {
+    match session.upgrade() {
         Some(s) => match s.declare_keyexpr(key_expr).res_sync() {
             Ok(id) => id.into_owned().into(),
             Err(e) => {
@@ -442,7 +442,7 @@ pub extern "C" fn z_undeclare_keyexpr(session: z_session_t, kexpr: &mut z_owned_
         return i8::MIN;
     };
 
-    match session.as_ref() {
+    match session.upgrade() {
         Some(s) => match s.undeclare(kexpr).res() {
             Ok(()) => 0,
             Err(e) => {

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -14,6 +14,7 @@
 
 use std::ops::{Deref, DerefMut};
 
+use zenoh::prelude::SessionDeclarations;
 use zenoh::{
     prelude::{Priority, Value},
     publication::Publisher,
@@ -128,7 +129,7 @@ pub extern "C" fn z_declare_publisher(
     keyexpr: z_keyexpr_t,
     options: Option<&z_publisher_options_t>,
 ) -> z_owned_publisher_t {
-    match session.as_ref() {
+    match session.upgrade() {
         Some(s) => {
             let mut p = s.declare_publisher(keyexpr);
             if let Some(options) = options {

--- a/src/pull_subscriber.rs
+++ b/src/pull_subscriber.rs
@@ -22,6 +22,7 @@ use crate::z_owned_closure_sample_t;
 use crate::z_reliability_t;
 use crate::LOG_INVALID_SESSION;
 use zenoh::prelude::sync::SyncResolve;
+use zenoh::prelude::SessionDeclarations;
 use zenoh::prelude::SplitBuffer;
 use zenoh::subscriber::Reliability;
 use zenoh_protocol::core::SubInfo;
@@ -177,8 +178,7 @@ pub unsafe extern "C" fn z_declare_pull_subscriber(
     let mut closure = z_owned_closure_sample_t::empty();
     std::mem::swap(callback, &mut closure);
 
-    let session: &'static z_owned_session_t = session.into();
-    match session.as_ref() {
+    match session.upgrade() {
         Some(s) => {
             if opts.is_null() {
                 let default = z_pull_subscriber_options_default();

--- a/src/put.rs
+++ b/src/put.rs
@@ -146,7 +146,7 @@ pub unsafe extern "C" fn z_put(
     len: size_t,
     mut opts: *const z_put_options_t,
 ) -> i8 {
-    match session.as_ref() {
+    match session.upgrade() {
         Some(s) => {
             let default = z_put_options_default();
             if opts.is_null() {
@@ -211,7 +211,7 @@ pub unsafe extern "C" fn z_delete(
     if opts.is_null() {
         opts = &default;
     }
-    match session.as_ref() {
+    match session.upgrade() {
         Some(s) => match s
             .delete(keyexpr)
             .congestion_control((*opts).congestion_control.into())

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -13,11 +13,12 @@
 //
 use crate::{
     impl_guarded_transmute, z_bytes_t, z_closure_query_call, z_encoding_default, z_encoding_t,
-    z_keyexpr_t, z_owned_closure_query_t, z_owned_session_t, z_session_t, z_value_t,
-    GuardedTransmute, LOG_INVALID_SESSION,
+    z_keyexpr_t, z_owned_closure_query_t, z_session_t, z_value_t, GuardedTransmute,
+    LOG_INVALID_SESSION,
 };
 use libc::c_void;
 use std::ops::Deref;
+use zenoh::prelude::SessionDeclarations;
 use zenoh::{
     prelude::{Sample, SplitBuffer},
     queryable::{Query, Queryable as CallbackQueryable},
@@ -142,8 +143,8 @@ pub extern "C" fn z_declare_queryable(
 ) -> z_owned_queryable_t {
     let mut closure = z_owned_closure_query_t::empty();
     std::mem::swap(&mut closure, callback);
-    let session: &'static z_owned_session_t = session.into();
-    let session = match session.as_ref() {
+
+    let session = match session.upgrade() {
         Some(s) => s,
         None => {
             log::error!("{}", LOG_INVALID_SESSION);

--- a/src/session.rs
+++ b/src/session.rs
@@ -11,7 +11,9 @@
 // Contributors:
 //   ZettaScale Zenoh team, <zenoh@zettascale.tech>
 //
+
 use crate::{config::*, impl_guarded_transmute, zc_init_logger, GuardedTransmute};
+use std::sync::{Arc, Weak};
 use zenoh::prelude::sync::SyncResolve;
 use zenoh::Session;
 use zenoh_util::core::zresult::ErrNo;
@@ -26,52 +28,53 @@ use zenoh_util::core::zresult::ErrNo;
 /// After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.  
 ///
 /// To check if `val` is still valid, you may use `z_X_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
-#[cfg(not(target_arch = "arm"))]
-#[repr(C, align(8))]
-pub struct z_owned_session_t([u64; 3]);
+#[repr(C)]
+pub struct z_owned_session_t(usize);
 
-#[cfg(target_arch = "arm")]
-#[repr(C, align(4))]
-pub struct z_owned_session_t([u32; 3]);
+impl_guarded_transmute!(Option<Arc<Session>>, z_owned_session_t);
 
-impl_guarded_transmute!(Option<Session>, z_owned_session_t);
-
-impl From<Option<Session>> for z_owned_session_t {
-    fn from(val: Option<Session>) -> Self {
+impl From<Option<Arc<Session>>> for z_owned_session_t {
+    fn from(val: Option<Arc<Session>>) -> Self {
         val.transmute()
     }
 }
 
-impl AsRef<Option<Session>> for z_owned_session_t {
-    fn as_ref(&self) -> &Option<Session> {
+impl AsRef<Option<Arc<Session>>> for z_owned_session_t {
+    fn as_ref(&self) -> &Option<Arc<Session>> {
         unsafe { std::mem::transmute(self) }
     }
 }
 
-impl AsMut<Option<Session>> for z_owned_session_t {
-    fn as_mut(&mut self) -> &mut Option<Session> {
+impl AsMut<Option<Arc<Session>>> for z_owned_session_t {
+    fn as_mut(&mut self) -> &mut Option<Arc<Session>> {
         unsafe { std::mem::transmute(self) }
     }
 }
 
-impl AsRef<Option<Session>> for z_session_t {
-    fn as_ref(&self) -> &Option<Session> {
-        unsafe { (*self.0).as_ref() }
+impl AsRef<Option<Weak<Session>>> for z_session_t {
+    fn as_ref(&self) -> &Option<Weak<Session>> {
+        unsafe { std::mem::transmute(self) }
     }
 }
 
-impl From<z_session_t> for &'static z_owned_session_t {
-    fn from(val: z_session_t) -> Self {
-        unsafe { &*val.0 }
+impl z_session_t {
+    pub fn upgrade(&self) -> Option<Arc<Session>> {
+        self.as_ref().as_ref().and_then(Weak::upgrade)
+    }
+}
+
+impl From<Option<Weak<Session>>> for z_session_t {
+    fn from(val: Option<Weak<Session>>) -> Self {
+        unsafe { std::mem::transmute(val) }
     }
 }
 
 impl z_owned_session_t {
-    pub fn new(session: Session) -> Self {
+    pub fn new(session: Arc<Session>) -> Self {
         Some(session).into()
     }
     pub fn null() -> Self {
-        None::<Session>.into()
+        None::<Arc<Session>>.into()
     }
 }
 
@@ -79,12 +82,14 @@ impl z_owned_session_t {
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct z_session_t(*const z_owned_session_t);
+pub struct z_session_t(usize);
 
 /// Returns a :c:type:`z_session_t` loaned from `s`.
+///
+/// This handle doesn't increase the refcount of the session, but does allow to do so with `z_session_rcinc`.
 #[no_mangle]
 pub extern "C" fn z_session_loan(s: &z_owned_session_t) -> z_session_t {
-    z_session_t(s)
+    s.as_ref().as_ref().map(Arc::downgrade).into()
 }
 
 /// Constructs a null safe-to-drop value of 'z_owned_session_t' type
@@ -110,7 +115,7 @@ pub extern "C" fn z_open(config: &mut z_owned_config_t) -> z_owned_session_t {
         }
     };
     match zenoh::open(*config).res() {
-        Ok(s) => z_owned_session_t::new(s),
+        Ok(s) => z_owned_session_t::new(Arc::new(s)),
         Err(e) => {
             log::error!("Error opening session: {}", e);
             z_owned_session_t::null()
@@ -126,11 +131,23 @@ pub extern "C" fn z_session_check(session: &z_owned_session_t) -> bool {
 }
 
 /// Closes a zenoh session. This drops and invalidates `session` for double-drop safety.
+///
+/// Returns 1 if the session reference count was decremented, but the session wasn't dropped
+/// because other handles still exist.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub extern "C" fn z_close(session: &mut z_owned_session_t) -> i8 {
-    if let Some(Err(e)) = session.as_mut().take().map(|s| s.close().res()) {
-        return e.errno().get();
+    let Some(s) = session.as_mut().take() else {return 0};
+    let Ok(s) = Arc::try_unwrap(s) else {return 1};
+    match s.close().res() {
+        Err(e) => e.errno().get(),
+        Ok(_) => 0,
     }
-    0
+}
+
+/// Increments the session's reference count, returning a new owning handle.
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub extern "C" fn z_session_rcinc(session: z_session_t) -> z_owned_session_t {
+    session.as_ref().as_ref().and_then(|s| s.upgrade()).into()
 }

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -1,4 +1,3 @@
-use crate::GuardedTransmute;
 //
 // Copyright (c) 2017, 2022 ZettaScale Technology.
 //
@@ -12,6 +11,7 @@ use crate::GuardedTransmute;
 // Contributors:
 //   ZettaScale Zenoh team, <zenoh@zettascale.tech>
 //
+
 use crate::collections::*;
 use crate::commons::*;
 use crate::impl_guarded_transmute;
@@ -19,8 +19,10 @@ use crate::keyexpr::*;
 use crate::session::*;
 use crate::z_closure_sample_call;
 use crate::z_owned_closure_sample_t;
+use crate::GuardedTransmute;
 use crate::LOG_INVALID_SESSION;
 use zenoh::prelude::sync::SyncResolve;
+use zenoh::prelude::SessionDeclarations;
 use zenoh::prelude::SplitBuffer;
 use zenoh::subscriber::Reliability;
 use zenoh_protocol::core::SubInfo;
@@ -202,8 +204,7 @@ pub unsafe extern "C" fn z_declare_subscriber(
     let mut closure = z_owned_closure_sample_t::empty();
     std::mem::swap(callback, &mut closure);
 
-    let session: &'static z_owned_session_t = session.into();
-    match session.as_ref() {
+    match session.upgrade() {
         Some(s) => {
             if opts.is_null() {
                 let default = z_subscriber_options_default();


### PR DESCRIPTION
With this, `z_owned_session_t` (`Option<Arc<Session>>`) is always movable, even when aliased by a `z_session_t` (`Option<Weak<Session>>`).