### PR TITLE
Rust 1.77 toolchain - Fix alignment and layout for z_owned_reply_t

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -346,8 +346,8 @@ typedef struct z_owned_closure_query_t {
  * To check if `val` is still valid, you may use `z_X_check(&val)` (or `z_check(val)` if your compiler supports `_Generic`), which will return `true` if `val` is valid.
  */
 #if defined(TARGET_ARCH_X86_64)
-typedef struct ALIGN(8) z_owned_reply_t {
-  uint64_t _0[28];
+typedef struct ALIGN(16) z_owned_reply_t {
+  uint64_t _0[30];
 } z_owned_reply_t;
 #endif
 #if defined(TARGET_ARCH_AARCH64)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.72.0"
+channel = "1.77.0"

--- a/src/get.rs
+++ b/src/get.rs
@@ -49,8 +49,8 @@ type ReplyInner = Option<Reply>;
 ///
 /// To check if `val` is still valid, you may use `z_X_check(&val)` (or `z_check(val)` if your compiler supports `_Generic`), which will return `true` if `val` is valid.
 #[cfg(target_arch = "x86_64")]
-#[repr(C, align(8))]
-pub struct z_owned_reply_t([u64; 28]);
+#[repr(C, align(16))]
+pub struct z_owned_reply_t([u64; 30]);
 
 #[cfg(target_arch = "aarch64")]
 #[repr(C, align(16))]

--- a/src/liveliness.rs
+++ b/src/liveliness.rs
@@ -173,7 +173,7 @@ pub extern "C" fn zc_liveliness_declare_subscriber(
         return z_owned_subscriber_t::null();
     };
     let callback = core::mem::replace(callback, z_owned_closure_sample_t::empty());
-    match session
+    let res = session
         .liveliness()
         .declare_subscriber(key)
         .callback(move |sample| {
@@ -185,8 +185,8 @@ pub extern "C" fn zc_liveliness_declare_subscriber(
             let sample = z_sample_t::new(&sample, &owner);
             z_closure_sample_call(&callback, &sample)
         })
-        .res()
-    {
+        .res();
+    match res {
         Ok(token) => z_owned_subscriber_t::new(token),
         Err(e) => {
             log::error!("Failed to subscribe to liveliness: {e}");

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -202,7 +202,7 @@ pub unsafe extern "C" fn ze_declare_querying_subscriber(
                         .query_timeout(std::time::Duration::from_millis(options.query_timeout_ms));
                 }
             }
-            match sub
+            let res = sub
                 .callback(move |sample| {
                     let payload = sample.payload.contiguous();
                     let owner = match payload {
@@ -212,8 +212,8 @@ pub unsafe extern "C" fn ze_declare_querying_subscriber(
                     let sample = z_sample_t::new(&sample, &owner);
                     z_closure_sample_call(&closure, &sample)
                 })
-                .res()
-            {
+                .res();
+            match res {
                 Ok(sub) => ze_owned_querying_subscriber_t::new(sub, session),
                 Err(e) => {
                     log::debug!("{}", e);


### PR DESCRIPTION
Rust 1.77 has been released: https://releases.rs/docs/1.77.0/
Along with 1.77 it comes the following change: https://github.com/rust-lang/rust/pull/116672/

This means that `u128` have now a different alignment on `x86` targets, making the compilation of zenoh-c to fail on `x86` when compiled with Rust `1.77`.

This patch fixes the memory layout and alignment of the `z_owned_reply_t` affected by that change.

However, I suggest to not merge this PR straight away since there are projects that depend on `main` branch of zenoh-c and they will not use Rust 1.77.  E.g.: https://github.com/ros2/rmw_zenoh will use the Rust shipped version in Ubuntu 24.04, which is `1.75`.

An option could be to have different layout depending on the compiler version but this capability seems to be still unstable: https://doc.rust-lang.org/unstable-book/language-features/cfg-version.html
A larger change may be hence needed in Zenoh, particularly in the `ZenohId` type to avoid using `u128` at all.