### PR TITLE
Align examples and remove reading from stdin

### DIFF
--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -90,7 +90,7 @@ const char* parse_opt(int argc, char** argv, const char* opt, bool opt_has_value
  * @param argv
  * @returns NULL if no option was found, else the first option string that was found
  */
-const char* check_unknown_opts(int argc, char** argv) {
+const char* check_unknown_opts(int argc, char** const argv) {
     for (int i = 1; i < argc; i++) {
         if (argv[i] && argv[i][0] == '-') {
             return argv[i];
@@ -155,7 +155,6 @@ void parse_zenoh_json_list_config(int argc, char** argv, const char* opt, const 
         size_t json_list_len = buflen + 3;  // buf + brackets + nullbyte
         char* json_list = (char*)malloc(json_list_len);
         snprintf(json_list, json_list_len, "[%s]", buf);
-        free(buf);
         // insert in config
         if (zc_config_insert_json(z_loan(*config), config_key, json_list) < 0) {
             printf(
@@ -167,6 +166,7 @@ void parse_zenoh_json_list_config(int argc, char** argv, const char* opt, const 
         }
         free(json_list);
     }
+    free(buf);
 }
 
 /**

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -139,7 +139,7 @@ void parse_zenoh_json_list_config(int argc, char** argv, const char* opt, const 
     char* buf = (char*)calloc(1, sizeof(char));
     const char* value = parse_opt(argc, argv, opt, true);
     while (value) {
-        size_t len_newbuf = strlen(buf) + strlen(value) + 4; // value + quotes + comma + nullbyte
+        size_t len_newbuf = strlen(buf) + strlen(value) + 4;  // value + quotes + comma + nullbyte
         char* newbuf = (char*)malloc(len_newbuf);
         snprintf(newbuf, len_newbuf, "%s'%s',", buf, value);
         free(buf);
@@ -158,9 +158,9 @@ void parse_zenoh_json_list_config(int argc, char** argv, const char* opt, const 
         // insert in config
         if (zc_config_insert_json(z_loan(*config), config_key, json_list) < 0) {
             printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                json_list, config_key, config_key);
+                "Couldn't insert value `%s` in configuration at `%s`\n`%s` is either not a JSON-serialized list of "
+                "strings, or values within the list do not respect expected format for `%s`\n",
+                json_list, json_list, json_list, config_key);
             free(json_list);
             exit(-1);
         }

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -27,7 +27,7 @@
         -e <CONNECT> (optional, string): endpoint to connect to. Repeat option to pass multiple endpoints. If none are given, endpoints will be discovered through multicast-scouting if it is enabled.\n\
             ex: '-e tcp/192.168.1.1:7447'\n\
         -l <LISTEN> (optional, string): locator to listen on. Repeat option to pass multiple locators. If none are given, the default configuration will be used.\n\
-            ex: '-l tcp/192.168.1.1:7447'\n\
+            e.g.: '-l tcp/192.168.1.1:7447'\n\
         --no-multicast-scouting (optional): By default zenohd replies to multicast scouting messages for being discovered by peers and clients. This option disables this feature.\n\
 "
 

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -25,7 +25,7 @@
         -c <CONFIG> (optional, string): The path to a configuration file for the session. If this option isn't passed, the default configuration will be used.\n\
         -m <MODE> (optional, string, default='peer'): The zenoh session mode. [possible values: peer, client, router]\n\
         -e <CONNECT> (optional, string): endpoint to connect to. Repeat option to pass multiple endpoints. If none are given, endpoints will be discovered through multicast-scouting if it is enabled.\n\
-            ex: '-e tcp/192.168.1.1:7447'\n\
+            e.g.: '-e tcp/192.168.1.1:7447'\n\
         -l <LISTEN> (optional, string): locator to listen on. Repeat option to pass multiple locators. If none are given, the default configuration will be used.\n\
             e.g.: '-l tcp/192.168.1.1:7447'\n\
         --no-multicast-scouting (optional): By default zenohd replies to multicast scouting messages for being discovered by peers and clients. This option disables this feature.\n\

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -40,7 +40,7 @@
  * pointer will be returned if option is found.
  * @returns NULL if option was not found, else a non-null value depending on if `opt_has_value`.
  */
-const char* parse_opt(const int argc, char** argv, const char* opt, const bool opt_has_value) {
+const char* parse_opt(int argc, char** argv, const char* opt, bool opt_has_value) {
     size_t optlen = strlen(opt);
     for (int i = 1; i < argc; i++) {
         if (argv[i] == NULL) {
@@ -90,7 +90,7 @@ const char* parse_opt(const int argc, char** argv, const char* opt, const bool o
  * @param argv
  * @returns NULL if no option was found, else the first option string that was found
  */
-const char* check_unknown_opts(const int argc, char** argv) {
+const char* check_unknown_opts(int argc, char** argv) {
     for (int i = 1; i < argc; i++) {
         if (argv[i] && argv[i][0] == '-') {
             return argv[i];
@@ -134,7 +134,7 @@ char** parse_pos_args(const int argc, char** argv, const size_t nb_args) {
  * @param config: address of an owned zenoh configuration
  * @param config_key: zenoh configuration key under which the parsed values will be inserted
  */
-void parse_zenoh_json_list_config(const int argc, char** argv, const char* opt, const char* config_key,
+void parse_zenoh_json_list_config(int argc, char** argv, const char* opt, const char* config_key,
                                   const z_owned_config_t* config) {
     char* buf = (char*)calloc(1, sizeof(char));
     const char* value = parse_opt(argc, argv, opt, true);

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -23,7 +23,7 @@
 #define COMMON_HELP \
     "\
         -c <CONFIG> (optional, string): The path to a configuration file for the session. If this option isn't passed, the default configuration will be used.\n\
-        -m <MODE> (optional, string, default='peer'): JSON-serialized string of the zenoh session mode. [possible values: 'peer', 'client', 'router']\n\
+        -m <MODE> (optional, string, default='peer'): The zenoh session mode. [possible values: peer, client, router]\n\
         -e <CONNECT> (optional, string): endpoint to connect to. Repeat option to pass multiple endpoints. If none are given, endpoints will be discovered through multicast-scouting if it is enabled.\n\
         -l <LISTEN> (optional, string): locator to listen on. Repeat option to pass multiple locators. If none are given, the default configuration will be used.\n\
         --no-multicast-scouting (optional): By default zenohd replies to multicast scouting messages for being discovered by peers and clients. This option disables this feature.\n\

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -162,7 +162,7 @@ void parse_zenoh_json_list_config(int argc, char** argv, const char* opt, const 
             printf(
                 "Couldn't insert value `%s` in configuration at `%s`\n`%s` is either not a JSON-serialized list of "
                 "strings, or values within the list do not respect expected format for `%s`\n",
-                json_list, json_list, json_list, config_key);
+                json_list, config_key, json_list, config_key);
             free(json_list);
             exit(-1);
         }

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -25,7 +25,9 @@
         -c <CONFIG> (optional, string): The path to a configuration file for the session. If this option isn't passed, the default configuration will be used.\n\
         -m <MODE> (optional, string, default='peer'): The zenoh session mode. [possible values: peer, client, router]\n\
         -e <CONNECT> (optional, string): endpoint to connect to. Repeat option to pass multiple endpoints. If none are given, endpoints will be discovered through multicast-scouting if it is enabled.\n\
+            ex: '-e tcp/192.168.1.1:7447'\n\
         -l <LISTEN> (optional, string): locator to listen on. Repeat option to pass multiple locators. If none are given, the default configuration will be used.\n\
+            ex: '-l tcp/192.168.1.1:7447'\n\
         --no-multicast-scouting (optional): By default zenohd replies to multicast scouting messages for being discovered by peers and clients. This option disables this feature.\n\
 "
 

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -1,0 +1,175 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <strings.h>
+
+#include "zenoh.h"
+
+#define COMMON_HELP \
+    "\
+        -c <CONFIG> (optional, string): The path to a configuration file for the session. If this option isn't passed, the default configuration will be used.\n\
+        -m <MODE> (optional, string, default='peer'): JSON-serialized string of the zenoh session mode. [possible values: 'peer', 'client', 'router']\n\
+        -e <CONNECT> (optional, string): JSON-serialized list of locators to connect to. If none are given, endpoints will be discovered through multicast-scouting if it is enabled.\n\
+        -l <LISTEN> (optional, string): JSON-serialized list of locators to listen on. If none are given, the default configuration will be used.\n\
+        --no-multicast-scouting (optional): By default zenohd replies to multicast scouting messages for being discovered by peers and clients. This option disables this feature.\n\
+"
+
+/**
+ * Parse an option of format `-f`, `--flag`, `-f <value>` or `--flag <value>` from `argv`. If found, the option and its
+ * eventual value are each replaced by an empty string in `argv`
+ * @param argc: argc passed from `main` function
+ * @param argv: argv passed from `main` function
+ * @param opt: option to parse (without `-` or `--` prefix)
+ * @param opt_has_value: if true, the option is of format `-f <value>` or `--flag <value>` and `value` will be returned
+ * if found, else an error message is printed and program will exit. If false, option has no value and a non-null
+ * pointer will be returned if option is found.
+ * @returns NULL if option was not found, else a non-null value depending on if `opt_has_value`.
+ */
+char* parse_opt(int argc, char** argv, char* opt, bool opt_has_value) {
+    size_t optlen = strlen(opt);
+    for (int i = 1; i < argc; i++) {
+        size_t len = strlen(argv[i]);
+        if (len >= 2) {
+            if (optlen == 1) {
+                if (argv[i][0] == '-' && argv[i][1] == opt[0]) {
+                    argv[i][0] = '\0';
+                    if (!opt_has_value) {
+                        return opt;
+                    } else if (i + 1 < argc && strlen(argv[i + 1]) > 0) {
+                        char* buf = (char*)malloc(strlen(argv[i + 1]));
+                        strcpy(buf, argv[i + 1]);
+                        argv[i + 1][0] = '\0';
+                        return buf;
+                    } else {
+                        printf("Option -%s given without a value\n", opt);
+                        exit(-1);
+                    }
+                }
+            } else if (optlen > 1 && len > 3 && argv[i][0] == '-' && argv[i][1] == '-') {
+                // Note: support for '--arg=<value>' syntax can be added here
+                if (strcmp(argv[i] + 2, opt) == 0) {
+                    argv[i][0] = '\0';
+                    if (!opt_has_value) {
+                        return opt;
+                    } else if (i + 1 < argc && strlen(argv[i + 1]) > 0) {
+                        char* buf = (char*)malloc(strlen(argv[i + 1]));
+                        strcpy(buf, argv[i + 1]);
+                        argv[i + 1][0] = '\0';
+                        return buf;
+                    } else {
+                        printf("Option --%s given without a value\n", opt);
+                        exit(-1);
+                    }
+                }
+            }
+        }
+    }
+    return NULL;
+}
+
+/**
+ * Check if any options remains in `argv`. Must be called after all expected options are parsed
+ * @param argc
+ * @param argv
+ * @returns NULL if no option was found, else the first option string that was found
+ */
+char* check_unknown_opts(int argc, char** argv) {
+    for (int i = 1; i < argc; i++) {
+        if (argv[i][0] == '-') {
+            return argv[i];
+        }
+    }
+    return NULL;
+}
+
+/**
+ * Parse positional arguments from `argv`. Must be called after all expected options are parsed, and after checking that
+ * no unknown options remain in `argv`
+ * @param argc
+ * @param argv
+ * @param nb_args: number of expected positional arguments
+ * @returns NULL if found more positional arguments than `nb_args`. Else an array of found arguments in order, followed
+ * by NULL values if found less positional arguments than `nb_args`
+ */
+char** parse_pos_args(int argc, char** argv, size_t nb_args) {
+    char** pos_argv = (char**)malloc(nb_args * sizeof(char*));
+    // Initialize pointers to NULL to detect when example is called with number of args < nb_args
+    for (int i = 0; i < nb_args; i++) {
+        pos_argv[i] = NULL;
+    }
+    size_t pos_argc = 0;
+    for (int i = 1; i < argc; i++) {
+        if (strlen(argv[i]) > 0) {
+            pos_argc++;
+            if (pos_argc > nb_args) {
+                free(pos_argv);
+                return NULL;
+            }
+            pos_argv[pos_argc - 1] = argv[i];
+        }
+    }
+    return pos_argv;
+}
+
+/**
+ * Parse zenoh options that are common to all examples (-c, -m, -e, -l, --no-multicast-scouting) and add them to
+ * `config`
+ * @param argc
+ * @param argv
+ * @param config: address of an owned zenoh configuration
+ */
+void parse_zenoh_common_args(int argc, char** argv, z_owned_config_t* config) {
+    // -c: A configuration file.
+    char* config_file = parse_opt(argc, argv, "c", true);
+    if (config_file) {
+        *config = zc_config_from_file(config_file);
+    }
+    // -m: The Zenoh session mode [default: peer].
+    char* mode = parse_opt(argc, argv, "m", true);
+    if (mode && zc_config_insert_json(z_loan(*config), Z_CONFIG_MODE_KEY, mode) < 0) {
+        printf(
+            "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+            "JSON-serialized string. Value must be one of: 'client', 'peer' or 'router'\n",
+            mode, Z_CONFIG_MODE_KEY, Z_CONFIG_MODE_KEY);
+        exit(-1);
+    }
+    // -e: Endpoints to connect to.
+    char* connect = parse_opt(argc, argv, "e", true);
+    if (connect && zc_config_insert_json(z_loan(*config), Z_CONFIG_CONNECT_KEY, connect) < 0) {
+        printf(
+            "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+            "JSON-serialized list of strings\n",
+            connect, Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
+        exit(-1);
+    }
+    // -l: Endpoints to listen on.
+    char* listen = parse_opt(argc, argv, "l", true);
+    if (listen && zc_config_insert_json(z_loan(*config), Z_CONFIG_LISTEN_KEY, listen) < 0) {
+        printf(
+            "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+            "JSON-serialized list of strings\n",
+            listen, Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
+        exit(-1);
+    }
+    // --no-multicast-scrouting: Disable the multicast-based scouting mechanism.
+    char* no_multicast_scouting = parse_opt(argc, argv, "no-multicast-scouting", false);
+    if (no_multicast_scouting && zc_config_insert_json(z_loan(*config), Z_CONFIG_MULTICAST_SCOUTING_KEY, "false") < 0) {
+        printf("Couldn't disable multicast-scouting.\n");
+        exit(-1);
+    }
+}

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -40,7 +40,7 @@
  * pointer will be returned if option is found.
  * @returns NULL if option was not found, else a non-null value depending on if `opt_has_value`.
  */
-char* parse_opt(int argc, char** argv, char* opt, bool opt_has_value) {
+char* parse_opt(const int argc, char** argv, const char* opt, const bool opt_has_value) {
     size_t optlen = strlen(opt);
     for (int i = 1; i < argc; i++) {
         if (argv[i] == NULL) {
@@ -52,7 +52,7 @@ char* parse_opt(int argc, char** argv, char* opt, bool opt_has_value) {
                 if (argv[i][0] == '-' && argv[i][1] == opt[0]) {
                     argv[i] = NULL;
                     if (!opt_has_value) {
-                        return opt;
+                        return (char*)opt;
                     } else if (i + 1 < argc && argv[i + 1]) {
                         char* value = argv[i + 1];
                         argv[i + 1] = NULL;
@@ -67,7 +67,7 @@ char* parse_opt(int argc, char** argv, char* opt, bool opt_has_value) {
                 if (strcmp(argv[i] + 2, opt) == 0) {
                     argv[i] = NULL;
                     if (!opt_has_value) {
-                        return opt;
+                        return (char*)opt;
                     } else if (i + 1 < argc && argv[i + 1]) {
                         char* value = argv[i + 1];
                         argv[i + 1] = NULL;
@@ -89,7 +89,7 @@ char* parse_opt(int argc, char** argv, char* opt, bool opt_has_value) {
  * @param argv
  * @returns NULL if no option was found, else the first option string that was found
  */
-char* check_unknown_opts(int argc, char** argv) {
+char* check_unknown_opts(const int argc, char** argv) {
     for (int i = 1; i < argc; i++) {
         if (argv[i] && argv[i][0] == '-') {
             return argv[i];
@@ -108,7 +108,7 @@ char* check_unknown_opts(int argc, char** argv) {
  * by NULL values if found less positional arguments than `nb_args`
  * @note Returned pointer is dynamically allocated and must be freed
  */
-char** parse_pos_args(int argc, char** argv, size_t nb_args) {
+char** parse_pos_args(const int argc, char** argv, const size_t nb_args) {
     char** pos_argv = (char**)malloc(nb_args * sizeof(char*));
     // Initialize pointers to NULL to detect when example is called with number of args < nb_args
     for (int i = 0; i < nb_args; i++) {
@@ -137,7 +137,8 @@ char** parse_pos_args(int argc, char** argv, size_t nb_args) {
  * @param config: address of an owned zenoh configuration
  * @param config_key: zenoh configuration key under which the parsed values will be inserted
  */
-void parse_zenoh_json_list_config(int argc, char** argv, char* opt, const char* config_key, z_owned_config_t* config) {
+void parse_zenoh_json_list_config(const int argc, char** argv, const char* opt, const char* config_key,
+                                  const z_owned_config_t* config) {
     char buf[256] = "";
     char* value = parse_opt(argc, argv, opt, true);
     while (value) {
@@ -177,7 +178,7 @@ void parse_zenoh_json_list_config(int argc, char** argv, char* opt, const char* 
  * @param argv
  * @param config: address of an owned zenoh configuration
  */
-void parse_zenoh_common_args(int argc, char** argv, z_owned_config_t* config) {
+void parse_zenoh_common_args(const int argc, char** argv, z_owned_config_t* config) {
     // -c: A configuration file.
     char* config_file = parse_opt(argc, argv, "c", true);
     if (config_file) {

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -16,7 +16,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <strings.h>
+#include <string.h>
 
 #include "zenoh.h"
 

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -40,7 +40,7 @@
  * pointer will be returned if option is found.
  * @returns NULL if option was not found, else a non-null value depending on if `opt_has_value`.
  */
-char* parse_opt(const int argc, char** argv, const char* opt, const bool opt_has_value) {
+const char* parse_opt(const int argc, char** argv, const char* opt, const bool opt_has_value) {
     size_t optlen = strlen(opt);
     for (int i = 1; i < argc; i++) {
         if (argv[i] == NULL) {
@@ -90,7 +90,7 @@ char* parse_opt(const int argc, char** argv, const char* opt, const bool opt_has
  * @param argv
  * @returns NULL if no option was found, else the first option string that was found
  */
-char* check_unknown_opts(const int argc, char** argv) {
+const char* check_unknown_opts(const int argc, char** argv) {
     for (int i = 1; i < argc; i++) {
         if (argv[i] && argv[i][0] == '-') {
             return argv[i];
@@ -137,7 +137,7 @@ char** parse_pos_args(const int argc, char** argv, const size_t nb_args) {
 void parse_zenoh_json_list_config(const int argc, char** argv, const char* opt, const char* config_key,
                                   const z_owned_config_t* config) {
     char* buf = (char*)calloc(1, sizeof(char));
-    char* value = parse_opt(argc, argv, opt, true);
+    const char* value = parse_opt(argc, argv, opt, true);
     while (value) {
         size_t len_newbuf = strlen(buf) + strlen(value) + 4; // value + quotes + comma + nullbyte
         char* newbuf = (char*)malloc(len_newbuf);
@@ -178,12 +178,12 @@ void parse_zenoh_json_list_config(const int argc, char** argv, const char* opt, 
  */
 void parse_zenoh_common_args(const int argc, char** argv, z_owned_config_t* config) {
     // -c: A configuration file.
-    char* config_file = parse_opt(argc, argv, "c", true);
+    const char* config_file = parse_opt(argc, argv, "c", true);
     if (config_file) {
         *config = zc_config_from_file(config_file);
     }
     // -m: The Zenoh session mode [default: peer].
-    char* mode = parse_opt(argc, argv, "m", true);
+    const char* mode = parse_opt(argc, argv, "m", true);
     if (mode) {
         size_t buflen = strlen(mode) + 3;  // mode + quotes + nullbyte
         char* buf = (char*)malloc(buflen);
@@ -203,7 +203,7 @@ void parse_zenoh_common_args(const int argc, char** argv, z_owned_config_t* conf
     // -l: Endpoint to listen on. Can be repeated
     parse_zenoh_json_list_config(argc, argv, "l", Z_CONFIG_LISTEN_KEY, config);
     // --no-multicast-scrouting: Disable the multicast-based scouting mechanism.
-    char* no_multicast_scouting = parse_opt(argc, argv, "no-multicast-scouting", false);
+    const char* no_multicast_scouting = parse_opt(argc, argv, "no-multicast-scouting", false);
     if (no_multicast_scouting && zc_config_insert_json(z_loan(*config), Z_CONFIG_MULTICAST_SCOUTING_KEY, "false") < 0) {
         printf("Couldn't disable multicast-scouting.\n");
         exit(-1);

--- a/examples/z_delete.c
+++ b/examples/z_delete.c
@@ -14,23 +14,19 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *keyexpr = "demo/example/zenoh-c-put";
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-put"
 
-    if (argc > 1) keyexpr = argv[1];
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 3) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
@@ -39,13 +35,49 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Deleting resources matching '%s'...\n", keyexpr);
+    printf("Deleting resources matching '%s'...\n", args.keyexpr);
     z_delete_options_t options = z_delete_options_default();
-    int res = z_delete(z_loan(s), z_keyexpr(keyexpr), &options);
+    int res = z_delete(z_loan(s), z_keyexpr(args.keyexpr), &options);
     if (res < 0) {
         printf("Delete failed...\n");
     }
 
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_delete [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression to write to\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_delete.c
+++ b/examples/z_delete.c
@@ -77,6 +77,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr};

--- a/examples/z_delete.c
+++ b/examples/z_delete.c
@@ -80,5 +80,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_delete.c
+++ b/examples/z_delete.c
@@ -64,12 +64,12 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -81,5 +81,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr};
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -14,36 +14,26 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *expr = "demo/example/**";
-    char *value = NULL;
-    switch (argc) {
-        default:
-        case 3:
-            value = argv[2];
-        case 2:
-            expr = argv[1];
-            break;
-        case 1:
-            // Do nothing
-            break;
-    }
-    z_keyexpr_t keyexpr = z_keyexpr(expr);
-    if (!z_check(keyexpr)) {
-        printf("%s is not a valid key expression", expr);
-        exit(-1);
-    }
+#define DEFAULT_SELECTOR "demo/example/**"
+#define DEFAULT_VALUE NULL
+
+struct args_t {
+    char* selector;  // -s
+    char* value;     // -v
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 3) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
+    struct args_t args = parse_args(argc, argv, &config);
+
+    z_keyexpr_t keyexpr = z_keyexpr(args.selector);
+    if (!z_check(keyexpr)) {
+        printf("%s is not a valid key expression", args.selector);
+        exit(-1);
     }
 
     printf("Opening session...\n");
@@ -53,11 +43,11 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Sending Query '%s'...\n", expr);
+    printf("Sending Query '%s'...\n", args.selector);
     z_owned_reply_channel_t channel = zc_reply_fifo_new(16);
     z_get_options_t opts = z_get_options_default();
-    if (value != NULL) {
-        opts.value.payload = z_bytes_from_str(value);
+    if (args.value != NULL) {
+        opts.value.payload = z_bytes_from_str(args.value);
     }
     z_get(z_loan(s), keyexpr, "", z_move(channel.send),
           &opts);  // here, the send is moved and will be dropped by zenoh when adequate
@@ -76,4 +66,45 @@ int main(int argc, char **argv) {
     z_drop(z_move(channel));
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_get [OPTIONS]\n\n\
+    Options:\n\
+        -s <SELECTOR> (optional, string, default='%s'): The selection of resources to query\n\
+        -v <VALUE> (optional, string): An optional value to put in the query\n",
+        DEFAULT_SELECTOR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* selector = parse_opt(argc, argv, "s", true);
+    if (!selector) {
+        selector = DEFAULT_SELECTOR;
+    }
+    char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.selector = selector, .value = value};
 }

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -87,16 +87,16 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* selector = parse_opt(argc, argv, "s", true);
+    const char* selector = parse_opt(argc, argv, "s", true);
     if (!selector) {
         selector = DEFAULT_SELECTOR;
     }
-    char* value = parse_opt(argc, argv, "v", true);
+    const char* value = parse_opt(argc, argv, "v", true);
     if (!value) {
         value = DEFAULT_VALUE;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -108,5 +108,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.selector = selector, .value = value};
+    return (struct args_t){.selector = (char*)selector, .value = (char*)value};
 }

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -104,6 +104,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.selector = selector, .value = value};

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -107,5 +107,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.selector = selector, .value = value};
 }

--- a/examples/z_get_liveliness.c
+++ b/examples/z_get_liveliness.c
@@ -79,12 +79,12 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -96,5 +96,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr};
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_get_liveliness.c
+++ b/examples/z_get_liveliness.c
@@ -14,29 +14,24 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *expr = "group1/**";
-    if (argc > 1) {
-        expr = argv[1];
-    }
+#define DEFAULT_KEYEXPR "group1/**"
 
-    z_keyexpr_t keyexpr = z_keyexpr(expr);
-    if (!z_check(keyexpr)) {
-        printf("%s is not a valid key expression\n", expr);
-        exit(-1);
-    }
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
+    struct args_t args = parse_args(argc, argv, &config);
+
+    z_keyexpr_t keyexpr = z_keyexpr(args.keyexpr);
+    if (!z_check(keyexpr)) {
+        printf("%s is not a valid key expression\n", args.keyexpr);
+        exit(-1);
     }
 
     printf("Opening session...\n");
@@ -46,7 +41,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Sending liveliness query '%s'...\n", expr);
+    printf("Sending liveliness query '%s'...\n", args.keyexpr);
     z_owned_reply_channel_t channel = zc_reply_fifo_new(16);
     zc_liveliness_get(z_loan(s), keyexpr, z_move(channel.send), NULL);
     z_owned_reply_t reply = z_reply_null();
@@ -64,4 +59,40 @@ int main(int argc, char **argv) {
     z_drop(z_move(channel));
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_get_liveliness [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression to query\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_get_liveliness.c
+++ b/examples/z_get_liveliness.c
@@ -92,6 +92,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr};

--- a/examples/z_get_liveliness.c
+++ b/examples/z_get_liveliness.c
@@ -95,5 +95,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_info.c
+++ b/examples/z_info.c
@@ -78,6 +78,7 @@ void parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
 }

--- a/examples/z_info.c
+++ b/examples/z_info.c
@@ -81,4 +81,5 @@ void parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
 }

--- a/examples/z_info.c
+++ b/examples/z_info.c
@@ -13,26 +13,21 @@
 
 #include <stdio.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-void print_zid(const z_id_t *id, void *ctx) {
+void parse_args(int argc, char** argv, z_owned_config_t* config);
+
+void print_zid(const z_id_t* id, void* ctx) {
     for (int i = 0; i < 16; i++) {
         printf("%02x", id->id[i]);
     }
     printf("\n");
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 1) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[1], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
@@ -56,4 +51,33 @@ int main(int argc, char **argv) {
     z_info_peers_zid(z_loan(s), z_move(callback2));
 
     z_close(z_move(s));
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_info [OPTIONS]\n\n\
+    Options:\n");
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+void parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
 }

--- a/examples/z_info.c
+++ b/examples/z_info.c
@@ -70,7 +70,7 @@ void parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(1);
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);

--- a/examples/z_liveliness.c
+++ b/examples/z_liveliness.c
@@ -93,6 +93,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr};

--- a/examples/z_liveliness.c
+++ b/examples/z_liveliness.c
@@ -13,29 +13,25 @@
 
 #include <stdio.h>
 #include <string.h>
+
+#include "parse_args.h"
 #include "zenoh.h"
 
+#define DEFAULT_KEYEXPR "group1/zenoh-rs"
+
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
 int main(int argc, char **argv) {
-    char *expr = "group1/zenoh-rs";
-    if (argc > 1) {
-        expr = argv[1];
-    }
-
-    z_keyexpr_t keyexpr = z_keyexpr(expr);
-    if (!z_check(keyexpr)) {
-        printf("%s is not a valid key expression\n", expr);
-        exit(-1);
-    }
-
     z_owned_config_t config = z_config_default();
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
+    struct args_t args = parse_args(argc, argv, &config);
+
+    z_keyexpr_t keyexpr = z_keyexpr(args.keyexpr);
+    if (!z_check(keyexpr)) {
+        printf("%s is not a valid key expression\n", args.keyexpr);
+        exit(-1);
     }
 
     printf("Opening session...\n");
@@ -45,7 +41,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Declaring liveliness token '%s'...\n", expr);
+    printf("Declaring liveliness token '%s'...\n", args.keyexpr);
     zc_owned_liveliness_token_t token = zc_liveliness_declare_token(z_loan(s), keyexpr, NULL);
     if (!z_check(token)) {
         printf("Unable to create liveliness token!\n");
@@ -64,4 +60,40 @@ int main(int argc, char **argv) {
     
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_liveliness [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression the liveliness token\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_liveliness.c
+++ b/examples/z_liveliness.c
@@ -80,12 +80,12 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -97,5 +97,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr};
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_liveliness.c
+++ b/examples/z_liveliness.c
@@ -96,5 +96,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_liveliness.c
+++ b/examples/z_liveliness.c
@@ -52,19 +52,16 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Enter 'd' to undeclare liveliness token, 'q' to quit...\n");
-    char c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            z_sleep_s(1);
-        } else if (c == 'd') {
-            printf("Undeclaring liveliness token...\n");
-            z_drop(z_move(token));
-        }
+    printf("Press CTRL-C to undeclare liveliness token and quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
+    // LivelinessTokens are automatically closed when dropped
+    // Use the code below to manually undeclare it if needed
+    printf("Undeclaring liveliness token...\n");
     z_drop(z_move(token));
+    
     z_close(z_move(s));
     return 0;
 }

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -102,5 +102,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.selector = selector};
 }

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -86,12 +86,12 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* selector = parse_opt(argc, argv, "s", true);
+    const char* selector = parse_opt(argc, argv, "s", true);
     if (!selector) {
         selector = DEFAULT_SELECTOR;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -103,5 +103,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.selector = selector};
+    return (struct args_t){.selector = (char*)selector};
 }

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -99,6 +99,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.selector = selector};

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -14,27 +14,24 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *expr = "demo/example/**";
-    if (argc > 1) {
-        expr = argv[1];
-    }
-    z_keyexpr_t keyexpr = z_keyexpr(expr);
-    if (!z_check(keyexpr)) {
-        printf("%s is not a valid key expression", expr);
-        exit(-1);
-    }
+#define DEFAULT_SELECTOR "demo/example/**"
+
+struct args_t {
+    char* selector;  // -s
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
+    struct args_t args = parse_args(argc, argv, &config);
+
+    z_keyexpr_t keyexpr = z_keyexpr(args.selector);
+    if (!z_check(keyexpr)) {
+        printf("%s is not a valid key expression", args.selector);
+        exit(-1);
     }
 
     printf("Opening session...\n");
@@ -44,7 +41,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Sending Query '%s'...\n", expr);
+    printf("Sending Query '%s'...\n", args.selector);
     z_get_options_t opts = z_get_options_default();
     opts.target = Z_QUERY_TARGET_ALL;
     z_owned_reply_channel_t channel = zc_reply_non_blocking_fifo_new(16);
@@ -69,4 +66,40 @@ int main(int argc, char **argv) {
     z_drop(z_move(channel));
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_non_blocking_get [OPTIONS]\n\n\
+    Options:\n\
+        -s <SELECTOR> (optional, string, default='%s'): The selection of resources to query\n",
+        DEFAULT_SELECTOR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* selector = parse_opt(argc, argv, "s", true);
+    if (!selector) {
+        selector = DEFAULT_SELECTOR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.selector = selector};
 }

--- a/examples/z_ping.c
+++ b/examples/z_ping.c
@@ -103,7 +103,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* arg = parse_opt(argc, argv, "s", true);
+    const char* arg = parse_opt(argc, argv, "s", true);
     unsigned int size = DEFAULT_PKT_SIZE;
     if (arg) {
         size = atoi(arg);

--- a/examples/z_ping.c
+++ b/examples/z_ping.c
@@ -130,5 +130,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.size = size, .number_of_pings = number_of_pings, .warmup_ms = warmup_ms};
 }

--- a/examples/z_ping.c
+++ b/examples/z_ping.c
@@ -118,5 +118,17 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     if (arg) {
         warmup_ms = atoi(arg);
     }
+    parse_zenoh_common_args(argc, argv, config);
+    arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
     return (struct args_t){.size = size, .number_of_pings = number_of_pings, .warmup_ms = warmup_ms};
 }

--- a/examples/z_pong.c
+++ b/examples/z_pong.c
@@ -34,7 +34,8 @@ int main(int argc, char** argv) {
     z_owned_publisher_t pub = z_declare_publisher(z_loan(session), pong, NULL);
     z_owned_closure_sample_t respond = z_closure(callback, drop, (void*)z_move(pub));
     z_owned_subscriber_t sub = z_declare_subscriber(z_loan(session), ping, z_move(respond), NULL);
-    while (getchar() != 'q') {
+    while (1) {
+        z_sleep_s(1);
     }
     z_drop(z_move(sub));
     z_close(z_move(session));

--- a/examples/z_pong.c
+++ b/examples/z_pong.c
@@ -66,6 +66,7 @@ void parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
 }

--- a/examples/z_pong.c
+++ b/examples/z_pong.c
@@ -69,4 +69,5 @@ void parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
 }

--- a/examples/z_pong.c
+++ b/examples/z_pong.c
@@ -1,7 +1,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
+
+void parse_args(int argc, char** argv, z_owned_config_t* config);
 
 void callback(const z_sample_t* sample, void* context) {
     z_publisher_t pub = z_loan(*(z_owned_publisher_t*)context);
@@ -20,19 +23,11 @@ void drop(void* context) {
     //  which makes passing a pointer to the stack safe as long as `sub` is dropped in a scope where `pub` is still
     //  valid.
 }
-struct args_t {
-    char* config_path;             // -c
-    uint8_t help_requested;        // -h
-};
-struct args_t parse_args(int argc, char** argv);
 
 int main(int argc, char** argv) {
-    struct args_t args = parse_args(argc, argv);
-    if (args.help_requested) {
-        printf("-c (optional, string): the path to a configuration file for the session. If this option isn't passed, the default configuration will be used.\n");
-        return 1;
-    }
-    z_owned_config_t config = args.config_path ? zc_config_from_file(args.config_path) : z_config_default();
+    z_owned_config_t config = z_config_default();
+    parse_args(argc, argv, &config);
+
     z_owned_session_t session = z_open(z_move(config));
     z_keyexpr_t ping = z_keyexpr_unchecked("test/ping");
     z_keyexpr_t pong = z_keyexpr_unchecked("test/pong");
@@ -45,25 +40,31 @@ int main(int argc, char** argv) {
     z_close(z_move(session));
 }
 
-char* getopt(int argc, char** argv, char option) {
-    for (int i = 0; i < argc; i++) {
-        size_t len = strlen(argv[i]);
-        if (len >= 2 && argv[i][0] == '-' && argv[i][1] == option) {
-            if (len > 2 && argv[i][2] == '=') {
-                return argv[i] + 3;
-            } else if (i + 1 < argc) {
-                return argv[i + 1];
-            }
-        }
-    }
-    return NULL;
+void print_help() {
+    printf(
+        "\
+    Usage: z_pong [OPTIONS]\n\n\
+    Options:\n");
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
 }
 
-struct args_t parse_args(int argc, char** argv) {
-    for (int i = 0; i < argc; i++) {
-        if (strcmp(argv[i], "-h") == 0) {
-            return (struct args_t){.help_requested = 1};
-        }
+void parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
     }
-    return (struct args_t){.help_requested = 0, .config_path = getopt(argc, argv, 'c')};
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
 }

--- a/examples/z_pong.c
+++ b/examples/z_pong.c
@@ -58,7 +58,7 @@ void parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(1);
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -96,15 +96,15 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
-    char* value = parse_opt(argc, argv, "v", true);
+    const char* value = parse_opt(argc, argv, "v", true);
     if (!value) {
         value = DEFAULT_VALUE;
     }
-    char* arg = parse_opt(argc, argv, "add-matching-listener", false);
+    const char* arg = parse_opt(argc, argv, "add-matching-listener", false);
     bool add_matching_listener = false;
     if (arg) {
         add_matching_listener = true;
@@ -122,5 +122,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr, .value = value, .add_matching_listener = add_matching_listener};
+    return (struct args_t){.keyexpr = (char*)keyexpr, .value = (char*)value, .add_matching_listener = add_matching_listener};
 }

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -118,6 +118,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr, .value = value, .add_matching_listener = add_matching_listener};

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -121,5 +121,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr, .value = value, .add_matching_listener = add_matching_listener};
 }

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -64,6 +64,7 @@ int main(int argc, char **argv) {
         listener =  zcu_publisher_matching_listener_callback(z_loan(pub), z_move(callback));
     }
 
+    printf("Press CTRL-C to quit...\n");
     char buf[256];
     for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -14,9 +14,20 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-void matching_status_handler(const zcu_matching_status_t *matching_status, void *arg) {
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-pub"
+#define DEFAULT_VALUE "Pub from C!"
+
+struct args_t {
+    char* keyexpr;               // -k
+    char* value;                 // -v
+    bool add_matching_listener;  // --add-matching-listener
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+void matching_status_handler(const zcu_matching_status_t* matching_status, void* arg) {
     if (matching_status->matching) {
         printf("Subscriber matched\n");
     } else {
@@ -24,25 +35,9 @@ void matching_status_handler(const zcu_matching_status_t *matching_status, void 
     }
 }
 
-int main(int argc, char **argv) {
-    char *keyexpr = "demo/example/zenoh-c-pub";
-    char *value = "Pub from C!";
-    bool add_matching_listener = false;
-
-    if (argc > 1) keyexpr = argv[1];
-    if (argc > 2) value = argv[2];
-    if (argc > 3) add_matching_listener = atoi(argv[3]);
-
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 4) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[4]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[4], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
@@ -51,32 +46,79 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Declaring Publisher on '%s'...\n", keyexpr);
-    z_owned_publisher_t pub = z_declare_publisher(z_loan(s), z_keyexpr(keyexpr), NULL);
+    printf("Declaring Publisher on '%s'...\n", args.keyexpr);
+    z_owned_publisher_t pub = z_declare_publisher(z_loan(s), z_keyexpr(args.keyexpr), NULL);
     if (!z_check(pub)) {
         printf("Unable to declare Publisher for key expression!\n");
         exit(-1);
     }
 
     zcu_owned_matching_listener_t listener;
-    if (add_matching_listener) {
+    if (args.add_matching_listener) {
         zcu_owned_closure_matching_status_t callback = z_closure(matching_status_handler);
-        listener =  zcu_publisher_matching_listener_callback(z_loan(pub), z_move(callback));
+        listener = zcu_publisher_matching_listener_callback(z_loan(pub), z_move(callback));
     }
 
     printf("Press CTRL-C to quit...\n");
     char buf[256];
     for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);
-        sprintf(buf, "[%4d] %s", idx, value);
-        printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
+        sprintf(buf, "[%4d] %s", idx, args.value);
+        printf("Putting Data ('%s': '%s')...\n", args.keyexpr, buf);
         z_publisher_put_options_t options = z_publisher_put_options_default();
         options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);
-        z_publisher_put(z_loan(pub), (const uint8_t *)buf, strlen(buf), &options);
+        z_publisher_put(z_loan(pub), (const uint8_t*)buf, strlen(buf), &options);
     }
 
     z_undeclare_publisher(z_move(pub));
 
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_pub [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEYEXPR> (optional, string, default='%s'): The key expression to write to\n\
+        -v <VALUE> (optional, string, default='%s'): The value to write\n\
+        --add-matching-listener (optional): Add matching listener\n",
+        DEFAULT_KEYEXPR, DEFAULT_VALUE);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    char* arg = parse_opt(argc, argv, "add-matching-listener", false);
+    bool add_matching_listener = false;
+    if (arg) {
+        add_matching_listener = true;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr, .value = value, .add_matching_listener = add_matching_listener};
 }

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -14,25 +14,21 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *keyexpr = "demo/example/zenoh-c-pub";
-    char *value = "Pub from C!";
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-pub"
+#define DEFAULT_VALUE "Pub from C!"
 
-    if (argc > 1) keyexpr = argv[1];
-    if (argc > 2) value = argv[2];
+struct args_t {
+    char* keyexpr;  // -k
+    char* value;    // -v
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 3) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
@@ -41,8 +37,8 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Declaring Publisher on '%s'...\n", keyexpr);
-    z_owned_publisher_t pub = z_declare_publisher(z_loan(s), z_keyexpr(keyexpr), NULL);
+    printf("Declaring Publisher on '%s'...\n", args.keyexpr);
+    z_owned_publisher_t pub = z_declare_publisher(z_loan(s), z_keyexpr(args.keyexpr), NULL);
     if (!z_check(pub)) {
         printf("Unable to declare Publisher for key expression!\n");
         exit(-1);
@@ -70,9 +66,9 @@ int main(int argc, char **argv) {
         sprintf(buf_ind, "%d", idx);
         z_bytes_map_insert_by_alias(&map, z_bytes_from_str("index"), z_bytes_from_str(buf_ind));
 
-        sprintf(buf, "[%4d] %s", idx, value);
-        printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
-        z_publisher_put(z_loan(pub), (const uint8_t *)buf, strlen(buf), &options);
+        sprintf(buf, "[%4d] %s", idx, args.value);
+        printf("Putting Data ('%s': '%s')...\n", args.keyexpr, buf);
+        z_publisher_put(z_loan(pub), (const uint8_t*)buf, strlen(buf), &options);
     }
 
     z_undeclare_publisher(z_move(pub));
@@ -81,4 +77,45 @@ int main(int argc, char **argv) {
     z_drop(z_move(map));
 
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_pub_attachement [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEYEXPR> (optional, string, default='%s'): The key expression to write to\n\
+        -v <VALUE> (optional, string, default='%s'): The value to write\n",
+        DEFAULT_KEYEXPR, DEFAULT_VALUE);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr, .value = value};
 }

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -118,5 +118,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr, .value = value};
 }

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -115,6 +115,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr, .value = value};

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -60,6 +60,7 @@ int main(int argc, char **argv) {
     // add some value
     z_bytes_map_insert_by_alias(&map, z_bytes_from_str("source"), z_bytes_from_str("C"));
 
+    printf("Press CTRL-C to quit...\n");
     char buf[256];
     char buf_ind[16];
     for (int idx = 0; 1; ++idx) {

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -98,16 +98,16 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
-    char* value = parse_opt(argc, argv, "v", true);
+    const char* value = parse_opt(argc, argv, "v", true);
     if (!value) {
         value = DEFAULT_VALUE;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -119,5 +119,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr, .value = value};
+    return (struct args_t){.keyexpr = (char*)keyexpr, .value = (char*)value};
 }

--- a/examples/z_pub_cache.c
+++ b/examples/z_pub_cache.c
@@ -14,25 +14,23 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *keyexpr = "demo/example/zenoh-c-pub";
-    char *value = "Pub from C!";
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-pub"
+#define DEFAULT_VALUE "Pub from C!"
+#define DEFAULT_HISTORY 1
 
-    if (argc > 1) keyexpr = argv[1];
-    if (argc > 2) value = argv[2];
+struct args_t {
+    char* keyexpr;         // -k
+    char* value;           // -v
+    unsigned int history;  // -i
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 3) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     if (zc_config_insert_json(z_loan(config), Z_CONFIG_ADD_TIMESTAMP_KEY, "true") < 0) {
         printf("Unable to configure timestamps!\n");
@@ -47,12 +45,12 @@ int main(int argc, char **argv) {
     }
 
     ze_publication_cache_options_t pub_cache_opts = ze_publication_cache_options_default();
-    pub_cache_opts.history = 42;
+    pub_cache_opts.history = args.history;
     pub_cache_opts.queryable_complete = false;
 
-    printf("Declaring publication cache on '%s'...\n", keyexpr);
+    printf("Declaring publication cache on '%s'...\n", args.keyexpr);
     ze_owned_publication_cache_t pub_cache =
-        ze_declare_publication_cache(z_loan(s), z_keyexpr(keyexpr), &pub_cache_opts);
+        ze_declare_publication_cache(z_loan(s), z_keyexpr(args.keyexpr), &pub_cache_opts);
     if (!z_check(pub_cache)) {
         printf("Unable to declare publication cache for key expression!\n");
         exit(-1);
@@ -62,13 +60,60 @@ int main(int argc, char **argv) {
     char buf[256];
     for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);
-        sprintf(buf, "[%4d] %s", idx, value);
-        printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
-        z_put(z_loan(s), z_keyexpr(keyexpr), (const uint8_t *)buf, strlen(buf), NULL);
+        sprintf(buf, "[%4d] %s", idx, args.value);
+        printf("Putting Data ('%s': '%s')...\n", args.keyexpr, buf);
+        z_put(z_loan(s), z_keyexpr(args.keyexpr), (const uint8_t*)buf, strlen(buf), NULL);
     }
 
     z_drop(z_move(pub_cache));
     z_close(z_move(s));
 
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_pub_cache [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEYEXPR> (optional, string, default='%s'): The key expression to write to\n\
+        -v <VALUE> (optional, string, default='%s'): The value to write\n\
+        -i <HISTORY> (optional, int, default='%d'): The number of publications to keep in cache\n",
+        DEFAULT_KEYEXPR, DEFAULT_VALUE, DEFAULT_HISTORY);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    char* arg = parse_opt(argc, argv, "i", true);
+    unsigned int history = DEFAULT_HISTORY;
+    if (arg) {
+        history = atoi(arg);
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr, .value = value, .history = history};
 }

--- a/examples/z_pub_cache.c
+++ b/examples/z_pub_cache.c
@@ -116,5 +116,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr, .value = value, .history = history};
 }

--- a/examples/z_pub_cache.c
+++ b/examples/z_pub_cache.c
@@ -91,15 +91,15 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
-    char* value = parse_opt(argc, argv, "v", true);
+    const char* value = parse_opt(argc, argv, "v", true);
     if (!value) {
         value = DEFAULT_VALUE;
     }
-    char* arg = parse_opt(argc, argv, "i", true);
+    const char* arg = parse_opt(argc, argv, "i", true);
     unsigned int history = DEFAULT_HISTORY;
     if (arg) {
         history = atoi(arg);
@@ -117,5 +117,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr, .value = value, .history = history};
+    return (struct args_t){.keyexpr = (char*)keyexpr, .value = (char*)value, .history = history};
 }

--- a/examples/z_pub_cache.c
+++ b/examples/z_pub_cache.c
@@ -58,6 +58,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
+    printf("Press CTRL-C to quit...\n");
     char buf[256];
     for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);

--- a/examples/z_pub_cache.c
+++ b/examples/z_pub_cache.c
@@ -113,6 +113,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr, .value = value, .history = history};

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -126,6 +126,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr, .value = value};

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -64,6 +64,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
+    printf("Press CTRL-C to quit...\n");
     for (int idx = 0; true; ++idx) {
         zc_owned_shmbuf_t shmbuf = zc_shm_alloc(&manager, 256);
         if (!z_check(shmbuf)) {

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -109,16 +109,16 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
-    char* value = parse_opt(argc, argv, "v", true);
+    const char* value = parse_opt(argc, argv, "v", true);
     if (!value) {
         value = DEFAULT_VALUE;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -130,5 +130,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr, .value = value};
+    return (struct args_t){.keyexpr = (char*)keyexpr, .value = (char*)value};
 }

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -129,5 +129,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr, .value = value};
 }

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -73,7 +73,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(1);
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -14,29 +14,21 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    if (argc < 2) {
-        printf("USAGE:\n\tz_pub_thr <payload-size> [<zenoh-locator>]\n\n");
-        exit(-1);
-    }
+struct args_t {
+    unsigned int size;  // positional_1
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
-    char *keyexpr = "test/thr";
-    size_t len = atoi(argv[1]);
-    uint8_t *value = (uint8_t *)z_malloc(len);
-    memset(value, 1, len);
+int main(int argc, char** argv) {
+    char* keyexpr = "test/thr";
 
     z_owned_config_t config = z_config_default();
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
+    uint8_t* value = (uint8_t*)z_malloc(args.size);
+    memset(value, 1, args.size);
 
     z_owned_session_t s = z_open(z_move(config));
     if (!z_check(s)) {
@@ -55,9 +47,46 @@ int main(int argc, char **argv) {
 
     printf("Press CTRL-C to quit...\n");
     while (1) {
-        z_publisher_put(z_loan(pub), (const uint8_t *)value, len, NULL);
+        z_publisher_put(z_loan(pub), (const uint8_t*)value, args.size, NULL);
     }
 
     z_undeclare_publisher(z_move(pub));
     z_close(z_move(s));
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_pub_thr [OPTIONS] <PAYLOAD_SIZE>\n\n\
+    Arguments:\n\
+        <PAYLOAD_SIZE> (required, int): Size of the payload to publish\n\n\
+    Options:\n");
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args) {
+        printf("Unexpected additional positional arguments\n");
+        exit(-1);
+    }
+    if (!pos_args[0]) {
+        printf("<PAYLOAD_SIZE> argument is required\n");
+        exit(-1);
+    }
+    unsigned int size = atoi(pos_args[0]);
+    return (struct args_t){.size = size};
 }

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -53,6 +53,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
+    printf("Press CTRL-C to quit...\n");
     while (1) {
         z_publisher_put(z_loan(pub), (const uint8_t *)value, len, NULL);
     }

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -85,8 +85,10 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     }
     if (!pos_args[0]) {
         printf("<PAYLOAD_SIZE> argument is required\n");
+        free(pos_args);
         exit(-1);
     }
     unsigned int size = atoi(pos_args[0]);
+    free(pos_args);
     return (struct args_t){.size = size};
 }

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -106,6 +106,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr};

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -93,12 +93,12 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -110,5 +110,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr};
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -12,33 +12,29 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 #include <stdio.h>
+
+#include "parse_args.h"
 #include "zenoh.h"
 
-const char *kind_to_str(z_sample_kind_t kind);
+#define DEFAULT_KEYEXPR "demo/example/**"
 
-void data_handler(const z_sample_t *sample, void *arg) {
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+const char* kind_to_str(z_sample_kind_t kind);
+
+void data_handler(const z_sample_t* sample, void* arg) {
     z_owned_str_t keystr = z_keyexpr_to_string(sample->keyexpr);
     printf(">> [Subscriber] Received %s ('%s': '%.*s')\n", kind_to_str(sample->kind), z_loan(keystr),
            (int)sample->payload.len, sample->payload.start);
     z_drop(z_move(keystr));
 }
 
-int main(int argc, char **argv) {
-    char *expr = "demo/example/**";
-    if (argc > 1) {
-        expr = argv[1];
-    }
-
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
@@ -48,15 +44,16 @@ int main(int argc, char **argv) {
     }
 
     z_owned_closure_sample_t callback = z_closure(data_handler);
-    printf("Declaring Subscriber on '%s'...\n", expr);
-    z_owned_pull_subscriber_t sub = z_declare_pull_subscriber(z_loan(s), z_keyexpr(expr), z_move(callback), NULL);
+    printf("Declaring Subscriber on '%s'...\n", args.keyexpr);
+    z_owned_pull_subscriber_t sub =
+        z_declare_pull_subscriber(z_loan(s), z_keyexpr(args.keyexpr), z_move(callback), NULL);
     if (!z_check(sub)) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }
 
     printf("Press CTRL-C to quit...\n");
-    for (int idx=0; 1; ++idx) {
+    for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);
         printf("[%4d] Pulling...\n", idx);
         z_subscriber_pull(z_loan(sub));
@@ -67,7 +64,7 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-const char *kind_to_str(z_sample_kind_t kind) {
+const char* kind_to_str(z_sample_kind_t kind) {
     switch (kind) {
         case Z_SAMPLE_KIND_PUT:
             return "PUT";
@@ -76,4 +73,40 @@ const char *kind_to_str(z_sample_kind_t kind) {
         default:
             return "UNKNOWN";
     }
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_pull [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression to subscribe to\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -55,15 +55,11 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Press <enter> to pull data...\n");
-    char c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            z_sleep_s(1);
-        } else {
-            z_subscriber_pull(z_loan(sub));
-        }
+    printf("Press CTRL-C to quit...\n");
+    for (int idx=0; 1; ++idx) {
+        z_sleep_s(1);
+        printf("[%4d] Pulling...\n", idx);
+        z_subscriber_pull(z_loan(sub));
     }
 
     z_undeclare_pull_subscriber(z_move(sub));

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -109,5 +109,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -93,5 +93,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr, .value = value};
 }

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -73,16 +73,16 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
-    char* value = parse_opt(argc, argv, "v", true);
+    const char* value = parse_opt(argc, argv, "v", true);
     if (!value) {
         value = DEFAULT_VALUE;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -94,5 +94,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr, .value = value};
+    return (struct args_t){.keyexpr = (char*)keyexpr, .value = (char*)value};
 }

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -90,6 +90,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr, .value = value};

--- a/examples/z_query_sub.c
+++ b/examples/z_query_sub.c
@@ -106,6 +106,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr};

--- a/examples/z_query_sub.c
+++ b/examples/z_query_sub.c
@@ -93,12 +93,12 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -110,5 +110,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr};
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_query_sub.c
+++ b/examples/z_query_sub.c
@@ -12,33 +12,29 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 #include <stdio.h>
+
+#include "parse_args.h"
 #include "zenoh.h"
 
-const char *kind_to_str(z_sample_kind_t kind);
+#define DEFAULT_KEYEXPR "demo/example/**"
 
-void data_handler(const z_sample_t *sample, void *arg) {
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+const char* kind_to_str(z_sample_kind_t kind);
+
+void data_handler(const z_sample_t* sample, void* arg) {
     z_owned_str_t keystr = z_keyexpr_to_string(sample->keyexpr);
     printf(">> [Subscriber] Received %s ('%s': '%.*s')\n", kind_to_str(sample->kind), z_loan(keystr),
            (int)sample->payload.len, sample->payload.start);
     z_drop(z_move(keystr));
 }
 
-int main(int argc, char **argv) {
-    char *expr = "demo/example/**";
-    if (argc > 1) {
-        expr = argv[1];
-    }
-
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
@@ -49,9 +45,9 @@ int main(int argc, char **argv) {
 
     ze_querying_subscriber_options_t sub_opts = ze_querying_subscriber_options_default();
     z_owned_closure_sample_t callback = z_closure(data_handler);
-    printf("Declaring querying subscriber on '%s'...\n", expr);
+    printf("Declaring querying subscriber on '%s'...\n", args.keyexpr);
     ze_owned_querying_subscriber_t sub =
-        ze_declare_querying_subscriber(z_loan(s), z_keyexpr(expr), z_move(callback), &sub_opts);
+        ze_declare_querying_subscriber(z_loan(s), z_keyexpr(args.keyexpr), z_move(callback), &sub_opts);
     if (!z_check(sub)) {
         printf("Unable to declare querying subscriber.\n");
         exit(-1);
@@ -68,7 +64,7 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-const char *kind_to_str(z_sample_kind_t kind) {
+const char* kind_to_str(z_sample_kind_t kind) {
     switch (kind) {
         case Z_SAMPLE_KIND_PUT:
             return "PUT";
@@ -77,4 +73,40 @@ const char *kind_to_str(z_sample_kind_t kind) {
         default:
             return "UNKNOWN";
     }
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_query_sub [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression to subscribe to\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_query_sub.c
+++ b/examples/z_query_sub.c
@@ -109,5 +109,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_query_sub.c
+++ b/examples/z_query_sub.c
@@ -57,13 +57,9 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Enter 'q' to quit...\n");
-    char c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            z_sleep_s(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
     z_drop(z_move(sub));

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -118,5 +118,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr, .value = value};
 }

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -70,13 +70,9 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Enter 'q' to quit...\n");
-    char c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            z_sleep_s(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
     z_undeclare_queryable(z_move(qable));

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -13,13 +13,22 @@
 
 #include <stdio.h>
 #include <string.h>
+
+#include "parse_args.h"
 #include "zenoh.h"
 
-const char *expr = "demo/example/zenoh-c-queryable";
-const char *value = "Queryable from C!";
-z_keyexpr_t keyexpr;
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-queryable"
+#define DEFAULT_VALUE "Queryable from C!"
 
-void query_handler(const z_query_t *query, void *context) {
+char* value = NULL;
+
+struct args_t {
+    char* keyexpr;  // -k
+    char* value;    // -v
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+void query_handler(const z_query_t* query, void* context) {
     z_owned_str_t keystr = z_keyexpr_to_string(z_query_keyexpr(query));
     z_bytes_t pred = z_query_parameters(query);
     z_value_t payload_value = z_query_value(query);
@@ -31,24 +40,14 @@ void query_handler(const z_query_t *query, void *context) {
     }
     z_query_reply_options_t options = z_query_reply_options_default();
     options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);
-    z_query_reply(query, z_keyexpr((const char *)context), (const unsigned char *)value, strlen(value), &options);
+    z_query_reply(query, z_keyexpr((const char*)context), (const unsigned char*)value, strlen(value), &options);
     z_drop(z_move(keystr));
 }
 
-int main(int argc, char **argv) {
-    if (argc > 1) {
-        expr = argv[1];
-    }
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
+    value = args.value;
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
@@ -56,14 +55,14 @@ int main(int argc, char **argv) {
         printf("Unable to open session!\n");
         exit(-1);
     }
-    keyexpr = z_keyexpr(expr);
+    z_keyexpr_t keyexpr = z_keyexpr(args.keyexpr);
     if (!z_check(keyexpr)) {
-        printf("%s is not a valid key expression", expr);
+        printf("%s is not a valid key expression", args.keyexpr);
         exit(-1);
     }
 
-    printf("Declaring Queryable on '%s'...\n", expr);
-    z_owned_closure_query_t callback = z_closure(query_handler, NULL, expr);
+    printf("Declaring Queryable on '%s'...\n", args.keyexpr);
+    z_owned_closure_query_t callback = z_closure(query_handler, NULL, args.keyexpr);
     z_owned_queryable_t qable = z_declare_queryable(z_loan(s), keyexpr, z_move(callback), NULL);
     if (!z_check(qable)) {
         printf("Unable to create queryable.\n");
@@ -78,4 +77,45 @@ int main(int argc, char **argv) {
     z_undeclare_queryable(z_move(qable));
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_queryable [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEYEXPR> (optional, string, default='%s'): The key expression matching queries to reply to\n\
+        -v <VALUE> (optional, string, default='%s'): The value to reply to queries with\n",
+        DEFAULT_KEYEXPR, DEFAULT_VALUE);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr, .value = value};
 }

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -115,6 +115,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr, .value = value};

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -98,16 +98,16 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
-    char* value = parse_opt(argc, argv, "v", true);
+    const char* value = parse_opt(argc, argv, "v", true);
     if (!value) {
         value = DEFAULT_VALUE;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -119,5 +119,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr, .value = value};
+    return (struct args_t){.keyexpr = (char*)keyexpr, .value = (char*)value};
 }

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -103,16 +103,16 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
-    char* value = parse_opt(argc, argv, "v", true);
+    const char* value = parse_opt(argc, argv, "v", true);
     if (!value) {
         value = DEFAULT_VALUE;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -124,5 +124,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr, .value = value};
+    return (struct args_t){.keyexpr = (char*)keyexpr, .value = (char*)value};
 }

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("^C to quit...\n");
+    printf("Press CTRL-C to quit...\n");
     z_owned_query_t oquery = z_query_null();
     for (z_call(channel.recv, &oquery); z_check(oquery); z_call(channel.recv, &oquery)) {
         z_query_t query = z_loan(oquery);

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -120,6 +120,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr, .value = value};

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -123,5 +123,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr, .value = value};
 }

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -14,32 +14,28 @@
 #include <stdio.h>
 #include <string.h>
 #include <zenoh_macros.h>
+
+#include "parse_args.h"
 #include "zenoh.h"
 
-const char *expr = "demo/example/zenoh-c-queryable";
-const char *value = "Queryable from C!";
-z_keyexpr_t keyexpr;
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-queryable"
+#define DEFAULT_VALUE "Queryable from C!"
 
-void query_handler(const z_query_t *query, void *context) {
-    z_owned_closure_owned_query_t *channel = (z_owned_closure_owned_query_t *)context;
+struct args_t {
+    char* keyexpr;  // -k
+    char* value;    // -v
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+void query_handler(const z_query_t* query, void* context) {
+    z_owned_closure_owned_query_t* channel = (z_owned_closure_owned_query_t*)context;
     z_owned_query_t oquery = z_query_clone(query);
     z_call(*channel, &oquery);
 }
 
-int main(int argc, char **argv) {
-    if (argc > 1) {
-        expr = argv[1];
-    }
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
@@ -47,13 +43,13 @@ int main(int argc, char **argv) {
         printf("Unable to open session!\n");
         exit(-1);
     }
-    keyexpr = z_keyexpr(expr);
+    z_keyexpr_t keyexpr = z_keyexpr(args.keyexpr);
     if (!z_check(keyexpr)) {
-        printf("%s is not a valid key expression", expr);
+        printf("%s is not a valid key expression", args.keyexpr);
         exit(-1);
     }
 
-    printf("Declaring Queryable on '%s'...\n", expr);
+    printf("Declaring Queryable on '%s'...\n", args.keyexpr);
     z_owned_query_channel_t channel = zc_query_fifo_new(16);
     z_owned_closure_query_t callback = z_closure(query_handler, NULL, &channel.send);
     z_owned_queryable_t qable = z_declare_queryable(z_loan(s), keyexpr, z_move(callback), NULL);
@@ -77,7 +73,7 @@ int main(int argc, char **argv) {
         }
         z_query_reply_options_t options = z_query_reply_options_default();
         options.encoding = z_encoding(Z_ENCODING_PREFIX_TEXT_PLAIN, NULL);
-        z_query_reply(&query, keyexpr, (const unsigned char *)value, strlen(value), &options);
+        z_query_reply(&query, keyexpr, (const unsigned char*)args.value, strlen(args.value), &options);
         z_drop(z_move(keystr));
         z_drop(z_move(oquery));
     }
@@ -86,4 +82,45 @@ int main(int argc, char **argv) {
     z_drop(z_move(channel));
     z_drop(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_queryable_with_channels [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEYEXPR> (optional, string, default='%s'): The key expression matching queries to reply to\n\
+        -v <VALUE> (optional, string, default='%s'): The value to reply to queries with\n",
+        DEFAULT_KEYEXPR, DEFAULT_VALUE);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr, .value = value};
 }

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -98,12 +98,12 @@ struct args_t parse_args(int argc, char **argv, z_owned_config_t *config) {
         print_help();
         exit(1);
     }
-    char *keyexpr = parse_opt(argc, argv, "k", true);
+    const char *keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char *arg = check_unknown_opts(argc, argv);
+    const char *arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -115,5 +115,5 @@ struct args_t parse_args(int argc, char **argv, z_owned_config_t *config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr};
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -62,13 +62,9 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Enter 'q' to quit...\n");
-    char c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            z_sleep_s(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
     z_undeclare_subscriber(z_move(sub));

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -111,6 +111,7 @@ struct args_t parse_args(int argc, char **argv, z_owned_config_t *config) {
     char **pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr};

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -114,5 +114,6 @@ struct args_t parse_args(int argc, char **argv, z_owned_config_t *config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -12,7 +12,16 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 #include <stdio.h>
+
+#include "parse_args.h"
 #include "zenoh.h"
+
+#define DEFAULT_KEYEXPR "demo/example/**"
+
+struct args_t {
+    char *keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char **argv, z_owned_config_t *config);
 
 const char *kind_to_str(z_sample_kind_t kind);
 
@@ -24,21 +33,9 @@ void data_handler(const z_sample_t *sample, void *arg) {
 }
 
 int main(int argc, char **argv) {
-    char *expr = "demo/example/**";
-    if (argc > 1) {
-        expr = argv[1];
-    }
-
     z_owned_config_t config = z_config_default();
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
+
     // A probing procedure for shared memory is performed upon session opening. To enable `z_pub_shm` to operate
     // over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
     // subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
@@ -55,8 +52,8 @@ int main(int argc, char **argv) {
     }
 
     z_owned_closure_sample_t callback = z_closure(data_handler);
-    printf("Declaring Subscriber on '%s'...\n", expr);
-    z_owned_subscriber_t sub = z_declare_subscriber(z_loan(s), z_keyexpr(expr), z_move(callback), NULL);
+    printf("Declaring Subscriber on '%s'...\n", args.keyexpr);
+    z_owned_subscriber_t sub = z_declare_subscriber(z_loan(s), z_keyexpr(args.keyexpr), z_move(callback), NULL);
     if (!z_check(sub)) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
@@ -81,4 +78,40 @@ const char *kind_to_str(z_sample_kind_t kind) {
         default:
             return "UNKNOWN";
     }
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_sub [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression to subscribe to\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char **argv, z_owned_config_t *config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char *keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char *arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char **pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -124,5 +124,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -13,16 +13,25 @@
 //
 #include <stdint.h>
 #include <stdio.h>
+
+#include "parse_args.h"
 #include "zenoh.h"
 
-const char *kind_to_str(z_sample_kind_t kind);
+#define DEFAULT_KEYEXPR "demo/example/**"
 
-int8_t attachment_reader(z_bytes_t key, z_bytes_t val, void *ctx) {
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+const char* kind_to_str(z_sample_kind_t kind);
+
+int8_t attachment_reader(z_bytes_t key, z_bytes_t val, void* ctx) {
     printf("   attachment: %.*s: '%.*s'\n", (int)key.len, key.start, (int)val.len, val.start);
     return 0;
 }
 
-void data_handler(const z_sample_t *sample, void *arg) {
+void data_handler(const z_sample_t* sample, void* arg) {
     z_owned_str_t keystr = z_keyexpr_to_string(sample->keyexpr);
     printf(">> [Subscriber] Received %s ('%s': '%.*s')\n", kind_to_str(sample->kind), z_loan(keystr),
            (int)sample->payload.len, sample->payload.start);
@@ -41,22 +50,9 @@ void data_handler(const z_sample_t *sample, void *arg) {
     z_drop(z_move(keystr));
 }
 
-int main(int argc, char **argv) {
-    char *expr = "demo/example/**";
-    if (argc > 1) {
-        expr = argv[1];
-    }
-
+int main(int argc, char** argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_LISTEN_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s = z_open(z_move(config));
@@ -66,8 +62,8 @@ int main(int argc, char **argv) {
     }
 
     z_owned_closure_sample_t callback = z_closure(data_handler);
-    printf("Declaring Subscriber on '%s'...\n", expr);
-    z_owned_subscriber_t sub = z_declare_subscriber(z_loan(s), z_keyexpr(expr), z_move(callback), NULL);
+    printf("Declaring Subscriber on '%s'...\n", args.keyexpr);
+    z_owned_subscriber_t sub = z_declare_subscriber(z_loan(s), z_keyexpr(args.keyexpr), z_move(callback), NULL);
     if (!z_check(sub)) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
@@ -83,7 +79,7 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-const char *kind_to_str(z_sample_kind_t kind) {
+const char* kind_to_str(z_sample_kind_t kind) {
     switch (kind) {
         case Z_SAMPLE_KIND_PUT:
             return "PUT";
@@ -92,4 +88,40 @@ const char *kind_to_str(z_sample_kind_t kind) {
         default:
             return "UNKNOWN";
     }
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_sub_attachement [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression to subscribe to\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
+    return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -73,13 +73,9 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Enter 'q' to quit...\n");
-    char c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            z_sleep_s(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
     z_undeclare_subscriber(z_move(sub));

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -121,6 +121,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr};

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -108,12 +108,12 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -125,5 +125,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr};
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_sub_liveliness.c
+++ b/examples/z_sub_liveliness.c
@@ -102,6 +102,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     char** pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
     return (struct args_t){.keyexpr = keyexpr};

--- a/examples/z_sub_liveliness.c
+++ b/examples/z_sub_liveliness.c
@@ -65,13 +65,9 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Enter 'q' to quit...\n");
-    char c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            z_sleep_s(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
     z_undeclare_subscriber(z_move(sub));

--- a/examples/z_sub_liveliness.c
+++ b/examples/z_sub_liveliness.c
@@ -89,12 +89,12 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         print_help();
         exit(1);
     }
-    char* keyexpr = parse_opt(argc, argv, "k", true);
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
     if (!keyexpr) {
         keyexpr = DEFAULT_KEYEXPR;
     }
     parse_zenoh_common_args(argc, argv, config);
-    char* arg = check_unknown_opts(argc, argv);
+    const char* arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);
@@ -106,5 +106,5 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         exit(-1);
     }
     free(pos_args);
-    return (struct args_t){.keyexpr = keyexpr};
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_sub_liveliness.c
+++ b/examples/z_sub_liveliness.c
@@ -105,5 +105,6 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
     return (struct args_t){.keyexpr = keyexpr};
 }

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -110,7 +110,7 @@ void parse_args(int argc, char **argv, z_owned_config_t *config) {
         exit(1);
     }
     parse_zenoh_common_args(argc, argv, config);
-    char *arg = check_unknown_opts(argc, argv);
+    const char *arg = check_unknown_opts(argc, argv);
     if (arg) {
         printf("Unknown option %s\n", arg);
         exit(-1);

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -87,9 +87,9 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    char c = 0;
-    while (c != 'q') {
-        c = fgetc(stdin);
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
     z_undeclare_subscriber(z_move(sub));

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -118,6 +118,7 @@ void parse_args(int argc, char **argv, z_owned_config_t *config) {
     char **pos_args = parse_pos_args(argc, argv, 1);
     if (!pos_args || pos_args[0]) {
         printf("Unexpected positional arguments\n");
+        free(pos_args);
         exit(-1);
     }
 }

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -121,4 +121,5 @@ void parse_args(int argc, char **argv, z_owned_config_t *config) {
         free(pos_args);
         exit(-1);
     }
+    free(pos_args);
 }

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -13,9 +13,12 @@
 //
 #include <stdio.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
 #define N 1000000
+
+void parse_args(int argc, char **argv, z_owned_config_t *config);
 
 typedef struct {
     volatile unsigned long count;
@@ -61,15 +64,7 @@ void drop_stats(void *context) {
 
 int main(int argc, char **argv) {
     z_owned_config_t config = z_config_default();
-    if (argc > 1) {
-        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[1], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    parse_args(argc, argv, &config);
 
     z_owned_session_t s = z_open(z_move(config));
     if (!z_check(s)) {
@@ -96,4 +91,33 @@ int main(int argc, char **argv) {
     z_undeclare_keyexpr(z_loan(s), z_move(ke));
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_sub_thr [OPTIONS]\n\n\
+    Options:\n");
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+void parse_args(int argc, char **argv, z_owned_config_t *config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    char *arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char **pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        exit(-1);
+    }
 }


### PR DESCRIPTION
These changes remove reading from stdin for all examples, and align their behaviors and outputs across projects.

This PR is part of an effort across currently active Zenoh projects. To maintain examples' implementations as close to each other as possible, any changes identified in other projects will be replicated in this PR. As such, **please do not merge these changes until all PRs are ready for merging**.

Related PRs:
- https://github.com/eclipse-zenoh/zenoh/pull/768
- https://github.com/eclipse-zenoh/zenoh-cpp/pull/103
- https://github.com/eclipse-zenoh/zenoh-java/pull/45
- https://github.com/eclipse-zenoh/zenoh-kotlin/pull/47
- https://github.com/eclipse-zenoh/zenoh-pico/pull/359
- https://github.com/eclipse-zenoh/zenoh-python/pull/150