### PR TITLE
Add zenoh-c-prebuilt Conan recipe

### DIFF
--- a/conan-recipes/.gitignore
+++ b/conan-recipes/.gitignore
@@ -1,0 +1,141 @@
+# Conan specific
+**/test_package/build/
+**/test_package/build-*/
+**/test_package/test_output/
+conan.lock
+conanbuildinfo.cmake
+conanbuildinfo.txt
+conaninfo.txt
+graph_info.json
+build/
+
+# CMake
+CMakeUserPresets.json
+
+# IDEs
+.idea
+.vs
+.vscode
+.project
+.pydevproject
+.settings/
+.ropeproject/
+.devcontainer/
+## emacs
+*~
+
+# Byte-compiled / optimized / DLL files / Cache
+__pycache__/
+**/test_package/__pycache__/
+*.pyc
+*.py[cod]
+*$py.class
+tmp/
+.DS_Store
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# scons build files
+*.dblite
+
+# vim temp files
+.*.sw?
+.sw?
+Session.vim
+*~
+.undodir

--- a/conan-recipes/prebuilt/all/conandata.yml
+++ b/conan-recipes/prebuilt/all/conandata.yml
@@ -1,0 +1,29 @@
+sources:
+  "0.10.1-rc":
+    "Windows":
+      "x86_64":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/releases/download/0.10.1-rc/zenoh-c-0.10.1-rc-x86_64-pc-windows-msvc.zip"
+        sha256: "a59a4c33a160298409649f16bee5f32f14de52c03273fe29d4497934cf05789e"
+    "Linux":
+      "x86_64":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/releases/download/0.10.1-rc/zenoh-c-0.10.1-rc-x86_64-unknown-linux-gnu.zip"
+        sha256: "0554b0fe753df3c023b09e005b309d654b1cc33ddc34190b5a5c370b72281c3b"
+      "armv6":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/releases/download/0.10.1-rc/zenoh-c-0.10.1-rc-arm-unknown-linux-gnueabi.zip"
+        sha256: "ca76eccb4dae25e0571f8724e161e26230137ee6134d8452548b94de174c9cb9"
+      "armv7hf":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/releases/download/0.10.1-rc/zenoh-c-0.10.1-rc-armv7-unknown-linux-gnueabihf.zip"
+        sha256: "542099758e543abec289daeff2fcf8eef26dc997832de2f13ac7e15b0b05474f"
+      "armv8":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/releases/download/0.10.1-rc/zenoh-c-0.10.1-rc-aarch64-unknown-linux-gnu.zip"
+        sha256: "1def0f7b7d7cd04ac6583d4c7ce96c82af7f2407422a54d778f658527da0e6ea"
+    "Macos":
+      "x86_64":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/releases/download/0.10.1-rc/zenoh-c-0.10.1-rc-x86_64-apple-darwin.zip"
+        sha256: "bd44c88b8ba3d8245d97f780fe82873ed8ee87c09c37365509e2feae2a198e28"
+      "armv8":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/releases/download/0.10.1-rc/zenoh-c-0.10.1-rc-aarch64-apple-darwin.zip"
+        sha256: "0df497b16cf1bd968deea36aca43d6c086a54d69ea78e3feaed309760e0dcaa4"
+    "license":
+        url: "https://github.com/eclipse-zenoh/zenoh-c/raw/0.10.1-rc/LICENSE"
+        sha256: "01a44774f7b1a453595c7c6d7f7308284ba6a1059dc49e14dad6647e1d44a338"

--- a/conan-recipes/prebuilt/all/conanfile.py
+++ b/conan-recipes/prebuilt/all/conanfile.py
@@ -1,0 +1,81 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, download, get
+from conan.tools.scm import Version
+
+import platform
+import os
+
+required_conan_version = ">=1.53.0"
+
+class ZenohCPackageConan(ConanFile):
+    name = "zenohc"
+    description = "C-API for Eclipse Zenoh: Zero Overhead Pub/Sub, Store/Query and Compute protocol"
+    tags = ["iot", "networking", "robotics", "messaging", "ros2", "edge-computing", "micro-controller", "pre-built"]
+    license = "Apache License 2.0"
+    author = "ZettaScale Zenoh Team <zenoh@zettascale.tech>"
+
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/eclipse-zenoh/zenoh-c"
+
+    package_type = "library"
+    settings = "os", "compiler", "build_type", "arch"
+
+    options = {
+        "shared": [True],
+    }
+    default_options = {
+        "shared": True,
+    }
+
+    @property
+    def _supported_platforms(self):
+        return [
+            ("Windows", "x86_64"),
+            ("Linux", "x86_64"),
+            ("Linux", "armv6"),
+            ("Linux", "armv7hf"),
+            ("Linux", "armv8"),
+            ("Macos", "x86_64"),
+            ("Macos", "armv8"),
+        ]
+
+    def layout(self):
+        pass
+
+    def configure(self):
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.build_type
+
+    def validate(self):
+        if (self.settings.os, self.settings.arch) not in self._supported_platforms:
+            raise ConanInvalidConfiguration("{}/{} target is not supported".format(self.settings.os, self.settings.arch))
+        if self.settings.os == "Linux":
+            libver = platform.libc_ver()
+            print(libver)
+            if libver[0] == "glibc" and Version(libver[1]) < '2.29':
+                raise ConanInvalidConfiguration("This library requires glibc >= 2.29")
+
+    def source(self):
+        pass
+
+    def build(self):
+        get(self, **self.conan_data["sources"][self.version][str(self.settings.os)][str(self.settings.arch)])
+        download(self, **self.conan_data["sources"][self.version]["license"], filename="LICENSE")
+
+    def package(self):
+        copy(self, "LICENSE", self.build_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*", os.path.join(self.build_folder, "lib"), os.path.join(self.package_folder, "lib"))
+        copy(self, "*", os.path.join(self.build_folder, "include"), os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "zenohc")
+        self.cpp_info.set_property("cmake_target_name", "zenohc::lib")
+
+        self.cpp_info.libs = ["zenohc"]
+        self.cpp_info.libdirs = ["lib"]
+        self.cpp_info.includedirs = ["include"]

--- a/conan-recipes/prebuilt/all/test_package/CMakeLists.txt
+++ b/conan-recipes/prebuilt/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(test_package LANGUAGES C)
+
+find_package(zenohc REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE zenohc::lib)

--- a/conan-recipes/prebuilt/all/test_package/conanfile.py
+++ b/conan-recipes/prebuilt/all/test_package/conanfile.py
@@ -1,0 +1,31 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class ZenohCPackageTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def configure(self):
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")

--- a/conan-recipes/prebuilt/all/test_package/test_package.c
+++ b/conan-recipes/prebuilt/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include "zenoh.h"
+
+int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
+    z_owned_config_t config = z_config_default();
+    return EXIT_SUCCESS;
+}

--- a/conan-recipes/prebuilt/config.yml
+++ b/conan-recipes/prebuilt/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.10.1-rc":
+    folder: all


### PR DESCRIPTION
This PR add a Conan recipe to install Zenoh-C (Currently only `0.10.1-rc`) without requiring Rust on the target host.
The recipe pulls the necessary artefacts from upstream's github release for the requested version.

This recipe only supports targets for which Zenoh-C is compiled in its releases.