### PR TITLE
Enable shared-memory in shared-memory examples

### DIFF
--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -34,6 +34,11 @@ int main(int argc, char **argv) {
     if (argc > 2) value = argv[2];
 
     z_owned_config_t config = z_config_default();
+    // Enable shared memory
+    if (zc_config_insert_json(z_loan(config), "transport/shared_memory/enabled", "true") < 0) {
+        printf("Error enabling Shared Memory");
+        exit(-1);
+    }
     if (argc > 3) {
         if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
             printf(

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -45,6 +45,13 @@ int main(int argc, char **argv) {
             exit(-1);
         }
     }
+    // A probing procedure for shared memory is performed upon session opening. To enable `z_pub_shm` to operate
+    // over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
+    // subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
+    if (zc_config_insert_json(z_loan(config), "transport/shared_memory/enabled", "true") < 0) {
+        printf("Error enabling Shared Memory");
+        exit(-1);
+    }
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));


### PR DESCRIPTION
Shared memory needs to be explicitly activated in the configuration in order to be operational.
This is not the case in the examples provided in zenoh-c.
Therefore, this PR enables shared-memory in shared-memory examples.