### PR TITLE
Fix Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,7 @@ jobs:
           esac
 
       - name: "Upload packages"
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.job.target }}
           path: |
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download result of previous builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: ARTIFACTS
       - name: Publish as github release


### PR DESCRIPTION
The Release workflow was using the `actions/upload-artifact@master` and `actions/download-artifact@v2`. Recently `actions/upload-artifact@v4` was released with [breaking](https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes) changes which made it incompatible with older releases of `actions/download-artifact`.