### PR TITLE
fix: Specify git remote when pushing the tag

### DIFF
--- a/ci/scripts/bump-and-tag.bash
+++ b/ci/scripts/bump-and-tag.bash
@@ -3,7 +3,7 @@
 set -xeo pipefail
 
 # Release number
-readonly version=${VERSION:-''}
+readonly version=${VERSION:?input VERSION is required}
 # Dependencies' pattern
 readonly bump_deps_pattern=${BUMP_DEPS_PATTERN:-''}
 # Dependencies' version
@@ -31,12 +31,7 @@ export GIT_COMMITTER_NAME=$git_user_name
 export GIT_COMMITTER_EMAIL=$git_user_email
 
 # Bump CMake project version
-if [[ "$version" == '' ]]; then
-  # If no version has been specified, infer it using git-describe
-  printf '%s' "$(git describe)" > version.txt
-else
-  printf '%s' "$version" > version.txt
-fi
+printf '%s' "$version" > version.txt
 # Propagate version change to Cargo.toml and Cargo.toml.in
 cmake . -DZENOHC_BUILD_IN_SOURCE_TREE=TRUE -DCMAKE_BUILD_TYPE=Release
 # Update Debian dependency of libzenohc-dev

--- a/ci/scripts/bump-and-tag.bash
+++ b/ci/scripts/bump-and-tag.bash
@@ -72,5 +72,5 @@ fi
 git tag "$version" -m "v$version"
 git log -10
 git show-ref --tags
-git push
-git push "$version"
+git push origin
+git push origin "$version"


### PR DESCRIPTION
While `git push` pushes the current branch into its remote, `git push <tag>` doesn't push the tag.