### PR TITLE
updated zenoh version info in Cargo.toml.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(
 	zenohc
-	VERSION 0.7.2.0
+	VERSION 0.7.2.1
 	DESCRIPTION "The C bindings for Zenoh"
 	HOMEPAGE_URL "https://github.com/eclipse-zenoh/zenoh-c"
 	LANGUAGES C

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 #
 [package]
 name = "zenoh-c"
-version = "0.7.2-rc"
+version = "0.7.2-rc.1"
 repository = "https://github.com/eclipse-zenoh/zenoh-c"
 homepage = "http://zenoh.io"
 authors = [
@@ -50,6 +50,7 @@ spin = "0.9.5"
 zenoh = { version = "0.7.2-rc", features = [ "unstable" ] }
 zenoh-protocol = { version = "0.7.2-rc" }
 zenoh-util = { version = "0.7.2-rc" }
+
 
 [build-dependencies]
 cbindgen = "0.24.3"

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -47,9 +47,10 @@ libc = "0.2.139"
 log = "0.4.17"
 rand = "0.8.5"
 spin = "0.9.5"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [ "unstable" ] }
-zenoh-protocol = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
-zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
+zenoh = { version = "0.7.2-rc", features = [ "unstable" ] }
+zenoh-protocol = { version = "0.7.2-rc" }
+zenoh-util = { version = "0.7.2-rc" }
+
 
 [build-dependencies]
 cbindgen = "0.24.3"


### PR DESCRIPTION
updates to make release 0.7.2 compilable: added references to zenoh-0.7.2 to Cargo.toml.in instead of autogenerated Cargo.toml.

This PR is not supposed to be merged, I think: the updates can be just kept in this `release-0.7.2-rc.1` branch