### PR TITLE
`keyexpr` methods of subscriber and publisher made available in C interface

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1268,7 +1268,6 @@ struct z_publisher_put_options_t z_publisher_put_options_default(void);
  * Returns ``true`` if `sub` is valid.
  */
 bool z_pull_subscriber_check(const struct z_owned_pull_subscriber_t *sub);
-struct z_keyexpr_t z_pull_subscriber_keyexpr(struct z_pull_subscriber_t subscriber);
 /**
  * Returns ``true`` if `sub` is valid.
  */

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -643,6 +643,12 @@ typedef struct z_owned_scouting_config_t {
   unsigned int zc_what;
 } z_owned_scouting_config_t;
 /**
+ * A loaned zenoh subscriber.
+ */
+typedef struct z_subscriber_t {
+  const struct z_owned_subscriber_t *_0;
+} z_subscriber_t;
+/**
  * An owned payload, backed by a reference counted owner.
  *
  * The `payload` field may be modified, and Zenoh will take the new values into account,
@@ -1222,6 +1228,10 @@ int8_t z_publisher_delete(struct z_publisher_t publisher,
  */
 struct z_publisher_delete_options_t z_publisher_delete_options_default(void);
 /**
+ * Returns the key expression of the publisher
+ */
+struct z_keyexpr_t z_publisher_keyexpr(struct z_publisher_t publisher);
+/**
  * Returns a :c:type:`z_publisher_t` loaned from `p`.
  */
 struct z_publisher_t z_publisher_loan(const struct z_owned_publisher_t *p);
@@ -1258,6 +1268,7 @@ struct z_publisher_put_options_t z_publisher_put_options_default(void);
  * Returns ``true`` if `sub` is valid.
  */
 bool z_pull_subscriber_check(const struct z_owned_pull_subscriber_t *sub);
+struct z_keyexpr_t z_pull_subscriber_keyexpr(struct z_pull_subscriber_t subscriber);
 /**
  * Returns ``true`` if `sub` is valid.
  */
@@ -1495,6 +1506,14 @@ struct z_owned_str_t z_str_null(void);
  * Returns ``true`` if `sub` is valid.
  */
 bool z_subscriber_check(const struct z_owned_subscriber_t *sub);
+/**
+ * Returns the key expression of the subscriber.
+ */
+struct z_keyexpr_t z_subscriber_keyexpr(struct z_subscriber_t subscriber);
+/**
+ * Returns a :c:type:`z_subscriber_t` loaned from `p`.
+ */
+struct z_subscriber_t z_subscriber_loan(const struct z_owned_subscriber_t *p);
 /**
  * Constructs a null safe-to-drop value of 'z_owned_subscriber_t' type
  */

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1230,7 +1230,7 @@ struct z_publisher_delete_options_t z_publisher_delete_options_default(void);
 /**
  * Returns the key expression of the publisher
  */
-struct z_keyexpr_t z_publisher_keyexpr(struct z_publisher_t publisher);
+struct z_owned_keyexpr_t z_publisher_keyexpr(struct z_publisher_t publisher);
 /**
  * Returns a :c:type:`z_publisher_t` loaned from `p`.
  */
@@ -1508,7 +1508,7 @@ bool z_subscriber_check(const struct z_owned_subscriber_t *sub);
 /**
  * Returns the key expression of the subscriber.
  */
-struct z_keyexpr_t z_subscriber_keyexpr(struct z_subscriber_t subscriber);
+struct z_owned_keyexpr_t z_subscriber_keyexpr(struct z_subscriber_t subscriber);
 /**
  * Returns a :c:type:`z_subscriber_t` loaned from `p`.
  */

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -8,11 +8,14 @@
                   z_owned_keyexpr_t : z_keyexpr_loan,                 \
                   z_owned_config_t : z_config_loan,                   \
                   z_owned_publisher_t : z_publisher_loan,             \
+                  z_owned_subscriber_t : z_subscriber_loan,           \
                   z_owned_pull_subscriber_t : z_pull_subscriber_loan, \
                   z_owned_encoding_t : z_encoding_loan,               \
                   z_owned_hello_t : z_hello_loan,                     \
                   z_owned_str_t : z_str_loan                          \
             )(&x)
+                //   z_owned_queryable_t : z_queryable_loan,             \
+// 
 #define z_drop(x) \
     _Generic((x), z_owned_session_t * : z_close,                                    \
                   z_owned_publisher_t * : z_undeclare_publisher,                    \

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -14,8 +14,7 @@
                   z_owned_hello_t : z_hello_loan,                     \
                   z_owned_str_t : z_str_loan                          \
             )(&x)
-                //   z_owned_queryable_t : z_queryable_loan,             \
-// 
+
 #define z_drop(x) \
     _Generic((x), z_owned_session_t * : z_close,                                    \
                   z_owned_publisher_t * : z_undeclare_publisher,                    \

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -24,8 +24,8 @@ use zenoh_util::core::{zresult::ErrNo, SyncResolve};
 
 use crate::{
     impl_guarded_transmute, z_congestion_control_t, z_encoding_default, z_encoding_t, z_keyexpr_t,
-    z_priority_t, z_session_t, zc_owned_payload_t, GuardedTransmute, UninitializedKeyExprError,
-    LOG_INVALID_SESSION,
+    z_owned_keyexpr_t, z_priority_t, z_session_t, zc_owned_payload_t, GuardedTransmute,
+    UninitializedKeyExprError, LOG_INVALID_SESSION,
 };
 
 /// Options passed to the :c:func:`z_declare_publisher` function.
@@ -343,11 +343,11 @@ pub extern "C" fn z_publisher_delete(
 /// Returns the key expression of the publisher
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_publisher_keyexpr(publisher: z_publisher_t) -> z_keyexpr_t {
+pub extern "C" fn z_publisher_keyexpr(publisher: z_publisher_t) -> z_owned_keyexpr_t {
     if let Some(p) = publisher.as_ref() {
         p.key_expr().clone().into()
     } else {
-        z_keyexpr_t::null()
+        z_keyexpr_t::null().into()
     }
 }
 

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -333,6 +333,17 @@ pub extern "C" fn z_publisher_delete(
     }
 }
 
+/// Returns the key expression of the publisher
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub extern "C" fn z_publisher_keyexpr(publisher: z_publisher_t) -> z_keyexpr_t {
+    if let Some(p) = publisher.as_ref() {
+        p.key_expr().clone().into()
+    } else {
+        z_keyexpr_t::null()
+    }
+}
+
 /// Undeclares the given :c:type:`z_owned_publisher_t`, droping it and invalidating it for double-drop safety.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]

--- a/src/pull_subscriber.rs
+++ b/src/pull_subscriber.rs
@@ -220,17 +220,6 @@ pub unsafe extern "C" fn z_declare_pull_subscriber(
     }
 }
 
-// Returns the key expression of the given :c:type:`z_pull_subscriber_t`.
-#[allow(clippy::missing_safety_doc)]
-#[no_mangle]
-pub extern "C" fn z_pull_subscriber_keyexpr(subscriber: z_pull_subscriber_t) -> z_keyexpr_t {
-    if let Some(sub) = subscriber.as_ref() {
-        sub.key_expr().clone().into()
-    } else {
-        z_keyexpr_t::null()
-    }
-}
-
 /// Undeclares the given :c:type:`z_owned_pull_subscriber_t`, droping it and invalidating it for double-drop safety.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]

--- a/src/pull_subscriber.rs
+++ b/src/pull_subscriber.rs
@@ -69,6 +69,12 @@ impl AsRef<PullSubscriber> for z_owned_pull_subscriber_t {
     }
 }
 
+impl<'a> AsRef<PullSubscriber> for z_pull_subscriber_t<'a> {
+    fn as_ref(&self) -> &PullSubscriber {
+        self.0.as_ref()
+    }
+}
+
 impl AsMut<PullSubscriber> for z_owned_pull_subscriber_t {
     fn as_mut(&mut self) -> &mut PullSubscriber {
         unsafe { std::mem::transmute(self) }
@@ -211,6 +217,17 @@ pub unsafe extern "C" fn z_declare_pull_subscriber(
             log::debug!("{}", LOG_INVALID_SESSION);
             z_owned_pull_subscriber_t::null()
         }
+    }
+}
+
+// Returns the key expression of the given :c:type:`z_pull_subscriber_t`.
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub extern "C" fn z_pull_subscriber_keyexpr(subscriber: z_pull_subscriber_t) -> z_keyexpr_t {
+    if let Some(sub) = subscriber.as_ref() {
+        sub.key_expr().clone().into()
+    } else {
+        z_keyexpr_t::null()
     }
 }
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -259,11 +259,11 @@ pub unsafe extern "C" fn z_declare_subscriber(
 /// Returns the key expression of the subscriber.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_subscriber_keyexpr(subscriber: z_subscriber_t) -> z_keyexpr_t {
+pub extern "C" fn z_subscriber_keyexpr(subscriber: z_subscriber_t) -> z_owned_keyexpr_t {
     if let Some(p) = subscriber.as_ref() {
         p.key_expr().clone().into()
     } else {
-        z_keyexpr_t::null()
+        z_keyexpr_t::null().into()
     }
 }
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -256,7 +256,6 @@ pub unsafe extern "C" fn z_declare_subscriber(
     }
 }
 
-
 /// Returns the key expression of the subscriber.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -117,6 +117,24 @@ pub extern "C" fn z_subscriber_null() -> z_owned_subscriber_t {
     z_owned_subscriber_t::null()
 }
 
+/// A loaned zenoh subscriber.
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct z_subscriber_t(*const z_owned_subscriber_t);
+
+impl<'a> AsRef<Subscriber> for z_subscriber_t {
+    fn as_ref(&self) -> &Subscriber {
+        unsafe { (*self.0).as_ref() }
+    }
+}
+
+/// Returns a :c:type:`z_subscriber_t` loaned from `p`.
+#[no_mangle]
+pub extern "C" fn z_subscriber_loan(p: &z_owned_subscriber_t) -> z_subscriber_t {
+    z_subscriber_t(p)
+}
+
 /// Options passed to the :c:func:`z_declare_subscriber` or :c:func:`z_declare_pull_subscriber` function.
 ///
 /// Members:
@@ -235,6 +253,18 @@ pub unsafe extern "C" fn z_declare_subscriber(
             log::debug!("{}", LOG_INVALID_SESSION);
             z_owned_subscriber_t::null()
         }
+    }
+}
+
+
+/// Returns the key expression of the subscriber.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub extern "C" fn z_subscriber_keyexpr(subscriber: z_subscriber_t) -> z_keyexpr_t {
+    if let Some(p) = subscriber.as_ref() {
+        p.key_expr().clone().into()
+    } else {
+        z_keyexpr_t::null()
     }
 }
 

--- a/tests/z_api_keyexpr_drop_test.c
+++ b/tests/z_api_keyexpr_drop_test.c
@@ -27,10 +27,10 @@ void test_publisher() {
     char keyexpr[256];
     strncpy(keyexpr, "foo/bar", 256);
     z_owned_publisher_t pub = z_declare_publisher(z_loan(s), z_keyexpr(keyexpr), NULL);
-    // strncpy(keyexpr, "baz/quax", 256);
+    strncpy(keyexpr, "baz/quax", 256);  // Update source string to ensure that the correct keyexpr
     z_keyexpr_t pub_keyexpr = z_publisher_keyexpr(z_loan(pub));
     z_owned_str_t pub_keyexpr_str = z_keyexpr_to_string(pub_keyexpr);
-    assert(strcmp(z_loan(pub_keyexpr_str), "foo/bar") == 0);
+    assert(strcmp(z_loan(pub_keyexpr_str), "foo/bar") == 0);  // Check that publisher keeps the correct keyexpr
     z_drop(z_move(pub_keyexpr_str));
     z_drop(z_move(pub));
     z_drop(z_move(s));
@@ -57,10 +57,10 @@ void test_subscriber() {
     char keyexpr[256];
     strncpy(keyexpr, "foo/bar", 256);
     z_owned_subscriber_t sub = z_declare_subscriber(z_loan(s), z_keyexpr(keyexpr), z_move(callback), NULL);
-    strncpy(keyexpr, "baz/quax", 256);
+    strncpy(keyexpr, "baz/quax", 256);  // Update source string to ensure that the keyexpr is copied into the subscriber
     z_keyexpr_t sub_keyexpr = z_subscriber_keyexpr(z_loan(sub));
     z_owned_str_t sub_keyexpr_str = z_keyexpr_to_string(sub_keyexpr);
-    assert(strcmp(z_loan(sub_keyexpr_str), "foo/bar") == 0);
+    assert(strcmp(z_loan(sub_keyexpr_str), "foo/bar") == 0);  // Check that subscriber keeps the correct keyexpr
     z_drop(z_move(sub_keyexpr_str));
     z_drop(z_move(sub));
     z_drop(z_move(s));
@@ -82,8 +82,9 @@ void test_subscriber() {
 
 int main(int argc, char **argv) {
     test_publisher();
-    // test_pull_subscriber();
     test_subscriber();
+    // TODO: Make same tests for pull subscriber and queryable when their `keyexpr` getters are implemented
+    // test_pull_subscriber();
     // test_queryable();
 
     return 0;

--- a/tests/z_api_keyexpr_drop_test.c
+++ b/tests/z_api_keyexpr_drop_test.c
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "zenoh.h"
+
+#undef NDEBUG
+#include <assert.h>
+
+void test_publisher() {
+    z_owned_config_t config = z_config_default();
+    z_owned_session_t s = z_open(z_move(config));
+    assert(z_check(s));
+    char keyexpr[256];
+    strncpy(keyexpr, "foo/bar", 256);
+    z_owned_publisher_t pub = z_declare_publisher(z_loan(s), z_keyexpr(keyexpr), NULL);
+    // strncpy(keyexpr, "baz/quax", 256);
+    z_keyexpr_t pub_keyexpr = z_publisher_keyexpr(z_loan(pub));
+    z_owned_str_t pub_keyexpr_str = z_keyexpr_to_string(pub_keyexpr);
+    assert(strcmp(z_loan(pub_keyexpr_str), "foo/bar") == 0);
+    z_drop(z_move(pub_keyexpr_str));
+    z_drop(z_move(pub));
+    z_drop(z_move(s));
+}
+
+void data_handler(const z_sample_t *sample, void *arg) {}
+
+// void test_pull_subscriber() {
+//     z_owned_config_t config = z_config_default();
+//     z_owned_session_t s = z_open(z_move(config));
+//     z_owned_closure_sample_t callback = z_closure(data_handler);
+//     char keyexpr[256];
+//     strncpy(keyexpr, "foo/bar", 256);
+//     z_owned_pull_subscriber_t sub = z_declare_pull_subscriber(z_loan(s), z_keyexpr(keyexpr), z_move(callback), NULL);
+//     strncpy(keyexpr, "baz/quax", 256);
+//     z_drop(z_move(sub));
+//     z_drop(z_move(s));
+// }
+
+void test_subscriber() {
+    z_owned_config_t config = z_config_default();
+    z_owned_session_t s = z_open(z_move(config));
+    z_owned_closure_sample_t callback = z_closure(data_handler);
+    char keyexpr[256];
+    strncpy(keyexpr, "foo/bar", 256);
+    z_owned_subscriber_t sub = z_declare_subscriber(z_loan(s), z_keyexpr(keyexpr), z_move(callback), NULL);
+    strncpy(keyexpr, "baz/quax", 256);
+    z_keyexpr_t sub_keyexpr = z_subscriber_keyexpr(z_loan(sub));
+    z_owned_str_t sub_keyexpr_str = z_keyexpr_to_string(sub_keyexpr);
+    assert(strcmp(z_loan(sub_keyexpr_str), "foo/bar") == 0);
+    z_drop(z_move(sub_keyexpr_str));
+    z_drop(z_move(sub));
+    z_drop(z_move(s));
+}
+
+// void query_handler(const z_query_t *query, void *context) {}
+
+// void test_queryable() {
+//     z_owned_config_t config = z_config_default();
+//     z_owned_session_t s = z_open(z_move(config));
+//     z_owned_closure_query_t callback = z_closure(query_handler);
+//     char keyexpr[256];
+//     strncpy(keyexpr, "foo/bar", 256);
+//     z_owned_queryable_t queryable = z_declare_queryable(z_loan(s), z_keyexpr(keyexpr), z_move(callback), NULL);
+//     strncpy(keyexpr, "baz/quax", 256);
+//     z_drop(z_move(queryable));
+//     z_drop(z_move(s));
+// }
+
+int main(int argc, char **argv) {
+    test_publisher();
+    // test_pull_subscriber();
+    test_subscriber();
+    // test_queryable();
+
+    return 0;
+}

--- a/tests/z_api_keyexpr_drop_test.c
+++ b/tests/z_api_keyexpr_drop_test.c
@@ -28,8 +28,8 @@ void test_publisher() {
     strncpy(keyexpr, "foo/bar", 256);
     z_owned_publisher_t pub = z_declare_publisher(z_loan(s), z_keyexpr(keyexpr), NULL);
     strncpy(keyexpr, "baz/quax", 256);  // Update source string to ensure that the correct keyexpr
-    z_keyexpr_t pub_keyexpr = z_publisher_keyexpr(z_loan(pub));
-    z_owned_str_t pub_keyexpr_str = z_keyexpr_to_string(pub_keyexpr);
+    z_owned_keyexpr_t pub_keyexpr = z_publisher_keyexpr(z_loan(pub));
+    z_owned_str_t pub_keyexpr_str = z_keyexpr_to_string(z_loan(pub_keyexpr));
     assert(strcmp(z_loan(pub_keyexpr_str), "foo/bar") == 0);  // Check that publisher keeps the correct keyexpr
     z_drop(z_move(pub_keyexpr_str));
     z_drop(z_move(pub));
@@ -58,8 +58,8 @@ void test_subscriber() {
     strncpy(keyexpr, "foo/bar", 256);
     z_owned_subscriber_t sub = z_declare_subscriber(z_loan(s), z_keyexpr(keyexpr), z_move(callback), NULL);
     strncpy(keyexpr, "baz/quax", 256);  // Update source string to ensure that the keyexpr is copied into the subscriber
-    z_keyexpr_t sub_keyexpr = z_subscriber_keyexpr(z_loan(sub));
-    z_owned_str_t sub_keyexpr_str = z_keyexpr_to_string(sub_keyexpr);
+    z_owned_keyexpr_t sub_keyexpr = z_subscriber_keyexpr(z_loan(sub));
+    z_owned_str_t sub_keyexpr_str = z_keyexpr_to_string(z_loan(sub_keyexpr));
     assert(strcmp(z_loan(sub_keyexpr_str), "foo/bar") == 0);  // Check that subscriber keeps the correct keyexpr
     z_drop(z_move(sub_keyexpr_str));
     z_drop(z_move(sub));


### PR DESCRIPTION
this also allowed to make correct test for https://github.com/eclipse-zenoh/zenoh-c/issues/160