### PR TITLE
Add ze_querying_subscriber_get method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -2779,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "zenoh-collections",
 ]
@@ -2809,7 +2809,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "log",
  "serde",
@@ -2822,12 +2822,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "flume",
  "json5",
@@ -2846,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -2856,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "aes",
  "hmac",
@@ -2869,7 +2869,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-std",
  "bincode",
@@ -2889,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2922,7 +2922,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2938,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2964,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2980,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3005,7 +3005,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3024,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "libloading",
  "log",
@@ -3088,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "const_format",
  "hex",
@@ -3104,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "anyhow",
 ]
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "bincode",
  "log",
@@ -3125,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-std",
  "event-listener",
@@ -3140,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -3172,7 +3172,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d2399cad7afda578df4d1f70b9026cd0e5354274"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#8ebf8b8d11abe8bba594258a7e14920f5c03c41f"
 dependencies = [
  "async-std",
  "async-trait",

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -316,6 +316,7 @@ Functions
 
 .. autocfunction:: zenoh_commons.h::ze_declare_querying_subscriber
 .. autocfunction:: zenoh_commons.h::ze_undeclare_querying_subscriber
+.. autocfunction:: zenoh_commons.h::ze_querying_subscriber_get
 .. autocfunction:: zenoh_commons.h::ze_querying_subscriber_check
 .. autocfunction:: zenoh_commons.h::ze_querying_subscriber_null
 .. autocfunction:: zenoh_commons.h::ze_querying_subscriber_options_default

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -2094,6 +2094,10 @@ ZENOHC_API struct ze_publication_cache_options_t ze_publication_cache_options_de
  * Returns ``true`` if `sub` is valid.
  */
 ZENOHC_API bool ze_querying_subscriber_check(const struct ze_owned_querying_subscriber_t *sub);
+/**
+ * Make a :c:type:`ze_owned_querying_subscriber_t` to perform an additional query on a specified selector.
+ * The queried samples will be merged with the received publications and made available in the subscriber callback.
+ */
 ZENOHC_API
 int8_t ze_querying_subscriber_get(struct ze_querying_subscriber_t sub,
                                   struct z_keyexpr_t selector,

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -795,6 +795,9 @@ typedef struct ze_querying_subscriber_options_t {
   enum zcu_reply_keyexpr_t query_accept_replies;
   uint64_t query_timeout_ms;
 } ze_querying_subscriber_options_t;
+typedef struct ze_querying_subscriber_t {
+  const struct ze_owned_querying_subscriber_t *_0;
+} ze_querying_subscriber_t;
 ZENOHC_API extern const unsigned int Z_ROUTER;
 ZENOHC_API extern const unsigned int Z_PEER;
 ZENOHC_API extern const unsigned int Z_CLIENT;
@@ -2091,6 +2094,15 @@ ZENOHC_API struct ze_publication_cache_options_t ze_publication_cache_options_de
  * Returns ``true`` if `sub` is valid.
  */
 ZENOHC_API bool ze_querying_subscriber_check(const struct ze_owned_querying_subscriber_t *sub);
+ZENOHC_API
+int8_t ze_querying_subscriber_get(struct ze_querying_subscriber_t sub,
+                                  struct z_keyexpr_t selector,
+                                  const struct z_get_options_t *options);
+/**
+ * Returns a :c:type:`ze_querying_subscriber_loan` loaned from `p`.
+ */
+ZENOHC_API
+struct ze_querying_subscriber_t ze_querying_subscriber_loan(const struct ze_owned_querying_subscriber_t *p);
 /**
  * Constructs a null safe-to-drop value of 'ze_owned_querying_subscriber_t' type
  */

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -124,6 +124,7 @@ template<> struct zenoh_loan_type<z_owned_pull_subscriber_t>{ typedef z_pull_sub
 template<> struct zenoh_loan_type<z_owned_encoding_t>{ typedef z_encoding_t type; };
 template<> struct zenoh_loan_type<z_owned_hello_t>{ typedef z_hello_t type; };
 template<> struct zenoh_loan_type<z_owned_str_t>{ typedef const char* type; };
+template<> struct zenoh_loan_type<ze_owned_querying_subscriber_t>{ typedef ze_querying_subscriber_t type; };
 
 template<> inline z_session_t z_loan(const z_owned_session_t& x) { return z_session_loan(&x); }
 template<> inline z_keyexpr_t z_loan(const z_owned_keyexpr_t& x) { return z_keyexpr_loan(&x); }

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -4,15 +4,16 @@
 
 // clang-format off
 #define z_loan(x) \
-    _Generic((x), z_owned_session_t : z_session_loan,                 \
-                  z_owned_keyexpr_t : z_keyexpr_loan,                 \
-                  z_owned_config_t : z_config_loan,                   \
-                  z_owned_publisher_t : z_publisher_loan,             \
-                  z_owned_subscriber_t : z_subscriber_loan,           \
-                  z_owned_pull_subscriber_t : z_pull_subscriber_loan, \
-                  z_owned_encoding_t : z_encoding_loan,               \
-                  z_owned_hello_t : z_hello_loan,                     \
-                  z_owned_str_t : z_str_loan                          \
+    _Generic((x), z_owned_session_t : z_session_loan,                          \
+                  z_owned_keyexpr_t : z_keyexpr_loan,                          \
+                  z_owned_config_t : z_config_loan,                            \
+                  z_owned_publisher_t : z_publisher_loan,                      \
+                  z_owned_subscriber_t : z_subscriber_loan,                    \
+                  z_owned_pull_subscriber_t : z_pull_subscriber_loan,          \
+                  z_owned_encoding_t : z_encoding_loan,                        \
+                  z_owned_hello_t : z_hello_loan,                              \
+                  z_owned_str_t : z_str_loan,                                  \
+                  ze_owned_querying_subscriber_t : ze_querying_subscriber_loan \
             )(&x)
 
 #define z_drop(x) \
@@ -133,6 +134,7 @@ template<> inline z_pull_subscriber_t z_loan(const z_owned_pull_subscriber_t& x)
 template<> inline z_encoding_t z_loan(const z_owned_encoding_t& x) { return z_encoding_loan(&x); }
 template<> inline z_hello_t z_loan(const z_owned_hello_t& x) { return z_hello_loan(&x); }
 template<> inline const char* z_loan(const z_owned_str_t& x) { return z_str_loan(&x); }
+template<> inline ze_querying_subscriber_t z_loan(const ze_owned_querying_subscriber_t& x) { return ze_querying_subscriber_loan(&x); }
 
 template<class T> struct zenoh_drop_type { typedef T type; };
 template<class T> inline typename zenoh_drop_type<T>::type z_drop(T*);

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -228,6 +228,8 @@ pub unsafe extern "C" fn ze_declare_querying_subscriber(
     }
 }
 
+/// Make a :c:type:`ze_owned_querying_subscriber_t` to perform an additional query on a specified selector.
+/// The queried samples will be merged with the received publications and made available in the subscriber callback.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn ze_querying_subscriber_get(


### PR DESCRIPTION
Add ze_querying_subscriber_get method as wrapper for FetchingSubscriber fetch with the default behavior: "get by specified selector".

Currently contains workaround with saved session, which must be removed as soon as new fetch method will be implemented in zenoh.

Testing:
- modify z_query_sub example to call the queryable:
add `ze_querying_subscriber_get(z_loan(sub), z_keyexpr("demo/example/zenoh-c-queryable"), NULL);` to the input check loop.
- run z_pub_cache example
- run z_queryable example
- run z_query_sub and press some key periodically
- check if z_query_sub receives the data from z_queryable