### PR TITLE
feat: Statically link C runtime on `-musl` targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-musl]
+rustflags = "-Ctarget-feature=-crt-static"
+
+[target.aarch64-unknown-linux-musl]
+rustflags = "-Ctarget-feature=-crt-static"


### PR DESCRIPTION
[This is needed to build the `cdylib` crate type for `-musl` targets.](https://github.com/rust-lang/rust/issues/59302)