### PR TITLE
z_bytes: expose wrap and rename new to from_str

### DIFF
--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
     z_owned_reply_channel_t channel = zc_reply_fifo_new(16);
     z_get_options_t opts = z_get_options_default();
     if (value != NULL) {
-        opts.value.payload = (z_bytes_t){.len = strlen(value), .start = (uint8_t *)value};
+        opts.value.payload = z_bytes_from_str(value);
     }
     z_get(z_loan(s), keyexpr, "", z_move(channel.send),
           &opts);  // here, the send is moved and will be dropped by zenoh when adequate

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
     options.attachment = z_bytes_map_as_attachment(&map);
 
     // add some value
-    z_bytes_map_insert_by_alias(&map, z_bytes_new("source"), z_bytes_new("C"));
+    z_bytes_map_insert_by_alias(&map, z_bytes_from_str("source"), z_bytes_from_str("C"));
 
     char buf[256];
     char buf_ind[16];
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
 
         // add some other attachment value
         sprintf(buf_ind, "%d", idx);
-        z_bytes_map_insert_by_alias(&map, z_bytes_new("index"), z_bytes_new(buf_ind));
+        z_bytes_map_insert_by_alias(&map, z_bytes_from_str("index"), z_bytes_from_str(buf_ind));
 
         sprintf(buf, "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
     if (argc > 2) value = argv[2];
 
     z_owned_bytes_map_t attachment = z_bytes_map_new();
-    z_bytes_map_insert_by_alias(&attachment, z_bytes_new("hello"), z_bytes_new("there"));
+    z_bytes_map_insert_by_alias(&attachment, z_bytes_from_str("hello"), z_bytes_from_str("there"));
 
     z_owned_config_t config = z_config_default();
     if (argc > 3) {

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -39,7 +39,7 @@ void data_handler(const z_sample_t *sample, void *arg) {
         z_attachment_iterate(sample->attachment, attachment_reader, NULL);
 
         // reads particular attachment item
-        z_bytes_t index = z_attachment_get(sample->attachment, z_bytes_new("index"));
+        z_bytes_t index = z_attachment_get(sample->attachment, z_bytes_from_str("index"));
         if (z_check(index)) {
             printf("   message number: %.*s\n", (int)index.len, index.start);
         }

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1038,6 +1038,13 @@ ZENOHC_API struct z_owned_bytes_map_t z_bytes_map_new(void);
  */
 ZENOHC_API struct z_owned_bytes_map_t z_bytes_map_null(void);
 /**
+ * Deprecated in favor of `z_bytes_from_str`: Returns a view of `str` using `strlen` (this should therefore not be used with untrusted inputs).
+ *
+ * `str == NULL` will cause this to return `z_bytes_null()`
+ */
+ZENOHC_API
+struct z_bytes_t z_bytes_new(const char *str);
+/**
  * Returns the gravestone value for `z_bytes_t`
  */
 ZENOHC_API struct z_bytes_t z_bytes_null(void);

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -953,6 +953,12 @@ ZENOHC_API struct z_attachment_t z_attachment_null(void);
  */
 ZENOHC_API bool z_bytes_check(const struct z_bytes_t *b);
 /**
+ * Returns a view of `str` using `strlen`.
+ *
+ * `str == NULL` will cause this to return `z_bytes_null()`
+ */
+ZENOHC_API struct z_bytes_t z_bytes_from_str(const char *str);
+/**
  * Aliases `this` into a generic `z_attachment_t`, allowing it to be passed to corresponding APIs.
  */
 ZENOHC_API struct z_attachment_t z_bytes_map_as_attachment(const struct z_owned_bytes_map_t *this_);
@@ -1032,15 +1038,13 @@ ZENOHC_API struct z_owned_bytes_map_t z_bytes_map_new(void);
  */
 ZENOHC_API struct z_owned_bytes_map_t z_bytes_map_null(void);
 /**
- * Returns a view of `str` using `strlen`.
- *
- * `str == NULL` will cause this to return `z_bytes_null()`
- */
-ZENOHC_API struct z_bytes_t z_bytes_new(const char *str);
-/**
  * Returns the gravestone value for `z_bytes_t`
  */
 ZENOHC_API struct z_bytes_t z_bytes_null(void);
+/**
+ * Constructs a `len` bytes long view starting at `start`.
+ */
+ZENOHC_API struct z_bytes_t z_bytes_wrap(const uint8_t *start, size_t len);
 /**
  * Closes a zenoh session. This drops and invalidates `session` for double-drop safety.
  *

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -953,7 +953,7 @@ ZENOHC_API struct z_attachment_t z_attachment_null(void);
  */
 ZENOHC_API bool z_bytes_check(const struct z_bytes_t *b);
 /**
- * Returns a view of `str` using `strlen`.
+ * Returns a view of `str` using `strlen` (this should therefore not be used with untrusted inputs).
  *
  * `str == NULL` will cause this to return `z_bytes_null()`
  */

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -78,6 +78,16 @@ pub unsafe extern "C" fn z_bytes_from_str(str: *const c_char) -> z_bytes_t {
     }
 }
 
+#[deprecated = "Renamed to z_bytes_from_str"]
+/// Deprecated in favor of `z_bytes_from_str`: Returns a view of `str` using `strlen` (this should therefore not be used with untrusted inputs).
+///
+/// `str == NULL` will cause this to return `z_bytes_null()`
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn z_bytes_new(str: *const c_char) -> z_bytes_t {
+    z_bytes_from_str(str)
+}
+
 /// Constructs a `len` bytes long view starting at `start`.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -61,7 +61,7 @@ pub extern "C" fn z_bytes_null() -> z_bytes_t {
     }
 }
 
-/// Returns a view of `str` using `strlen`.
+/// Returns a view of `str` using `strlen` (this should therefore not be used with untrusted inputs).
 ///
 /// `str == NULL` will cause this to return `z_bytes_null()`
 #[no_mangle]

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -66,7 +66,7 @@ pub extern "C" fn z_bytes_null() -> z_bytes_t {
 /// `str == NULL` will cause this to return `z_bytes_null()`
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_new(str: *const c_char) -> z_bytes_t {
+pub unsafe extern "C" fn z_bytes_from_str(str: *const c_char) -> z_bytes_t {
     if str.is_null() {
         z_bytes_null()
     } else {
@@ -75,6 +75,17 @@ pub unsafe extern "C" fn z_bytes_new(str: *const c_char) -> z_bytes_t {
             len,
             start: str.cast(),
         }
+    }
+}
+
+/// Constructs a `len` bytes long view starting at `start`.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn z_bytes_wrap(start: *const u8, len: usize) -> z_bytes_t {
+    if start.is_null() {
+        z_bytes_null()
+    } else {
+        z_bytes_t { len, start }
     }
 }
 

--- a/tests/z_api_attachment_test.c
+++ b/tests/z_api_attachment_test.c
@@ -24,18 +24,18 @@
 void writting_through_map_by_alias_read_by_get() {
     // Writing
     z_owned_bytes_map_t map = z_bytes_map_new();
-    z_bytes_map_insert_by_alias(&map, z_bytes_new("k1"), z_bytes_new("v1"));
-    z_bytes_map_insert_by_alias(&map, z_bytes_new("k2"), z_bytes_new("v2"));
+    z_bytes_map_insert_by_alias(&map, z_bytes_from_str("k1"), z_bytes_from_str("v1"));
+    z_bytes_map_insert_by_alias(&map, z_bytes_from_str("k2"), z_bytes_from_str("v2"));
     z_attachment_t attachment = z_bytes_map_as_attachment(&map);
 
     // Elements check
-    z_bytes_t a1 = z_attachment_get(attachment, z_bytes_new("k1"));
+    z_bytes_t a1 = z_attachment_get(attachment, z_bytes_from_str("k1"));
     ASSERT_STR_BYTES_EQUAL("v1", a1);
 
-    z_bytes_t a2 = z_attachment_get(attachment, z_bytes_new("k2"));
+    z_bytes_t a2 = z_attachment_get(attachment, z_bytes_from_str("k2"));
     ASSERT_STR_BYTES_EQUAL("v2", a2);
 
-    z_bytes_t a_non = z_attachment_get(attachment, z_bytes_new("k_non"));
+    z_bytes_t a_non = z_attachment_get(attachment, z_bytes_from_str("k_non"));
     assert(a_non.start == NULL);
     assert(a_non.len == 0);
 
@@ -56,8 +56,8 @@ int8_t _attachment_reader(z_bytes_t key, z_bytes_t value, void* ctx) {
 void writting_through_map_by_copy_read_by_iter() {
     // Writing
     z_owned_bytes_map_t map = z_bytes_map_new();
-    z_bytes_map_insert_by_copy(&map, z_bytes_new("k1"), z_bytes_new("v1"));
-    z_bytes_map_insert_by_copy(&map, z_bytes_new("k2"), z_bytes_new("v2"));
+    z_bytes_map_insert_by_copy(&map, z_bytes_from_str("k1"), z_bytes_from_str("v1"));
+    z_bytes_map_insert_by_copy(&map, z_bytes_from_str("k2"), z_bytes_from_str("v2"));
     z_attachment_t attachment = z_bytes_map_as_attachment(&map);
 
     // Elements check
@@ -69,11 +69,11 @@ void writting_through_map_by_copy_read_by_iter() {
 
 int8_t _iteration_driver(const void* data, z_attachment_iter_body_t body, void* ctx) {
     int8_t ret = 0;
-    ret = body(z_bytes_new("k1"), z_bytes_new("v1"), ctx);
+    ret = body(z_bytes_from_str("k1"), z_bytes_from_str("v1"), ctx);
     if (ret) {
         return ret;
     }
-    ret = body(z_bytes_new("k2"), z_bytes_new("v2"), ctx);
+    ret = body(z_bytes_from_str("k2"), z_bytes_from_str("v2"), ctx);
     return ret;
 }
 
@@ -81,13 +81,13 @@ void writting_no_map_read_by_get() {
     z_attachment_t attachment = {.data = NULL, .iteration_driver = &_iteration_driver};
 
     // Elements check
-    z_bytes_t a1 = z_attachment_get(attachment, z_bytes_new("k1"));
+    z_bytes_t a1 = z_attachment_get(attachment, z_bytes_from_str("k1"));
     ASSERT_STR_BYTES_EQUAL("v1", a1);
 
-    z_bytes_t a2 = z_attachment_get(attachment, z_bytes_new("k2"));
+    z_bytes_t a2 = z_attachment_get(attachment, z_bytes_from_str("k2"));
     ASSERT_STR_BYTES_EQUAL("v2", a2);
 
-    z_bytes_t a_non = z_attachment_get(attachment, z_bytes_new("k_non"));
+    z_bytes_t a_non = z_attachment_get(attachment, z_bytes_from_str("k_non"));
     assert(a_non.start == NULL);
     assert(a_non.len == 0);
 }
@@ -95,7 +95,7 @@ void writting_no_map_read_by_get() {
 void invalid_attachment_safety() {
     z_attachment_t attachment = z_attachment_null();
 
-    z_bytes_t a_non = z_attachment_get(attachment, z_bytes_new("k_non"));
+    z_bytes_t a_non = z_attachment_get(attachment, z_bytes_from_str("k_non"));
     assert(a_non.start == NULL);
     assert(a_non.len == 0);
 

--- a/tests/z_int_pub_sub_attachment_test.c
+++ b/tests/z_int_pub_sub_attachment_test.c
@@ -48,13 +48,13 @@ int run_publisher() {
     }
 
     z_owned_bytes_map_t map = z_bytes_map_new();
-    z_bytes_map_insert_by_copy(&map, z_bytes_new(K_CONST), z_bytes_new(V_CONST));
+    z_bytes_map_insert_by_copy(&map, z_bytes_from_str(K_CONST), z_bytes_from_str(V_CONST));
 
     z_publisher_put_options_t options = z_publisher_put_options_default();
     options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);
     options.attachment = z_bytes_map_as_attachment(&map);
     for (int i = 0; i < values_count; ++i) {
-        z_bytes_map_insert_by_copy(&map, z_bytes_new(K_VAR), z_bytes_new(values[i]));
+        z_bytes_map_insert_by_copy(&map, z_bytes_from_str(K_VAR), z_bytes_from_str(values[i]));
         z_publisher_put(z_loan(pub), (const uint8_t *)values[i], strlen(values[i]), &options);
     }
 
@@ -78,10 +78,10 @@ void data_handler(const z_sample_t *sample, void *arg) {
         exit(-1);
     }
 
-    z_bytes_t v_const = z_attachment_get(sample->attachment, z_bytes_new(K_CONST));
+    z_bytes_t v_const = z_attachment_get(sample->attachment, z_bytes_from_str(K_CONST));
     ASSERT_STR_BYTES_EQUAL(V_CONST, v_const);
 
-    z_bytes_t v_var = z_attachment_get(sample->attachment, z_bytes_new(K_VAR));
+    z_bytes_t v_var = z_attachment_get(sample->attachment, z_bytes_from_str(K_VAR));
     ASSERT_STR_BYTES_EQUAL(values[val_num], v_var);
 
     if (++val_num == values_count) {

--- a/tests/z_int_queryable_attachment_test.c
+++ b/tests/z_int_queryable_attachment_test.c
@@ -38,14 +38,14 @@ void query_handler(const z_query_t *query, void *context) {
 
     z_attachment_t attachment = z_query_attachment(query);
 
-    z_bytes_t v_const = z_attachment_get(attachment, z_bytes_new(K_CONST));
+    z_bytes_t v_const = z_attachment_get(attachment, z_bytes_from_str(K_CONST));
     ASSERT_STR_BYTES_EQUAL(V_CONST, v_const);
 
-    z_bytes_t v_var = z_attachment_get(attachment, z_bytes_new(K_VAR));
+    z_bytes_t v_var = z_attachment_get(attachment, z_bytes_from_str(K_VAR));
     ASSERT_STR_BYTES_EQUAL(values[value_num], v_var);
 
     z_owned_bytes_map_t map = z_bytes_map_new();
-    z_bytes_map_insert_by_copy(&map, z_bytes_new(K_CONST), z_bytes_new(V_CONST));
+    z_bytes_map_insert_by_copy(&map, z_bytes_from_str(K_CONST), z_bytes_from_str(V_CONST));
 
     z_query_reply_options_t options = z_query_reply_options_default();
     options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);
@@ -94,13 +94,13 @@ int run_get() {
     }
 
     z_owned_bytes_map_t map = z_bytes_map_new();
-    z_bytes_map_insert_by_copy(&map, z_bytes_new(K_CONST), z_bytes_new(V_CONST));
+    z_bytes_map_insert_by_copy(&map, z_bytes_from_str(K_CONST), z_bytes_from_str(V_CONST));
 
     z_get_options_t opts = z_get_options_default();
     opts.attachment = z_bytes_map_as_attachment(&map);
 
     for (int val_num = 0; val_num < values_count; ++val_num) {
-        z_bytes_map_insert_by_copy(&map, z_bytes_new(K_VAR), z_bytes_new(values[val_num]));
+        z_bytes_map_insert_by_copy(&map, z_bytes_from_str(K_VAR), z_bytes_from_str(values[val_num]));
 
         z_owned_reply_channel_t channel = zc_reply_fifo_new(16);
         z_get(z_loan(s), z_keyexpr(keyexpr), "", z_move(channel.send), &opts);
@@ -113,7 +113,7 @@ int run_get() {
 
             ASSERT_STR_BYTES_EQUAL(values[val_num], sample.payload);
 
-            z_bytes_t v_const = z_attachment_get(sample.attachment, z_bytes_new(K_CONST));
+            z_bytes_t v_const = z_attachment_get(sample.attachment, z_bytes_from_str(K_CONST));
             ASSERT_STR_BYTES_EQUAL(V_CONST, v_const);
 
             z_drop(z_move(keystr));


### PR DESCRIPTION
This includes a breaking change that was approved by @Mallets, exposing more senseful constructors for `z_bytes_t`.