### PR TITLE
add z_(owned_)keyexpr_t autocanonize initializers

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -106,6 +106,7 @@ Key expression
 .. autocstruct:: zenoh_commons.h::z_owned_keyexpr_t
 
 .. autocfunction:: zenoh_commons.h::z_keyexpr
+.. autocfunction:: zenoh_commons.h::z_keyexpr_autocanonize
 .. autocfunction:: zenoh_commons.h::z_keyexpr_unchecked
 .. autocfunction:: zenoh_commons.h::z_keyexpr_to_string
 .. autocfunction:: zenoh_commons.h::z_keyexpr_as_bytes
@@ -120,6 +121,7 @@ Key expression
 .. autocfunction:: zenoh_commons.h::z_keyexpr_intersects
 
 .. autocfunction:: zenoh_commons.h::z_keyexpr_new
+.. autocfunction:: zenoh_commons.h::z_keyexpr_new_autocanonize
 .. autocfunction:: zenoh_commons.h::z_keyexpr_loan
 .. autocfunction:: zenoh_commons.h::z_keyexpr_check
 .. autocfunction:: zenoh_commons.h::z_keyexpr_drop

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1552,6 +1552,14 @@ ZENOHC_API struct z_keyexpr_t z_keyexpr(const char *name);
  */
 ZENOHC_API struct z_bytes_t z_keyexpr_as_bytes(struct z_keyexpr_t keyexpr);
 /**
+ * Constructs a :c:type:`z_keyexpr_t` departing from a string.
+ * It is a loaned key expression that aliases `name`.
+ * The string is canonized in-place before being passed to keyexpr.
+ * May SEGFAULT if `start` is NULL or lies in read-only memory (as values initialized with string litterals do).
+ */
+ZENOHC_API
+struct z_keyexpr_t z_keyexpr_autocanonize(char *name);
+/**
  * Canonizes the passed string in place, possibly shortening it by modifying `len`.
  *
  * Returns ``0`` upon success, negative values upon failure.
@@ -1639,6 +1647,11 @@ ZENOHC_API struct z_keyexpr_t z_keyexpr_loan(const struct z_owned_keyexpr_t *key
  * Constructs a :c:type:`z_keyexpr_t` departing from a string, copying the passed string.
  */
 ZENOHC_API struct z_owned_keyexpr_t z_keyexpr_new(const char *name);
+/**
+ * Constructs a :c:type:`z_keyexpr_t` departing from a string, copying the passed string. The copied string is canonized.
+ */
+ZENOHC_API
+struct z_owned_keyexpr_t z_keyexpr_new_autocanonize(const char *name);
 /**
  * Constructs a null safe-to-drop value of 'z_owned_keyexpr_t' type
  */
@@ -2174,6 +2187,15 @@ ZENOHC_API void zc_init_logger(void);
  * It is a loaned key expression that aliases `name`.
  */
 ZENOHC_API struct z_keyexpr_t zc_keyexpr_from_slice(const char *name, size_t len);
+/**
+ * Constructs a :c:type:`z_keyexpr_t` departing from a string.
+ * It is a loaned key expression that aliases `name`.
+ * The string is canonized in-place before being passed to keyexpr.
+ * May SEGFAULT if `start` is NULL or lies in read-only memory (as values initialized with string litterals do).
+ */
+ZENOHC_API
+struct z_keyexpr_t zc_keyexpr_from_slice_autocanonize(char *name,
+                                                      size_t *len);
 /**
  * Constructs a :c:type:`z_keyexpr_t` departing from a string without checking any of `z_keyexpr_t`'s assertions:
  * - `name` MUST be valid UTF8.

--- a/tests/z_api_keyexpr_test.c
+++ b/tests/z_api_keyexpr_test.c
@@ -41,6 +41,22 @@ void canonize() {
     printf("'%s', err = %d\n", keyexpr, err);
     assert(err == 0);
     assert(strcmp(keyexpr, "a/**/c") == 0);
+
+    strcpy(keyexpr, "a/**/**/c");
+    z_keyexpr_t key_expr_canonized = z_keyexpr_autocanonize(keyexpr);
+    assert(z_keyexpr_check(keyexpr) == true);
+    assert(strcmp(keyexpr, "a/**/c") == 0);
+    assert(z_keyexpr_as_bytes(key_expr_canonized).len == len_new);
+    assert(strncmp(z_keyexpr_as_bytes(key_expr_canonized).start, "a/**/c", len_new) == 0);
+
+    strcpy(keyexpr, "a/**/**/c");
+    len_new = len_old;
+    key_expr_canonized = zc_keyexpr_from_slice_autocanonize(keyexpr, &len_new);
+    assert(z_keyexpr_check(keyexpr) == true);
+    assert(len_new == len_old - 3);
+    assert(strncmp(keyexpr, "a/**/c", len_new) == 0);
+    assert(z_keyexpr_as_bytes(key_expr_canonized).len == len_new);
+    assert(strncmp(z_keyexpr_as_bytes(key_expr_canonized).start, "a/**/c", len_new) == 0);
 }
 
 void includes() {


### PR DESCRIPTION
add z_(owned_)keyexpr_t autocanonize initializers. Closes #267. 