### PR TITLE
Use wall time in throughput test

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,7 +17,8 @@ file(GLOB files "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
 foreach(file ${files})
     get_filename_component(target ${file} NAME_WE)
 
-    if(NOT(UNIX) AND(${target} STREQUAL "z_ping" OR ${target} STREQUAL "z_pong"))
+    # FIXME: remove once zenoh time primitives are available and examples updated
+    if(NOT(UNIX) AND(${target} STREQUAL "z_ping" OR ${target} STREQUAL "z_pong" OR ${target} STREQUAL "z_sub_thr"))
         continue()
     endif()
 

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -21,43 +21,48 @@
 typedef struct {
     volatile unsigned long count;
     volatile unsigned long finished_rounds;
-    volatile clock_t start;
-    volatile clock_t stop;
-    volatile clock_t first_start;
+    struct timespec start;
+    struct timespec first_start;
 } z_stats_t;
 
 z_stats_t *z_stats_make() {
     z_stats_t *stats = malloc(sizeof(z_stats_t));
     stats->count = 0;
     stats->finished_rounds = 0;
-    stats->first_start = 0;
+    stats->first_start.tv_nsec = 0;
     return stats;
+}
+
+static inline unsigned long elapsed_us(const struct timespec *start, const struct timespec *end) {
+    return (unsigned long)(1000000 * (end->tv_sec - start->tv_sec) + (end->tv_nsec - start->tv_nsec) / 1000);
 }
 
 void on_sample(const z_sample_t *sample, void *context) {
     z_stats_t *stats = (z_stats_t *)context;
     if (stats->count == 0) {
-        stats->start = clock();
-        if (!stats->first_start) {
+        clock_gettime(CLOCK_MONOTONIC, &stats->start);
+        if (stats->first_start.tv_nsec == 0) {
             stats->first_start = stats->start;
         }
         stats->count++;
     } else if (stats->count < N) {
         stats->count++;
     } else {
-        stats->stop = clock();
+        struct timespec end;
+        clock_gettime(CLOCK_MONOTONIC, &end);
         stats->finished_rounds++;
-        printf("%f msg/s\n", N * (double)CLOCKS_PER_SEC / (double)(stats->stop - stats->start));
+        printf("%f msg/s\n", (double)N * 1000000.0 / (double)elapsed_us(&stats->start, &end));
         stats->count = 0;
     }
 }
 void drop_stats(void *context) {
-    const clock_t end = clock();
     const z_stats_t *stats = (z_stats_t *)context;
-    const double elapsed = (double)(end - stats->first_start) / (double)CLOCKS_PER_SEC;
     const unsigned long sent_messages = N * stats->finished_rounds + stats->count;
+    struct timespec end;
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double elapsed_s = (double)elapsed_us(&stats->first_start, &end) / 1000000.0;
     printf("Stats being dropped after unsubscribing: sent %ld messages over %f seconds (%f msg/s)\n", sent_messages,
-           elapsed, (double)sent_messages / elapsed);
+           elapsed_s, (double)sent_messages / elapsed_s);
     free(context);
 }
 

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -33,8 +33,8 @@ z_stats_t *z_stats_make() {
     return stats;
 }
 
-static inline unsigned long elapsed_us(const struct timespec *start, const struct timespec *end) {
-    return (unsigned long)(1000000 * (end->tv_sec - start->tv_sec) + (end->tv_nsec - start->tv_nsec) / 1000);
+static inline double elapsed_us(const struct timespec *start, const struct timespec *end) {
+    return (double)(1000000.0 * (end->tv_sec - start->tv_sec) + (end->tv_nsec - start->tv_nsec) / 1000.0);
 }
 
 void on_sample(const z_sample_t *sample, void *context) {
@@ -51,7 +51,7 @@ void on_sample(const z_sample_t *sample, void *context) {
         struct timespec end;
         clock_gettime(CLOCK_MONOTONIC, &end);
         stats->finished_rounds++;
-        printf("%f msg/s\n", (double)N * 1000000.0 / (double)elapsed_us(&stats->start, &end));
+        printf("%f msg/s\n", (double)N * 1000000.0 / elapsed_us(&stats->start, &end));
         stats->count = 0;
     }
 }
@@ -60,7 +60,7 @@ void drop_stats(void *context) {
     const unsigned long sent_messages = N * stats->finished_rounds + stats->count;
     struct timespec end;
     clock_gettime(CLOCK_MONOTONIC, &end);
-    double elapsed_s = (double)elapsed_us(&stats->first_start, &end) / 1000000.0;
+    double elapsed_s = elapsed_us(&stats->first_start, &end) / 1000000.0;
     printf("Stats being dropped after unsubscribing: sent %ld messages over %f seconds (%f msg/s)\n", sent_messages,
            elapsed_s, (double)sent_messages / elapsed_s);
     free(context);

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -33,8 +33,8 @@ z_stats_t *z_stats_make() {
     return stats;
 }
 
-static inline double elapsed_us(const struct timespec *start, const struct timespec *end) {
-    return (double)(1000000.0 * (end->tv_sec - start->tv_sec) + (end->tv_nsec - start->tv_nsec) / 1000.0);
+static inline double get_elapsed_s(const struct timespec *start, const struct timespec *end) {
+    return (double)(end->tv_sec - start->tv_sec) + (double)(end->tv_nsec - start->tv_nsec) / 1.0E9;
 }
 
 void on_sample(const z_sample_t *sample, void *context) {
@@ -51,7 +51,7 @@ void on_sample(const z_sample_t *sample, void *context) {
         struct timespec end;
         clock_gettime(CLOCK_MONOTONIC, &end);
         stats->finished_rounds++;
-        printf("%f msg/s\n", (double)N * 1000000.0 / elapsed_us(&stats->start, &end));
+        printf("%f msg/s\n", (double)N / get_elapsed_s(&stats->start, &end));
         stats->count = 0;
     }
 }
@@ -60,7 +60,7 @@ void drop_stats(void *context) {
     const unsigned long sent_messages = N * stats->finished_rounds + stats->count;
     struct timespec end;
     clock_gettime(CLOCK_MONOTONIC, &end);
-    double elapsed_s = elapsed_us(&stats->first_start, &end) / 1000000.0;
+    double elapsed_s = get_elapsed_s(&stats->first_start, &end);
     printf("Stats being dropped after unsubscribing: sent %ld messages over %f seconds (%f msg/s)\n", sent_messages,
            elapsed_s, (double)sent_messages / elapsed_s);
     free(context);


### PR DESCRIPTION
Throughput test had the same issue of using system time instead of wall time as #184.

This PR switch this to wall time using `CLOCK_MONOTONIC`.