### PR TITLE
Revert library name to `zenohc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ fs2 = "0.4.3"
 serde_yaml = "0.9.19"
 
 [lib]
-path="src/lib.rs"
-name = "zenohcd"
+path= "src/lib.rs"
+name = "zenohc"
 crate-type = ["cdylib", "staticlib"]
 doctest = false
 


### PR DESCRIPTION
In #213 the library name was changed to `zenohcd` but this is not strictly necessary and currently breaks the Release workflow because it [relies](https://github.com/eclipse-zenoh/zenoh-c/blob/master/.github/workflows/release.yml#L196) on the old library name.