### PR TITLE
allow to pass quoted parameters to rust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,9 +169,13 @@ set_genexpr_condition(libs DEBUG $<CONFIG:Debug> "${libsd}" "${libsr}")
 #
 # Build rust sources
 #
-set_genexpr_condition(cargo_release_flag DEBUG $<CONFIG:Debug> "" "--release")
-set(cargo_flags ${ZENOHC_CARGO_FLAGS} ${cargo_release_flag})
-set(cargo_flags ${cargo_flags} --manifest-path=${cargo_toml_dir}/Cargo.toml)
+
+# Combine "--release" and "--manifest-path" options under DEBUG condition to avoid passing empty parameter to cargo command line in `add_custom_command`, causing build failure
+# This empty item ($<IF:$<CONFIG:Debug>;,--release>) can't be filtered out by `list(FILTER ...)` because it becomes empty only on 
+# build stage when generator expressions are evaluated.
+set_genexpr_condition(cargo_flags DEBUG $<CONFIG:Debug> 
+	"--manifest-path=${cargo_toml_dir}/Cargo.toml"
+	"--release;--manifest-path=${cargo_toml_dir}/Cargo.toml")
 
 if(ZENOHC_BUILD_WITH_LOGGER_AUTOINIT)
 	set(cargo_flags ${cargo_flags} --features=logger-autoinit)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,8 +174,9 @@ set_genexpr_condition(libs DEBUG $<CONFIG:Debug> "${libsd}" "${libsr}")
 # This empty item ($<IF:$<CONFIG:Debug>;,--release>) can't be filtered out by `list(FILTER ...)` because it becomes empty only on 
 # build stage when generator expressions are evaluated.
 set_genexpr_condition(cargo_flags DEBUG $<CONFIG:Debug> 
-	"--manifest-path=${cargo_toml_dir}/Cargo.toml;${ZENOHC_CARGO_FLAGS}"
-	"--release;--manifest-path=${cargo_toml_dir}/Cargo.toml;${ZENOHC_CARGO_FLAGS}")
+	"--manifest-path=${cargo_toml_dir_debug}/Cargo.toml"
+	"--release;--manifest-path=${cargo_toml_dir_release}/Cargo.toml")
+set(cargo_flags ${cargo_flags} ${ZENOHC_CARGO_FLAGS})
 
 if(ZENOHC_BUILD_WITH_LOGGER_AUTOINIT)
 	set(cargo_flags ${cargo_flags} --features=logger-autoinit)
@@ -197,6 +198,7 @@ add_custom_command(
 	COMMAND ${CMAKE_COMMAND} -E echo \"cargo +${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}\"
 	COMMAND cargo +${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}
 	VERBATIM
+	COMMAND_EXPAND_LISTS
 )
 add_custom_target(cargo ALL DEPENDS "${libs}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,8 +174,8 @@ set_genexpr_condition(libs DEBUG $<CONFIG:Debug> "${libsd}" "${libsr}")
 # This empty item ($<IF:$<CONFIG:Debug>;,--release>) can't be filtered out by `list(FILTER ...)` because it becomes empty only on 
 # build stage when generator expressions are evaluated.
 set_genexpr_condition(cargo_flags DEBUG $<CONFIG:Debug> 
-	"--manifest-path=${cargo_toml_dir}/Cargo.toml"
-	"--release;--manifest-path=${cargo_toml_dir}/Cargo.toml")
+	"--manifest-path=${cargo_toml_dir}/Cargo.toml;${ZENOHC_CARGO_FLAGS}"
+	"--release;--manifest-path=${cargo_toml_dir}/Cargo.toml;${ZENOHC_CARGO_FLAGS}")
 
 if(ZENOHC_BUILD_WITH_LOGGER_AUTOINIT)
 	set(cargo_flags ${cargo_flags} --features=logger-autoinit)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ add_custom_command(
 	COMMAND ${CMAKE_COMMAND} -E echo \"RUSTFLAGS = $$RUSTFLAGS\"
 	COMMAND ${CMAKE_COMMAND} -E echo \"cargo +${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}\"
 	COMMAND cargo +${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}
+	VERBATIM
 )
 add_custom_target(cargo ALL DEPENDS "${libs}")
 


### PR DESCRIPTION
This command line allows to perform cross-compilation on arm for x86_64:
```
cmake -S zenoh-c -B build -DZENOHC_CUSTOM_TARGET=x86_64-unknown-linux-gnu -DZENOHC_CARGO_FLAGS="--config target.x86_64-unknown-linux-gnu.linker=\"/usr/bin/x86_64-linux-gnu-gcc\""
```

It fails without the `VERBATIM` option in CMake's `add_custom_command`. Without this option the quotes around path to linker are incorrectly removed.

After adding `VERBATIM` compilation started to fail on multiconfig-builders (MSVC, Ninja Multi-Config), so this also was fixed.