### PR TITLE
cmake required version reduced to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 project(
 	zenohc
 	VERSION 0.10.0.0

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     # Settings when 'examples' is the root projet
-    cmake_minimum_required(VERSION 3.20)
+    cmake_minimum_required(VERSION 3.16)
     project(zenohc_examples LANGUAGES C)
     include(../cmake/helpers.cmake)
     set_default_build_type(Release)


### PR DESCRIPTION
Minimum required CMake version reduced to 3.16 to not require users to update CMake on Ubuntu 20.04