### PR TITLE
Attachment support implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "anstream"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,7 +131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
@@ -143,7 +191,7 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -157,11 +205,11 @@ dependencies = [
  "autocfg",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-lite",
  "rustix 0.37.25",
  "signal-hook",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -344,7 +392,7 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b922faaf31122819ec80c4047cc684c6979a087366c069611e33649bf98e18d"
 dependencies = [
- "clap",
+ "clap 3.2.25",
  "heck",
  "indexmap 1.9.3",
  "log",
@@ -390,11 +438,45 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.6.0",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -405,6 +487,18 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
@@ -532,7 +626,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -568,7 +662,7 @@ checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -586,6 +680,17 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -885,7 +990,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -967,7 +1072,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.2",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -987,7 +1092,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
  "rustix 0.38.21",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1065,7 +1170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1146,7 +1251,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1275,9 +1380,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "3.9.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -1507,7 +1612,7 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1556,10 +1661,10 @@ checksum = "e13f81c9a9d574310b8351f8666f5a93ac3b0069c45c28ad52c10291389a7cf9"
 dependencies = [
  "bytes",
  "rand",
- "ring",
+ "ring 0.16.20",
  "rustc-hash",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "slab",
  "thiserror",
  "tinyvec",
@@ -1576,7 +1681,7 @@ dependencies = [
  "libc",
  "socket2 0.5.4",
  "tracing",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1686,9 +1791,23 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1755,7 +1874,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1768,7 +1887,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.12",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1778,8 +1897,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki",
+ "ring 0.16.20",
+ "rustls-webpki 0.101.5",
  "sct",
 ]
 
@@ -1790,7 +1909,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.3",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.0.0",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -1805,13 +1937,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7673e0aa20ee4937c6aacfc12bb8341cfbf054cdd21df6bec5fd0629fe9339b"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2635c8bc2b88d367767c5de8ea1d8db9af3f6219eba28442242d9ab81d1b89"
+dependencies = [
+ "ring 0.17.7",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1826,7 +1985,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1865,8 +2024,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -2078,7 +2237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2168,7 +2327,7 @@ dependencies = [
  "fastrand 2.0.1",
  "redox_syscall 0.4.1",
  "rustix 0.38.21",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2244,7 +2403,7 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.4",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2407,6 +2566,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "unzip-n"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2598,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -2575,9 +2746,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+checksum = "0de2cfda980f21be5a7ed2eadb3e6fe074d56022bea2cdeb1a62eb220fc04188"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "win-sys"
@@ -2638,7 +2812,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2647,13 +2830,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.48.5",
  "windows_aarch64_msvc 0.48.5",
  "windows_i686_gnu 0.48.5",
  "windows_i686_msvc 0.48.5",
  "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.48.5",
  "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -2661,6 +2859,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2675,6 +2879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2685,6 +2895,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2699,6 +2915,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2711,10 +2933,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2729,9 +2963,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -2739,7 +2979,7 @@ dependencies = [
  "base64",
  "const_format",
  "env_logger",
- "event-listener",
+ "event-listener 4.0.0",
  "flume",
  "form_urlencoded",
  "futures",
@@ -2780,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "zenoh-collections",
 ]
@@ -2810,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "log",
  "serde",
@@ -2823,12 +3063,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "flume",
  "json5",
@@ -2847,7 +3087,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -2857,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "aes",
  "hmac",
@@ -2870,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-std",
  "bincode",
@@ -2890,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -2904,7 +3144,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2923,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2940,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2950,9 +3190,9 @@ dependencies = [
  "log",
  "quinn",
  "rustls",
- "rustls-native-certs",
- "rustls-pemfile",
- "rustls-webpki",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.0.0",
+ "rustls-webpki 0.102.0",
  "secrecy",
  "zenoh-config",
  "zenoh-core",
@@ -2966,7 +3206,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2982,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2991,8 +3231,8 @@ dependencies = [
  "futures",
  "log",
  "rustls",
- "rustls-pemfile",
- "rustls-webpki",
+ "rustls-pemfile 2.0.0",
+ "rustls-webpki 0.102.0",
  "secrecy",
  "webpki-roots",
  "zenoh-config",
@@ -3007,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3026,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3044,7 +3284,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3064,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3077,7 +3317,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "libloading",
  "log",
@@ -3090,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "const_format",
  "hex",
@@ -3106,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "anyhow",
 ]
@@ -3114,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "bincode",
  "log",
@@ -3127,10 +3367,10 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-std",
- "event-listener",
+ "event-listener 4.0.0",
  "flume",
  "futures",
  "tokio",
@@ -3142,7 +3382,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -3174,11 +3414,11 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#49011f1fd55125609ee2115ed53e0793c406f8dc"
 dependencies = [
  "async-std",
  "async-trait",
- "clap",
+ "clap 4.4.11",
  "const_format",
  "flume",
  "futures",

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,7 +24,25 @@ Bytes
 
 .. autocstruct:: zenoh_commons.h::z_bytes_t
 
+.. autocfunction:: zenoh_commons.h::z_bytes_new
 .. autocfunction:: zenoh_commons.h::z_bytes_check
+.. autocfunction:: zenoh_commons.h::z_bytes_null
+
+Bytes map
+---------
+
+.. autocstruct:: zenoh_commons.h::z_owned_bytes_map_t
+
+.. autocfunction:: zenoh_commons.h::z_bytes_map_new
+.. autocfunction:: zenoh_commons.h::z_bytes_map_check
+.. autocfunction:: zenoh_commons.h::z_bytes_map_null
+.. autocfunction:: zenoh_commons.h::z_bytes_map_drop
+.. autocfunction:: zenoh_commons.h::z_bytes_map_get
+.. autocfunction:: zenoh_commons.h::z_bytes_map_insert_by_alias
+.. autocfunction:: zenoh_commons.h::z_bytes_map_insert_by_copy
+.. autocfunction:: zenoh_commons.h::z_bytes_map_iter
+.. autocfunction:: zenoh_commons.h::z_bytes_map_from_attachment
+.. autocfunction:: zenoh_commons.h::z_bytes_map_from_attachment_aliasing
 
 .. Scouting
 .. ========
@@ -131,6 +149,16 @@ Sample
 ======
 
 .. autocstruct:: zenoh_commons.h::z_sample_t
+
+Attachment
+==========
+
+.. autocstruct:: zenoh_commons.h::z_attachment_t
+
+.. autocfunction:: zenoh_commons.h::z_attachment_null
+.. autocfunction:: zenoh_commons.h::z_attachment_get
+.. autocfunction:: zenoh_commons.h::z_attachment_check
+.. autocfunction:: zenoh_commons.h::z_attachment_iterate
 
 Publication
 ===========
@@ -250,6 +278,7 @@ Types
 .. autocfunction:: zenoh_commons.h::z_query_keyexpr
 .. autocfunction:: zenoh_commons.h::z_query_parameters
 .. autocfunction:: zenoh_commons.h::z_query_value
+.. autocfunction:: zenoh_commons.h::z_query_attachment
 
 Functions
 ---------

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#include <stdio.h>
+#include <string.h>
+
+#include "zenoh.h"
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+#define sleep(x) Sleep(x * 1000)
+#else
+#include <unistd.h>
+#endif
+
+int main(int argc, char **argv) {
+    char *keyexpr = "demo/example/zenoh-c-pub";
+    char *value = "Pub from C!";
+
+    if (argc > 1) keyexpr = argv[1];
+    if (argc > 2) value = argv[2];
+
+    z_owned_config_t config = z_config_default();
+    if (argc > 3) {
+        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
+            exit(-1);
+        }
+    }
+
+    printf("Opening session...\n");
+    z_owned_session_t s = z_open(z_move(config));
+    if (!z_check(s)) {
+        printf("Unable to open session!\n");
+        exit(-1);
+    }
+
+    printf("Declaring Publisher on '%s'...\n", keyexpr);
+    z_owned_publisher_t pub = z_declare_publisher(z_loan(s), z_keyexpr(keyexpr), NULL);
+    if (!z_check(pub)) {
+        printf("Unable to declare Publisher for key expression!\n");
+        exit(-1);
+    }
+
+    z_publisher_put_options_t options = z_publisher_put_options_default();
+    options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);
+
+    // allocate attachment map
+    z_owned_bytes_map_t map = z_bytes_map_new();
+
+    // set it as an attachment
+    options.attachment = z_bytes_map_as_attachment(&map);
+
+    // add some value
+    z_bytes_map_insert_by_alias(&map, z_bytes_new("source"), z_bytes_new("C"));
+
+    char buf[256];
+    char buf_ind[16];
+    for (int idx = 0; 1; ++idx) {
+        sleep(1);
+
+        // add some other attachment value
+        sprintf(buf_ind, "%d", idx);
+        z_bytes_map_insert_by_alias(&map, z_bytes_new("index"), z_bytes_new(buf_ind));
+
+        sprintf(buf, "[%4d] %s", idx, value);
+        printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
+        z_publisher_put(z_loan(pub), (const uint8_t *)buf, strlen(buf), &options);
+    }
+
+    z_undeclare_publisher(z_move(pub));
+
+    z_close(z_move(s));
+    z_drop(z_move(map));
+
+    return 0;
+}

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -23,6 +23,9 @@ int main(int argc, char **argv) {
     if (argc > 1) keyexpr = argv[1];
     if (argc > 2) value = argv[2];
 
+    z_owned_bytes_map_t attachment = z_bytes_map_new();
+    z_bytes_map_insert_by_alias(&attachment, z_bytes_new("hello"), z_bytes_new("there"));
+
     z_owned_config_t config = z_config_default();
     if (argc > 3) {
         if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
@@ -44,11 +47,13 @@ int main(int argc, char **argv) {
     printf("Putting Data ('%s': '%s')...\n", keyexpr, value);
     z_put_options_t options = z_put_options_default();
     options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);
+    options.attachment = z_bytes_map_as_attachment(&attachment);
     int res = z_put(z_loan(s), z_keyexpr(keyexpr), (const uint8_t *)value, strlen(value), &options);
     if (res < 0) {
         printf("Put failed...\n");
     }
 
     z_close(z_move(s));
+    z_drop(z_move(attachment));
     return 0;
 }

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -1,0 +1,105 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#include <stdint.h>
+#include <stdio.h>
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+#define sleep(x) Sleep(x * 1000)
+#else
+#include <unistd.h>
+#endif
+#include "zenoh.h"
+
+const char *kind_to_str(z_sample_kind_t kind);
+
+int8_t attachment_reader(z_bytes_t key, z_bytes_t val, void *ctx) {
+    printf("   attachment: %.*s: '%.*s'\n", (int)key.len, key.start, (int)val.len, val.start);
+    return 0;
+}
+
+void data_handler(const z_sample_t *sample, void *arg) {
+    z_owned_str_t keystr = z_keyexpr_to_string(sample->keyexpr);
+    printf(">> [Subscriber] Received %s ('%s': '%.*s')\n", kind_to_str(sample->kind), z_loan(keystr),
+           (int)sample->payload.len, sample->payload.start);
+
+    // checks if attachment exists
+    if (z_check(sample->attachment)) {
+        // reads full attachment
+        z_attachment_iterate(sample->attachment, attachment_reader, NULL);
+
+        // reads particular attachment item
+        z_bytes_t index = z_attachment_get(sample->attachment, z_bytes_new("index"));
+        if (z_check(index)) {
+            printf("   message number: %.*s\n", (int)index.len, index.start);
+        }
+    }
+    z_drop(z_move(keystr));
+}
+
+int main(int argc, char **argv) {
+    char *expr = "demo/example/**";
+    if (argc > 1) {
+        expr = argv[1];
+    }
+
+    z_owned_config_t config = z_config_default();
+    if (argc > 2) {
+        if (zc_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2]) < 0) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
+            exit(-1);
+        }
+    }
+
+    printf("Opening session...\n");
+    z_owned_session_t s = z_open(z_move(config));
+    if (!z_check(s)) {
+        printf("Unable to open session!\n");
+        exit(-1);
+    }
+
+    z_owned_closure_sample_t callback = z_closure(data_handler);
+    printf("Declaring Subscriber on '%s'...\n", expr);
+    z_owned_subscriber_t sub = z_declare_subscriber(z_loan(s), z_keyexpr(expr), z_move(callback), NULL);
+    if (!z_check(sub)) {
+        printf("Unable to declare subscriber.\n");
+        exit(-1);
+    }
+
+    printf("Enter 'q' to quit...\n");
+    char c = 0;
+    while (c != 'q') {
+        c = getchar();
+        if (c == -1) {
+            sleep(1);
+        }
+    }
+
+    z_undeclare_subscriber(z_move(sub));
+    z_close(z_move(s));
+    return 0;
+}
+
+const char *kind_to_str(z_sample_kind_t kind) {
+    switch (kind) {
+        case Z_SAMPLE_KIND_PUT:
+            return "PUT";
+        case Z_SAMPLE_KIND_DELETE:
+            return "DELETE";
+        default:
+            return "UNKNOWN";
+    }
+}

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -149,12 +149,55 @@ typedef enum zcu_reply_keyexpr_t {
   ZCU_REPLY_KEYEXPR_MATCHING_QUERY = 1,
 } zcu_reply_keyexpr_t;
 /**
- * An array of bytes.
+ * A contiguous view of bytes owned by some other entity.
+ *
+ * `start` being `null` is considered a gravestone value,
+ * and empty slices are represented using a possibly dangling pointer for `start`.
  */
 typedef struct z_bytes_t {
   size_t len;
   const uint8_t *start;
 } z_bytes_t;
+/**
+ * The body of a loop over an attachment's key-value pairs.
+ *
+ * `key` and `value` are loaned to the body for the duration of a single call.
+ * `context` is passed transparently through the iteration driver.
+ *
+ * Returning `0` is treated as `continue`.
+ * Returning any other value is treated as `break`.
+ */
+typedef int8_t (*z_attachment_iter_body_t)(struct z_bytes_t key,
+                                           struct z_bytes_t value,
+                                           void *context);
+/**
+ * The driver of a loop over an attachment's key-value pairs.
+ *
+ * This function is expected to call `loop_body` once for each key-value pair
+ * within `iterator`, passing `context`, and returning any non-zero value immediately (breaking iteration).
+ */
+typedef int8_t (*z_attachment_iter_driver_t)(const void *iterator,
+                                             z_attachment_iter_body_t loop_body,
+                                             void *context);
+/**
+ * A iteration based map of byte slice to byte slice.
+ *
+ * `iteration_driver == NULL` marks the gravestone value, as this type is often optional.
+ * Users are encouraged to use `z_attachment_null` and `z_attachment_check` to interact.
+ */
+typedef struct z_attachment_t {
+  const void *data;
+  z_attachment_iter_driver_t iteration_driver;
+} z_attachment_t;
+/**
+ * A map of maybe-owned vector of bytes to owned vector of bytes.
+ *
+ * In Zenoh C, this map is backed by Rust's standard HashMap, with a DoS-resistant hasher
+ */
+typedef struct z_owned_bytes_map_t {
+  uint64_t _0[2];
+  size_t _1[4];
+} z_owned_bytes_map_t;
 /**
  * Represents a Zenoh ID.
  *
@@ -248,17 +291,17 @@ typedef struct z_owned_closure_query_t {
  */
 #if defined(TARGET_ARCH_X86_64)
 typedef struct ALIGN(8) z_owned_reply_t {
-  uint64_t _0[23];
+  uint64_t _0[28];
 } z_owned_reply_t;
 #endif
 #if defined(TARGET_ARCH_AARCH64)
 typedef struct ALIGN(16) z_owned_reply_t {
-  uint64_t _0[24];
+  uint64_t _0[30];
 } z_owned_reply_t;
 #endif
 #if defined(TARGET_ARCH_ARM)
 typedef struct ALIGN(8) z_owned_reply_t {
-  uint64_t _0[17];
+  uint64_t _0[19];
 } z_owned_reply_t;
 #endif
 /**
@@ -332,6 +375,7 @@ typedef struct z_timestamp_t {
  *   z_encoding_t encoding: The encoding of the value of this data sample.
  *   z_sample_kind_t kind: The kind of this data sample (PUT or DELETE).
  *   z_timestamp_t timestamp: The timestamp of this data sample.
+ *   z_attachment_t attachment: The attachment of this data sample.
  */
 typedef struct z_sample_t {
   struct z_keyexpr_t keyexpr;
@@ -340,6 +384,7 @@ typedef struct z_sample_t {
   const void *_zc_buf;
   enum z_sample_kind_t kind;
   struct z_timestamp_t timestamp;
+  struct z_attachment_t attachment;
 } z_sample_t;
 /**
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
@@ -550,12 +595,14 @@ typedef struct z_value_t {
  *     z_query_target_t target: The Queryables that should be target of the query.
  *     z_query_consolidation_t consolidation: The replies consolidation strategy to apply on replies to the query.
  *     z_value_t value: An optional value to attach to the query.
+ *     z_attachment_t attachment: The attachment to attach to the query.
  *     uint64_t timeout: The timeout for the query in milliseconds. 0 means default query timeout from zenoh configuration.
  */
 typedef struct z_get_options_t {
   enum z_query_target_t target;
   struct z_query_consolidation_t consolidation;
   struct z_value_t value;
+  struct z_attachment_t attachment;
   uint64_t timeout_ms;
 } z_get_options_t;
 /**
@@ -610,9 +657,11 @@ typedef struct z_publisher_delete_options_t {
  *
  * Members:
  *     z_encoding_t encoding: The encoding of the payload.
+ *     z_attachment_t attachment: The attachment to attach to the publication.
  */
 typedef struct z_publisher_put_options_t {
   struct z_encoding_t encoding;
+  struct z_attachment_t attachment;
 } z_publisher_put_options_t;
 typedef struct z_pull_subscriber_t {
   const struct z_owned_pull_subscriber_t *_0;
@@ -624,11 +673,13 @@ typedef struct z_pull_subscriber_t {
  *     z_encoding_t encoding: The encoding of the payload.
  *     z_congestion_control_t congestion_control: The congestion control to apply when routing this message.
  *     z_priority_t priority: The priority of this message.
+ *     z_attachment_t attachment: The attachment to this message.
  */
 typedef struct z_put_options_t {
   struct z_encoding_t encoding;
   enum z_congestion_control_t congestion_control;
   enum z_priority_t priority;
+  struct z_attachment_t attachment;
 } z_put_options_t;
 /**
  * Owned variant of a Query received by a Queryable.
@@ -649,9 +700,11 @@ typedef struct z_owned_query_t {
  *
  * Members:
  *   z_encoding_t encoding: The encoding of the payload.
+ *   z_attachment_t attachment: The attachment to this reply.
  */
 typedef struct z_query_reply_options_t {
   struct z_encoding_t encoding;
+  struct z_attachment_t attachment;
 } z_query_reply_options_t;
 /**
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:
@@ -826,9 +879,122 @@ ZENOHC_API extern const char *Z_CONFIG_SCOUTING_TIMEOUT_KEY;
 ZENOHC_API extern const char *Z_CONFIG_SCOUTING_DELAY_KEY;
 ZENOHC_API extern const char *Z_CONFIG_ADD_TIMESTAMP_KEY;
 /**
+ * Returns the gravestone value for `z_attachment_t`.
+ */
+ZENOHC_API bool z_attachment_check(const struct z_attachment_t *this_);
+/**
+ * Returns the value associated with the key.
+ */
+ZENOHC_API struct z_bytes_t z_attachment_get(struct z_attachment_t this_, struct z_bytes_t key);
+/**
+ * Iterate over `this`'s key-value pairs, breaking if `body` returns a non-zero
+ * value for a key-value pair, and returning the latest return value.
+ *
+ * `context` is passed to `body` to allow stateful closures.
+ *
+ * This function takes no ownership whatsoever.
+ */
+ZENOHC_API
+int8_t z_attachment_iterate(struct z_attachment_t this_,
+                            z_attachment_iter_body_t body,
+                            void *context);
+/**
+ * Returns the gravestone value for `z_attachment_t`.
+ */
+ZENOHC_API struct z_attachment_t z_attachment_null(void);
+/**
  * Returns ``true`` if `b` is initialized.
  */
 ZENOHC_API bool z_bytes_check(const struct z_bytes_t *b);
+/**
+ * Aliases `this` into a generic `z_attachment_t`, allowing it to be passed to corresponding APIs.
+ */
+ZENOHC_API struct z_attachment_t z_bytes_map_as_attachment(const struct z_owned_bytes_map_t *this_);
+/**
+ * Returns `true` if the map is not in its gravestone state
+ */
+ZENOHC_API bool z_bytes_map_check(const struct z_owned_bytes_map_t *this_);
+/**
+ * Destroys the map, resetting `this` to its gravestone value.
+ *
+ * This function is double-free safe, passing a pointer to the gravestone value will have no effect.
+ */
+ZENOHC_API void z_bytes_map_drop(struct z_owned_bytes_map_t *this_);
+/**
+ * Constructs a map from the provided attachment, copying keys and values.
+ *
+ * If `this` is at gravestone value, the returned value will also be at gravestone value.
+ */
+ZENOHC_API struct z_owned_bytes_map_t z_bytes_map_from_attachment(struct z_attachment_t this_);
+/**
+ * Constructs a map from the provided attachment, aliasing the attachment's keys and values.
+ *
+ * If `this` is at gravestone value, the returned value will also be at gravestone value.
+ */
+ZENOHC_API
+struct z_owned_bytes_map_t z_bytes_map_from_attachment_aliasing(struct z_attachment_t this_);
+/**
+ * Returns the value associated with `key`, returning a gravestone value if:
+ * - `this` or `key` is in gravestone state.
+ * - `this` has no value associated to `key`
+ */
+ZENOHC_API
+struct z_bytes_t z_bytes_map_get(const struct z_owned_bytes_map_t *this_,
+                                 struct z_bytes_t key);
+/**
+ * Associates `value` to `key` in the map, aliasing them.
+ *
+ * Note that once `key` is aliased, reinserting at the same key may alias the previous instance, or the new instance of `key`.
+ *
+ * Calling this with `NULL` or the gravestone value is undefined behaviour.
+ */
+ZENOHC_API
+void z_bytes_map_insert_by_alias(const struct z_owned_bytes_map_t *this_,
+                                 struct z_bytes_t key,
+                                 struct z_bytes_t value);
+/**
+ * Associates `value` to `key` in the map, copying them to obtain ownership: `key` and `value` are not aliased past the function's return.
+ *
+ * Calling this with `NULL` or the gravestone value is undefined behaviour.
+ */
+ZENOHC_API
+void z_bytes_map_insert_by_copy(const struct z_owned_bytes_map_t *this_,
+                                struct z_bytes_t key,
+                                struct z_bytes_t value);
+/**
+ * Iterates over the key-value pairs in the map.
+ *
+ * `body` will be called once per pair, with `ctx` as its last argument.
+ * If `body` returns a non-zero value, the iteration will stop immediately and the value will be returned.
+ * Otherwise, this will return 0 once all pairs have been visited.
+ * `body` is not given ownership of the key nor value, which alias the pairs in the map.
+ * It is safe to keep these aliases until existing keys are modified/removed, or the map is destroyed.
+ * Note that this map is unordered.
+ *
+ * Calling this with `NULL` or the gravestone value is undefined behaviour.
+ */
+ZENOHC_API
+int8_t z_bytes_map_iter(const struct z_owned_bytes_map_t *this_,
+                        z_attachment_iter_body_t body,
+                        void *ctx);
+/**
+ * Constructs a new map.
+ */
+ZENOHC_API struct z_owned_bytes_map_t z_bytes_map_new(void);
+/**
+ * Constructs the gravestone value for `z_owned_bytes_map_t`
+ */
+ZENOHC_API struct z_owned_bytes_map_t z_bytes_map_null(void);
+/**
+ * Returns a view of `str` using `strlen`.
+ *
+ * `str == NULL` will cause this to return `z_bytes_null()`
+ */
+ZENOHC_API struct z_bytes_t z_bytes_new(const char *str);
+/**
+ * Returns the gravestone value for `z_bytes_t`
+ */
+ZENOHC_API struct z_bytes_t z_bytes_null(void);
 /**
  * Closes a zenoh session. This drops and invalidates `session` for double-drop safety.
  *
@@ -1427,6 +1593,12 @@ int8_t z_put(struct z_session_t session,
  * Constructs the default value for :c:type:`z_put_options_t`.
  */
 ZENOHC_API struct z_put_options_t z_put_options_default(void);
+/**
+ * Returns the attachment to the query by aliasing.
+ *
+ * `z_check(return_value) == false` if there was no attachment to the query.
+ */
+ZENOHC_API struct z_attachment_t z_query_attachment(const struct z_query_t *query);
 /**
  * Returns `false` if `this` is in a gravestone state, `true` otherwise.
  *

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -38,6 +38,7 @@
                   z_owned_closure_zid_t * : z_closure_zid_drop,                       \
                   z_owned_reply_channel_closure_t * : z_reply_channel_closure_drop,   \
                   z_owned_reply_channel_t * : z_reply_channel_drop,                   \
+                  z_owned_bytes_map_t * : z_bytes_map_drop,                           \
                   zc_owned_payload_t * : zc_payload_drop,                             \
                   zc_owned_shmbuf_t * : zc_shmbuf_drop,                               \
                   zc_owned_shm_manager_t * : zc_shm_manager_drop,                     \
@@ -67,6 +68,8 @@
                   z_owned_closure_zid_t * : z_closure_zid_null,                     \
                   z_owned_reply_channel_closure_t * : z_reply_channel_closure_null, \
                   z_owned_reply_channel_t * : z_reply_channel_null,                 \
+                  z_owned_bytes_map_t * : z_bytes_map_null,                         \
+                  z_attachment_t * : z_attachment_null,                             \
                   zc_owned_payload_t * : zc_payload_null,                           \
                   zc_owned_shmbuf_t * : zc_shmbuf_null,                             \
                   zc_owned_shm_manager_t * : zc_shm_manager_null,                   \
@@ -90,6 +93,8 @@
                   z_owned_hello_t : z_hello_check,                              \
                   z_owned_query_t : z_query_check,                              \
                   z_owned_str_t : z_str_check,                                  \
+                  z_owned_bytes_map_t : z_bytes_map_check,                      \
+                  z_attachment_t : z_attachment_check,                          \
                   zc_owned_payload_t : zc_payload_check,                        \
                   zc_owned_shmbuf_t : zc_shmbuf_check,                          \
                   zc_owned_shm_manager_t : zc_shm_manager_check,                \
@@ -169,6 +174,7 @@ template<> struct zenoh_drop_type<z_owned_closure_hello_t> { typedef void type; 
 template<> struct zenoh_drop_type<z_owned_closure_zid_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_reply_channel_closure_t> { typedef void type; };
 template<> struct zenoh_drop_type<z_owned_reply_channel_t> { typedef void type; };
+template<> struct zenoh_drop_type<z_owned_bytes_map_t> { typedef void type; };
 template<> struct zenoh_drop_type<zc_owned_liveliness_token_t> { typedef void type; };
 template<> struct zenoh_drop_type<ze_owned_publication_cache_t> { typedef int8_t type; };
 template<> struct zenoh_drop_type<ze_owned_querying_subscriber_t> { typedef int8_t type; };
@@ -196,6 +202,7 @@ template<> inline void z_drop(z_owned_closure_hello_t* v) { z_closure_hello_drop
 template<> inline void z_drop(z_owned_closure_zid_t* v) { z_closure_zid_drop(v); }
 template<> inline void z_drop(z_owned_reply_channel_closure_t* v) { z_reply_channel_closure_drop(v); }
 template<> inline void z_drop(z_owned_reply_channel_t* v) { z_reply_channel_drop(v); }
+template<> inline void z_drop(z_owned_bytes_map_t* v) { z_bytes_map_drop(v); }
 template<> inline void z_drop(zc_owned_liveliness_token_t* v) { zc_liveliness_undeclare_token(v); }
 template<> inline int8_t z_drop(ze_owned_publication_cache_t* v) { return ze_undeclare_publication_cache(v); }
 template<> inline int8_t z_drop(ze_owned_querying_subscriber_t* v) { return ze_undeclare_querying_subscriber(v); }
@@ -223,6 +230,7 @@ inline void z_null(z_owned_closure_hello_t& v) { v = z_closure_hello_null(); }
 inline void z_null(z_owned_closure_zid_t& v) { v = z_closure_zid_null(); }
 inline void z_null(z_owned_reply_channel_closure_t& v) { v = z_reply_channel_closure_null(); }
 inline void z_null(z_owned_reply_channel_t& v) { v = z_reply_channel_null(); }
+inline void z_null(z_owned_bytes_map_t& v) { v = z_bytes_map_null(); }
 inline void z_null(zc_owned_liveliness_token_t& v) { v = zc_liveliness_token_null(); }
 inline void z_null(ze_owned_publication_cache_t& v) { v = ze_publication_cache_null(); }
 inline void z_null(ze_owned_querying_subscriber_t& v) { v = ze_querying_subscriber_null(); }
@@ -245,6 +253,8 @@ inline bool z_check(const z_owned_reply_t& v) { return z_reply_check(&v); }
 inline bool z_check(const z_owned_hello_t& v) { return z_hello_check(&v); }
 inline bool z_check(const z_owned_query_t& v) { return z_query_check(&v); }
 inline bool z_check(const z_owned_str_t& v) { return z_str_check(&v); }
+inline bool z_check(const z_owned_bytes_map_t& v) { return z_bytes_map_check(&v); }
+inline bool z_check(const z_attachment_t& v) { return z_attachment_check(&v); }
 inline bool z_check(const zc_owned_liveliness_token_t& v) { return zc_liveliness_token_check(&v); }
 inline bool z_check(const ze_owned_publication_cache_t& v) { return ze_publication_cache_check(&v); }
 inline bool z_check(const ze_owned_querying_subscriber_t& v) { return ze_querying_subscriber_check(&v); }

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,0 +1,344 @@
+use std::{borrow::Cow, cell::UnsafeCell, collections::HashMap};
+
+use libc::c_void;
+
+use crate::{impl_guarded_transmute, z_bytes_null, z_bytes_t};
+
+use zenoh::sample::{Attachment, AttachmentBuilder};
+
+/// The body of a loop over an attachment's key-value pairs.
+///
+/// `key` and `value` are loaned to the body for the duration of a single call.
+/// `context` is passed transparently through the iteration driver.
+///
+/// Returning `0` is treated as `continue`.
+/// Returning any other value is treated as `break`.
+pub type z_attachment_iter_body_t =
+    extern "C" fn(key: z_bytes_t, value: z_bytes_t, context: *mut c_void) -> i8;
+
+/// The driver of a loop over an attachment's key-value pairs.
+///
+/// This function is expected to call `loop_body` once for each key-value pair
+/// within `iterator`, passing `context`, and returning any non-zero value immediately (breaking iteration).
+pub type z_attachment_iter_driver_t = Option<
+    extern "C" fn(
+        iterator: *const c_void,
+        loop_body: z_attachment_iter_body_t,
+        context: *mut c_void,
+    ) -> i8,
+>;
+
+/// A iteration based map of byte slice to byte slice.
+///
+/// `iteration_driver == NULL` marks the gravestone value, as this type is often optional.
+/// Users are encouraged to use `z_attachment_null` and `z_attachment_check` to interact.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct z_attachment_t {
+    pub data: *const c_void,
+    pub iteration_driver: z_attachment_iter_driver_t,
+}
+
+/// Returns the gravestone value for `z_attachment_t`.
+#[no_mangle]
+pub extern "C" fn z_attachment_check(this: &z_attachment_t) -> bool {
+    this.iteration_driver.is_some()
+}
+
+/// Returns the gravestone value for `z_attachment_t`.
+#[no_mangle]
+pub extern "C" fn z_attachment_null() -> z_attachment_t {
+    z_attachment_t {
+        data: core::ptr::null_mut(),
+        iteration_driver: None,
+    }
+}
+
+/// Iterate over `this`'s key-value pairs, breaking if `body` returns a non-zero
+/// value for a key-value pair, and returning the latest return value.
+///
+/// `context` is passed to `body` to allow stateful closures.
+///
+/// This function takes no ownership whatsoever.
+#[no_mangle]
+pub extern "C" fn z_attachment_iterate(
+    this: z_attachment_t,
+    body: z_attachment_iter_body_t,
+    context: *mut c_void,
+) -> i8 {
+    (this.iteration_driver.unwrap())(this.data, body, context)
+}
+
+/// Returns the value associated with the key.
+#[no_mangle]
+pub extern "C" fn z_attachment_get(this: z_attachment_t, key: z_bytes_t) -> z_bytes_t {
+    struct attachment_get_iterator_context {
+        key: z_bytes_t,
+        value: z_bytes_t,
+    }
+
+    extern "C" fn attachment_get_iterator(
+        key: z_bytes_t,
+        value: z_bytes_t,
+        context: *mut c_void,
+    ) -> i8 {
+        unsafe {
+            let context = &mut *(context as *mut attachment_get_iterator_context);
+            if context.key.as_slice() == key.as_slice() {
+                context.value = value;
+                1
+            } else {
+                0
+            }
+        }
+    }
+
+    let mut context = attachment_get_iterator_context {
+        key,
+        value: z_bytes_null(),
+    };
+
+    if this.iteration_driver.map_or(false, |iteration_driver| {
+        (iteration_driver)(
+            this.data,
+            attachment_get_iterator,
+            &mut context as *mut _ as *mut c_void,
+        ) != 0
+    }) {
+        context.value
+    } else {
+        z_bytes_null()
+    }
+}
+
+/// A map of maybe-owned vector of bytes to owned vector of bytes.
+///
+/// In Zenoh C, this map is backed by Rust's standard HashMap, with a DoS-resistant hasher
+#[repr(C)]
+pub struct z_owned_bytes_map_t {
+    _0: [u64; 2],
+    _1: [usize; 4],
+}
+
+impl_guarded_transmute!(
+    Option<HashMap<Cow<'static, [u8]>, Cow<'static, [u8]>>>,
+    z_owned_bytes_map_t
+);
+
+impl core::ops::Deref for z_owned_bytes_map_t {
+    type Target = UnsafeCell<Option<HashMap<Cow<'static, [u8]>, Cow<'static, [u8]>>>>;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+
+/// Constructs a new map.
+#[no_mangle]
+pub extern "C" fn z_bytes_map_new() -> z_owned_bytes_map_t {
+    unsafe { core::mem::transmute(Some(HashMap::<Cow<[u8]>, Cow<[u8]>>::new())) }
+}
+
+/// Constructs the gravestone value for `z_owned_bytes_map_t`
+#[no_mangle]
+pub extern "C" fn z_bytes_map_null() -> z_owned_bytes_map_t {
+    unsafe { core::mem::transmute(None::<HashMap<Cow<[u8]>, Cow<[u8]>>>) }
+}
+
+/// Returns `true` if the map is not in its gravestone state
+#[no_mangle]
+pub extern "C" fn z_bytes_map_check(this: &z_owned_bytes_map_t) -> bool {
+    unsafe { &*this.get() }.is_some()
+}
+/// Destroys the map, resetting `this` to its gravestone value.
+///
+/// This function is double-free safe, passing a pointer to the gravestone value will have no effect.
+#[no_mangle]
+pub extern "C" fn z_bytes_map_drop(this: &mut z_owned_bytes_map_t) {
+    let this = unsafe { &mut *this.get() };
+    this.take();
+}
+
+/// Returns the value associated with `key`, returning a gravestone value if:
+/// - `this` or `key` is in gravestone state.
+/// - `this` has no value associated to `key`
+#[no_mangle]
+pub extern "C" fn z_bytes_map_get(this: &z_owned_bytes_map_t, key: z_bytes_t) -> z_bytes_t {
+    let this = unsafe { &*this.get() };
+    let (Some(this), Some(key)) = (this.as_ref(), key.as_slice()) else {
+        return z_bytes_null();
+    };
+    if let Some(value) = this.get(key) {
+        value.as_ref().into()
+    } else {
+        z_bytes_null()
+    }
+}
+
+/// Associates `value` to `key` in the map, copying them to obtain ownership: `key` and `value` are not aliased past the function's return.
+///
+/// Calling this with `NULL` or the gravestone value is undefined behaviour.
+#[no_mangle]
+pub extern "C" fn z_bytes_map_insert_by_copy(
+    this: &z_owned_bytes_map_t,
+    key: z_bytes_t,
+    value: z_bytes_t,
+) {
+    let this = unsafe { &mut *this.get() };
+    if let (Some(this), Some(key), Some(value)) = (this.as_mut(), key.as_slice(), value.as_slice())
+    {
+        this.insert(Cow::Owned(key.to_owned()), Cow::Owned(value.to_owned()));
+    }
+}
+
+/// Associates `value` to `key` in the map, aliasing them.
+///
+/// Note that once `key` is aliased, reinserting at the same key may alias the previous instance, or the new instance of `key`.
+///
+/// Calling this with `NULL` or the gravestone value is undefined behaviour.
+#[no_mangle]
+pub extern "C" fn z_bytes_map_insert_by_alias(
+    this: &z_owned_bytes_map_t,
+    key: z_bytes_t,
+    value: z_bytes_t,
+) {
+    let this = unsafe { &mut *this.get() };
+    if let (Some(this), Some(key), Some(value)) = (this.as_mut(), key.as_slice(), value.as_slice())
+    {
+        unsafe {
+            this.insert(
+                Cow::Borrowed(core::mem::transmute(key)),
+                Cow::Borrowed(core::mem::transmute(value)),
+            )
+        };
+    }
+}
+
+/// Iterates over the key-value pairs in the map.
+///
+/// `body` will be called once per pair, with `ctx` as its last argument.
+/// If `body` returns a non-zero value, the iteration will stop immediately and the value will be returned.
+/// Otherwise, this will return 0 once all pairs have been visited.
+/// `body` is not given ownership of the key nor value, which alias the pairs in the map.
+/// It is safe to keep these aliases until existing keys are modified/removed, or the map is destroyed.
+/// Note that this map is unordered.
+///
+/// Calling this with `NULL` or the gravestone value is undefined behaviour.
+#[no_mangle]
+pub extern "C" fn z_bytes_map_iter(
+    this: &z_owned_bytes_map_t,
+    body: z_attachment_iter_body_t,
+    ctx: *mut c_void,
+) -> i8 {
+    let this = unsafe { &*this.get() };
+    if let Some(this) = this.as_ref() {
+        for (key, value) in this.iter() {
+            let result = body(key.as_ref().into(), value.as_ref().into(), ctx);
+            if result != 0 {
+                return result;
+            }
+        }
+    }
+    0
+}
+
+const Z_BYTES_MAP_ITERATION_DRIVER: z_attachment_iter_driver_t =
+    Some(unsafe { core::mem::transmute(z_bytes_map_iter as extern "C" fn(_, _, _) -> i8) });
+
+pub(crate) extern "C" fn insert_in_attachment_builder(
+    key: z_bytes_t,
+    value: z_bytes_t,
+    ctx: *mut c_void,
+) -> i8 {
+    let attachment_builder_ref: &mut AttachmentBuilder =
+        unsafe { &mut *(ctx as *mut AttachmentBuilder) };
+    attachment_builder_ref.insert(key.as_slice().unwrap(), value.as_slice().unwrap());
+    0
+}
+
+pub(crate) extern "C" fn attachment_iteration_driver(
+    this: *const c_void,
+    body: z_attachment_iter_body_t,
+    ctx: *mut c_void,
+) -> i8 {
+    let attachments_ref: &Attachment = unsafe { &*(this as *mut Attachment) };
+    for (key, value) in attachments_ref.iter() {
+        let result = body(key.as_ref().into(), value.as_ref().into(), ctx);
+        if result != 0 {
+            return result;
+        }
+    }
+    0
+}
+
+/// Aliases `this` into a generic `z_attachment_t`, allowing it to be passed to corresponding APIs.
+#[no_mangle]
+pub extern "C" fn z_bytes_map_as_attachment(this: &z_owned_bytes_map_t) -> z_attachment_t {
+    if z_bytes_map_check(this) {
+        z_attachment_t {
+            data: this as *const z_owned_bytes_map_t as *mut _,
+            iteration_driver: Z_BYTES_MAP_ITERATION_DRIVER,
+        }
+    } else {
+        z_attachment_t {
+            data: core::ptr::null_mut(),
+            iteration_driver: None,
+        }
+    }
+}
+
+extern "C" fn bytes_map_from_attachment_iterator(
+    key: z_bytes_t,
+    value: z_bytes_t,
+    ctx: *mut c_void,
+) -> i8 {
+    let map = unsafe { &*ctx.cast::<z_owned_bytes_map_t>() };
+    z_bytes_map_insert_by_copy(map, key, value);
+    0
+}
+extern "C" fn bytes_map_from_attachment_iterator_by_alias(
+    key: z_bytes_t,
+    value: z_bytes_t,
+    ctx: *mut c_void,
+) -> i8 {
+    let map = unsafe { &*ctx.cast::<z_owned_bytes_map_t>() };
+    z_bytes_map_insert_by_alias(map, key, value);
+    0
+}
+
+/// Constructs a map from the provided attachment, copying keys and values.
+///
+/// If `this` is at gravestone value, the returned value will also be at gravestone value.
+#[no_mangle]
+pub extern "C" fn z_bytes_map_from_attachment(this: z_attachment_t) -> z_owned_bytes_map_t {
+    if z_attachment_check(&this) {
+        let mut map = z_bytes_map_new();
+        z_attachment_iterate(
+            this,
+            bytes_map_from_attachment_iterator,
+            &mut map as *mut _ as *mut _,
+        );
+        map
+    } else {
+        z_bytes_map_null()
+    }
+}
+
+/// Constructs a map from the provided attachment, aliasing the attachment's keys and values.
+///
+/// If `this` is at gravestone value, the returned value will also be at gravestone value.
+#[no_mangle]
+pub extern "C" fn z_bytes_map_from_attachment_aliasing(
+    this: z_attachment_t,
+) -> z_owned_bytes_map_t {
+    if z_attachment_check(&this) {
+        let mut map = z_bytes_map_new();
+        z_attachment_iterate(
+            this,
+            bytes_map_from_attachment_iterator_by_alias,
+            &mut map as *mut _ as *mut _,
+        );
+        map
+    } else {
+        z_bytes_map_null()
+    }
+}

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -11,10 +11,13 @@
 // Contributors:
 //   ZettaScale Zenoh team, <zenoh@zettascale.tech>
 //
-use libc::size_t;
+use libc::{c_char, size_t};
 use zenoh::prelude::ZenohId;
 
-/// An array of bytes.  
+/// A contiguous view of bytes owned by some other entity.
+///
+/// `start` being `null` is considered a gravestone value,
+/// and empty slices are represented using a possibly dangling pointer for `start`.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct z_bytes_t {
@@ -23,6 +26,12 @@ pub struct z_bytes_t {
 }
 
 impl z_bytes_t {
+    pub fn as_slice(&self) -> Option<&[u8]> {
+        if self.start.is_null() {
+            return None;
+        }
+        Some(unsafe { core::slice::from_raw_parts(self.start, self.len) })
+    }
     pub fn empty() -> Self {
         z_bytes_t {
             start: std::ptr::null(),
@@ -41,6 +50,32 @@ impl Default for z_bytes_t {
 #[no_mangle]
 pub extern "C" fn z_bytes_check(b: &z_bytes_t) -> bool {
     !b.start.is_null()
+}
+
+/// Returns the gravestone value for `z_bytes_t`
+#[no_mangle]
+pub extern "C" fn z_bytes_null() -> z_bytes_t {
+    z_bytes_t {
+        len: 0,
+        start: core::ptr::null(),
+    }
+}
+
+/// Returns a view of `str` using `strlen`.
+///
+/// `str == NULL` will cause this to return `z_bytes_null()`
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn z_bytes_new(str: *const c_char) -> z_bytes_t {
+    if str.is_null() {
+        z_bytes_null()
+    } else {
+        let len = unsafe { libc::strlen(str) };
+        z_bytes_t {
+            len,
+            start: str.cast(),
+        }
+    }
 }
 
 /// Frees `b` and invalidates it for double-drop safety.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ mod publication_cache;
 pub use publication_cache::*;
 mod querying_subscriber;
 pub use querying_subscriber::*;
+pub mod attachment;
 #[cfg(feature = "shared-memory")]
 mod shm;
 

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -11,6 +11,10 @@
 // Contributors:
 //   ZettaScale Zenoh team, <zenoh@zettascale.tech>
 //
+use crate::attachment::{
+    attachment_iteration_driver, insert_in_attachment_builder, z_attachment_check,
+    z_attachment_iterate, z_attachment_null, z_attachment_t,
+};
 use crate::{
     impl_guarded_transmute, z_bytes_t, z_closure_query_call, z_encoding_default, z_encoding_t,
     z_keyexpr_t, z_owned_closure_query_t, z_session_t, z_value_t, GuardedTransmute,
@@ -22,6 +26,7 @@ use zenoh::prelude::SessionDeclarations;
 use zenoh::{
     prelude::{Sample, SplitBuffer},
     queryable::{Query, Queryable as CallbackQueryable},
+    sample::AttachmentBuilder,
     value::Value,
 };
 use zenoh_util::core::{zresult::ErrNo, SyncResolve};
@@ -169,10 +174,12 @@ pub extern "C" fn z_queryable_options_default() -> z_queryable_options_t {
 ///
 /// Members:
 ///   z_encoding_t encoding: The encoding of the payload.
+///   z_attachment_t attachment: The attachment to this reply.
 #[allow(non_camel_case_types)]
 #[repr(C)]
 pub struct z_query_reply_options_t {
     pub encoding: z_encoding_t,
+    pub attachment: z_attachment_t,
 }
 
 /// Constructs the default value for :c:type:`z_query_reply_options_t`.
@@ -181,6 +188,7 @@ pub struct z_query_reply_options_t {
 pub extern "C" fn z_query_reply_options_default() -> z_query_reply_options_t {
     z_query_reply_options_t {
         encoding: z_encoding_default(),
+        attachment: z_attachment_null(),
     }
 }
 
@@ -282,6 +290,15 @@ pub unsafe extern "C" fn z_query_reply(
         );
         if let Some(o) = options {
             s.encoding = o.encoding.into();
+            if z_attachment_check(&o.attachment) {
+                let mut attachment_builder = AttachmentBuilder::new();
+                z_attachment_iterate(
+                    o.attachment,
+                    insert_in_attachment_builder,
+                    &mut attachment_builder as *mut AttachmentBuilder as *mut c_void,
+                );
+                s = s.with_attachment(attachment_builder.build());
+            };
         }
         if let Err(e) = query.reply(Ok(s)).res_sync() {
             log::error!("{}", e);
@@ -332,5 +349,20 @@ pub unsafe extern "C" fn z_query_value(query: &z_query_t) -> z_value_t {
             value.into()
         }
         None => (&Value::empty()).into(),
+    }
+}
+
+/// Returns the attachment to the query by aliasing.
+///
+/// `z_check(return_value) == false` if there was no attachment to the query.
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn z_query_attachment(query: &z_query_t) -> z_attachment_t {
+    match query.as_ref().and_then(|q| q.attachment()) {
+        Some(attachment) => z_attachment_t {
+            data: attachment as *const _ as *mut c_void,
+            iteration_driver: Some(attachment_iteration_driver),
+        },
+        None => z_attachment_null(),
     }
 }

--- a/tests/z_api_attachment_test.c
+++ b/tests/z_api_attachment_test.c
@@ -1,0 +1,107 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "zenoh.h"
+
+#undef NDEBUG
+#include <assert.h>
+
+void writting_through_map_by_alias_read_by_get() {
+    // Writing
+    z_owned_bytes_map_t map = z_bytes_map_new();
+    z_bytes_map_insert_by_alias(&map, z_bytes_new("k1"), z_bytes_new("v1"));
+    z_bytes_map_insert_by_alias(&map, z_bytes_new("k2"), z_bytes_new("v2"));
+    z_attachment_t attachment = z_bytes_map_as_attachment(&map);
+
+    // Elements check
+    z_bytes_t a1 = z_attachment_get(attachment, z_bytes_new("k1"));
+    assert(a1.start != NULL);
+    assert(a1.len == 2);
+    assert(!strncmp(a1.start, "v1", a1.len));
+
+    z_bytes_t a2 = z_attachment_get(attachment, z_bytes_new("k2"));
+    assert(a2.start != NULL);
+    assert(a2.len == 2);
+    assert(!strncmp(a2.start, "v2", a2.len));
+
+    z_bytes_t a_non = z_attachment_get(attachment, z_bytes_new("k_non"));
+    assert(a_non.start == NULL);
+    assert(a_non.len == 0);
+
+    z_drop(z_move(map));
+}
+
+int8_t _attachment_reader(z_bytes_t key, z_bytes_t value, void* ctx) {
+    assert((size_t)ctx == 42);
+    if (!strncmp(key.start, "k1", key.len)) {
+        assert(!strncmp(value.start, "v1", value.len));
+    }
+    if (!strncmp(key.start, "k2", key.len)) {
+        assert(!strncmp(value.start, "v2", value.len));
+    }
+    return 24;
+}
+
+void writting_through_map_by_copy_read_by_iter() {
+    // Writing
+    z_owned_bytes_map_t map = z_bytes_map_new();
+    z_bytes_map_insert_by_copy(&map, z_bytes_new("k1"), z_bytes_new("v1"));
+    z_bytes_map_insert_by_copy(&map, z_bytes_new("k2"), z_bytes_new("v2"));
+    z_attachment_t attachment = z_bytes_map_as_attachment(&map);
+
+    // Elements check
+    int res = z_attachment_iterate(attachment, _attachment_reader, (void*)42);
+    assert(res == 24);
+
+    z_drop(z_move(map));
+}
+
+int8_t _iteration_driver(const void* data, z_attachment_iter_body_t body, void* ctx) {
+    int8_t ret = 0;
+    ret = body(z_bytes_new("k1"), z_bytes_new("v1"), ctx);
+    if (ret) {
+        return ret;
+    }
+    ret = body(z_bytes_new("k2"), z_bytes_new("v2"), ctx);
+    return ret;
+}
+
+void writting_no_map_read_by_get() {
+    z_attachment_t attachment = {.data = NULL, .iteration_driver = &_iteration_driver};
+
+    // Elements check
+    z_bytes_t a1 = z_attachment_get(attachment, z_bytes_new("k1"));
+    assert(a1.start != NULL);
+    assert(a1.len == 2);
+    assert(!strncmp(a1.start, "v1", a1.len));
+
+    z_bytes_t a2 = z_attachment_get(attachment, z_bytes_new("k2"));
+    assert(a2.start != NULL);
+    assert(a2.len == 2);
+    assert(!strncmp(a2.start, "v2", a2.len));
+
+    z_bytes_t a_non = z_attachment_get(attachment, z_bytes_new("k_non"));
+    assert(a_non.start == NULL);
+    assert(a_non.len == 0);
+}
+
+int main(int argc, char** argv) {
+    writting_through_map_by_alias_read_by_get();
+    writting_through_map_by_copy_read_by_iter();
+    writting_no_map_read_by_get();
+}

--- a/tests/z_int_pub_sub_attachment_test.c
+++ b/tests/z_int_pub_sub_attachment_test.c
@@ -1,0 +1,130 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#include "z_int_helpers.h"
+
+#ifdef VALID_PLATFORM
+
+#include <string.h>
+
+#include "zenoh.h"
+
+const char *const SEM_NAME = "/z_int_test_sync_sem";
+sem_t *sem;
+
+const char *const keyexpr = "test/key";
+const char *const values[] = {"test_value_1", "test_value_2", "test_value_3"};
+const size_t values_count = sizeof(values) / sizeof(values[0]);
+
+const char *const K_VAR = "k_var";
+const char *const K_CONST = "k_const";
+const char *const V_CONST = "v const";
+
+int run_publisher() {
+    SEM_WAIT(sem);
+
+    z_owned_config_t config = z_config_default();
+    z_owned_session_t s = z_open(z_move(config));
+    if (!z_check(s)) {
+        perror("Unable to open session!");
+        return -1;
+    }
+
+    z_owned_publisher_t pub = z_declare_publisher(z_loan(s), z_keyexpr(keyexpr), NULL);
+    if (!z_check(pub)) {
+        perror("Unable to declare Publisher for key expression!");
+        return -1;
+    }
+
+    z_owned_bytes_map_t map = z_bytes_map_new();
+    z_bytes_map_insert_by_copy(&map, z_bytes_new(K_CONST), z_bytes_new(V_CONST));
+
+    z_publisher_put_options_t options = z_publisher_put_options_default();
+    options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);
+    options.attachment = z_bytes_map_as_attachment(&map);
+    for (int i = 0; i < values_count; ++i) {
+        z_bytes_map_insert_by_copy(&map, z_bytes_new(K_VAR), z_bytes_new(values[i]));
+        z_publisher_put(z_loan(pub), (const uint8_t *)values[i], strlen(values[i]), &options);
+    }
+
+    z_undeclare_publisher(z_move(pub));
+    z_close(z_move(s));
+    z_drop(z_move(map));
+    return 0;
+}
+
+void data_handler(const z_sample_t *sample, void *arg) {
+    static int val_num = 0;
+    z_owned_str_t keystr = z_keyexpr_to_string(sample->keyexpr);
+    if (strcmp(keyexpr, z_loan(keystr))) {
+        perror("Unexpected key received");
+        exit(-1);
+    }
+    z_drop(z_move(keystr));
+
+    if (strncmp(values[val_num], (const char *)sample->payload.start, (int)sample->payload.len)) {
+        perror("Unexpected value received");
+        exit(-1);
+    }
+
+    z_bytes_t v_const = z_attachment_get(sample->attachment, z_bytes_new(K_CONST));
+    ASSERT_STR_BYTES_EQUAL(V_CONST, v_const);
+
+    z_bytes_t v_var = z_attachment_get(sample->attachment, z_bytes_new(K_VAR));
+    ASSERT_STR_BYTES_EQUAL(values[val_num], v_var);
+
+    if (++val_num == values_count) {
+        exit(0);
+    };
+}
+
+int run_subscriber() {
+    z_owned_config_t config = z_config_default();
+
+    z_owned_session_t s = z_open(z_move(config));
+    if (!z_check(s)) {
+        perror("Unable to open session!");
+        return -1;
+    }
+
+    z_owned_closure_sample_t callback = z_closure(data_handler);
+    z_owned_subscriber_t sub = z_declare_subscriber(z_loan(s), z_keyexpr(keyexpr), z_move(callback), NULL);
+    if (!z_check(sub)) {
+        perror("Unable to declare subscriber!");
+        return -1;
+    }
+
+    SEM_POST(sem);
+    sleep(10);
+
+    z_undeclare_subscriber(z_move(sub));
+    z_close(z_move(s));
+
+    return -1;
+}
+
+int main() {
+    SEM_INIT(sem, SEM_NAME);
+
+    func_ptr_t funcs[] = {run_publisher, run_subscriber};
+    assert(run_timeouted_test(funcs, 2, 10) == 0);
+
+    SEM_DROP(sem, SEM_NAME);
+
+    return 0;
+}
+
+#else
+int main() { return 0; }
+#endif  // VALID_PLATFORM

--- a/tests/z_int_queryable_attachment_test.c
+++ b/tests/z_int_queryable_attachment_test.c
@@ -1,0 +1,142 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#include "z_int_helpers.h"
+
+#ifdef VALID_PLATFORM
+
+#include "zenoh.h"
+
+const char *const SEM_NAME = "/z_int_test_queryable_sync_sem";
+sem_t *sem;
+
+const char *const keyexpr = "test/key";
+const char *const values[] = {"test_value_1", "test_value_2", "test_value_3"};
+const size_t values_count = sizeof(values) / sizeof(values[0]);
+
+const char *const K_VAR = "k_var";
+const char *const K_CONST = "k_const";
+const char *const V_CONST = "v const";
+
+void query_handler(const z_query_t *query, void *context) {
+    static int value_num = 0;
+
+    z_owned_str_t keystr = z_keyexpr_to_string(z_query_keyexpr(query));
+    z_bytes_t pred = z_query_parameters(query);
+    z_value_t payload_value = z_query_value(query);
+
+    z_attachment_t attachment = z_query_attachment(query);
+
+    z_bytes_t v_const = z_attachment_get(attachment, z_bytes_new(K_CONST));
+    ASSERT_STR_BYTES_EQUAL(V_CONST, v_const);
+
+    z_bytes_t v_var = z_attachment_get(attachment, z_bytes_new(K_VAR));
+    ASSERT_STR_BYTES_EQUAL(values[value_num], v_var);
+
+    z_owned_bytes_map_t map = z_bytes_map_new();
+    z_bytes_map_insert_by_copy(&map, z_bytes_new(K_CONST), z_bytes_new(V_CONST));
+
+    z_query_reply_options_t options = z_query_reply_options_default();
+    options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);
+    options.attachment = z_bytes_map_as_attachment(&map);
+    z_query_reply(query, z_keyexpr((const char *)context), values[value_num], strlen(values[value_num]), &options);
+    z_drop(z_move(keystr));
+    z_drop(z_move(map));
+
+    if (++value_num == values_count) {
+        exit(0);
+    }
+}
+
+int run_queryable() {
+    z_owned_config_t config = z_config_default();
+    z_owned_session_t s = z_open(z_move(config));
+    if (!z_check(s)) {
+        perror("Unable to open session!");
+        return -1;
+    }
+
+    z_owned_closure_query_t callback = z_closure(query_handler, NULL, keyexpr);
+    z_owned_queryable_t qable = z_declare_queryable(z_loan(s), z_keyexpr(keyexpr), z_move(callback), NULL);
+    if (!z_check(qable)) {
+        printf("Unable to create queryable.\n");
+        return -1;
+    }
+
+    SEM_POST(sem);
+    sleep(10);
+
+    z_drop(z_move(qable));
+    z_close(z_move(s));
+    return 0;
+}
+
+int run_get() {
+    SEM_WAIT(sem);
+
+    z_owned_config_t config = z_config_default();
+    z_owned_session_t s = z_open(z_move(config));
+    if (!z_check(s)) {
+        perror("Unable to open session!");
+        return -1;
+    }
+
+    z_owned_bytes_map_t map = z_bytes_map_new();
+    z_bytes_map_insert_by_copy(&map, z_bytes_new(K_CONST), z_bytes_new(V_CONST));
+
+    z_get_options_t opts = z_get_options_default();
+    opts.attachment = z_bytes_map_as_attachment(&map);
+
+    for (int val_num = 0; val_num < values_count; ++val_num) {
+        z_bytes_map_insert_by_copy(&map, z_bytes_new(K_VAR), z_bytes_new(values[val_num]));
+
+        z_owned_reply_channel_t channel = zc_reply_fifo_new(16);
+        z_get(z_loan(s), z_keyexpr(keyexpr), "", z_move(channel.send), &opts);
+        z_owned_reply_t reply = z_reply_null();
+        for (z_call(channel.recv, &reply); z_check(reply); z_call(channel.recv, &reply)) {
+            assert(z_reply_is_ok(&reply));
+
+            z_sample_t sample = z_reply_ok(&reply);
+            z_owned_str_t keystr = z_keyexpr_to_string(sample.keyexpr);
+
+            ASSERT_STR_BYTES_EQUAL(values[val_num], sample.payload);
+
+            z_bytes_t v_const = z_attachment_get(sample.attachment, z_bytes_new(K_CONST));
+            ASSERT_STR_BYTES_EQUAL(V_CONST, v_const);
+
+            z_drop(z_move(keystr));
+        }
+        z_drop(z_move(reply));
+        z_drop(z_move(channel));
+    }
+    z_close(z_move(s));
+    z_drop(z_move(map));
+
+    return 0;
+}
+
+int main() {
+    SEM_INIT(sem, SEM_NAME);
+
+    func_ptr_t funcs[] = {run_queryable, run_get};
+    assert(run_timeouted_test(funcs, 2, 10) == 0);
+
+    SEM_DROP(sem, SEM_NAME);
+
+    return 0;
+}
+
+#else
+int main() { return 0; }
+#endif  // VALID_PLATFORM


### PR DESCRIPTION
Implement [attachment api](https://github.com/eclipse-zenoh/zenoh/pull/613) support "C" binding

Allows add attachment to pub/sub/query/reply.

Expands z_bytes_t with methods:
 - z_bytes_new
 - z_bytes_null

Adds z_owned_bytes_map_t:
 - z_bytes_map_new
 - z_bytes_map_check
 - z_bytes_map_null
 - z_bytes_map_drop
 - z_bytes_map_get
 - z_bytes_map_insert_by_alias
 - z_bytes_map_insert_by_copy
 - z_bytes_map_iter
 - z_bytes_map_from_attachment
 - z_bytes_map_from_attachment_aliasing

Adds method to the z_query_t:
 - z_query_attachment

Adds z_attachment_t:
 - z_attachment_null
 - z_attachment_get
 - z_attachment_check
 - z_attachment_iterate

Adds samples:
 - z_pub_attachment.c
 - z_sub_attachment.c

Adds tests:
 - z_api_attachment_test.c
 - z_int_queryable_attachment_test.c
 - z_int_pub_sub_attachment_test.c

---
Failed because zenoh PR still not merged.
~Tests maybe require reworks~
~Documentation should be updated after API review~