### PR TITLE
Add zenoh-c-from-source Conan recipe

### DIFF
--- a/conan-recipes/from-source/all/conandata.yml
+++ b/conan-recipes/from-source/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "0.10.1-rc":
+    url: "https://github.com/eclipse-zenoh/zenoh-c/archive/refs/tags/0.10.1-rc.tar.gz"
+    sha256: "9fb703eff79b7c1ef216f411dadcb7f0132c8ba665823b5a8252b467b4937438"
+patches:
+  "0.10.1-rc":
+    - patch_file: patches/0001-cmakelists-remove-cargo-channel.patch
+    - patch_file: patches/0002-cmakelists-build-lib-only.patch

--- a/conan-recipes/from-source/all/conandata.yml
+++ b/conan-recipes/from-source/all/conandata.yml
@@ -4,5 +4,5 @@ sources:
     sha256: "9fb703eff79b7c1ef216f411dadcb7f0132c8ba665823b5a8252b467b4937438"
 patches:
   "0.10.1-rc":
-    - patch_file: patches/0001-cmakelists-patch-cargo-channel.patch
+    - patch_file: patches/0001-cmakelists-remove-cargo-channel.patch
     - patch_file: patches/0002-cmakelists-build-lib-only.patch

--- a/conan-recipes/from-source/all/conandata.yml
+++ b/conan-recipes/from-source/all/conandata.yml
@@ -4,5 +4,5 @@ sources:
     sha256: "9fb703eff79b7c1ef216f411dadcb7f0132c8ba665823b5a8252b467b4937438"
 patches:
   "0.10.1-rc":
-    - patch_file: patches/0001-cmakelists-remove-cargo-channel.patch
+    - patch_file: patches/0001-cmakelists-patch-cargo-channel.patch
     - patch_file: patches/0002-cmakelists-build-lib-only.patch

--- a/conan-recipes/from-source/all/conanfile.py
+++ b/conan-recipes/from-source/all/conanfile.py
@@ -23,7 +23,7 @@ class ZenohCPackageConan(ConanFile):
     name = "zenohc"
     description = "C-API for Eclipse Zenoh: Zero Overhead Pub/sub, Store/Query and Compute protocol"
     tags = ["iot", "networking", "robotics", "messaging", "ros2", "edge-computing", "micro-controller"]
-    license = "Apache License 2.0"
+    license = "EPL-2.0 OR Apache-2.0"
     author = "ZettaScale Zenoh Team"
 
     url = "https://github.com/conan-io/conan-center-index"

--- a/conan-recipes/from-source/all/conanfile.py
+++ b/conan-recipes/from-source/all/conanfile.py
@@ -1,0 +1,113 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import apply_conandata_patches, get, copy, export_conandata_patches
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps
+import os
+
+required_conan_version = ">=1.53.0"
+
+class ZenohCPackageConan(ConanFile):
+    name = "zenohc"
+    description = "C-API for Eclipse Zenoh: Zero Overhead Pub/sub, Store/Query and Compute protocol"
+    tags = ["iot", "networking", "robotics", "messaging", "ros2", "edge-computing", "micro-controller"]
+    license = "Apache License 2.0"
+    author = "ZettaScale Zenoh Team"
+
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/eclipse-zenoh/zenoh-c"
+
+    package_type = "library"
+    settings = "os", "compiler", "build_type", "arch"
+
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "ZENOHC_BUILD_WITH_LOGGER_AUTOINIT":[True, False],
+        "ZENOHC_BUILD_WITH_SHARED_MEMORY":[True, False],
+        "ZENOHC_CARGO_FLAGS": ["ANY"],
+    }
+
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "ZENOHC_BUILD_WITH_LOGGER_AUTOINIT": True,
+        "ZENOHC_BUILD_WITH_SHARED_MEMORY": True,
+        "ZENOHC_CARGO_FLAGS": "",
+    }
+
+    @property
+    def _supported_platforms(self):
+        return [
+            ("Windows", "x86_64"),
+            ("Linux", "x86_64"),
+            ("Linux", "armv6"),
+            ("Linux", "armv7hf"),
+            ("Linux", "armv8"),
+            ("Macos", "x86_64"),
+            ("Macos", "armv8"),
+        ]
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def validate(self):
+        if (self.settings.os, self.settings.arch) not in self._supported_platforms:
+            raise ConanInvalidConfiguration("{}/{} combination is not supported".format(self.settings.os, self.settings.arch))
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        for opt, val in self.options.items():
+            tc.variables[opt] = val
+        tc.variables["ZENOHC_LIB_STATIC"] = str(not self.options.shared)
+        tc.variables["ZENOHC_INSTALL_STATIC_LIBRARY"] = tc.variables["ZENOHC_LIB_STATIC"]
+    
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        if self.settings.build_type == "Debug":
+            self.cpp_info.libs = ["zenohcd"]
+        else:
+            self.cpp_info.libs = ["zenohc"]
+        
+        self.cpp_info.set_property("cmake_file_name", "zenohc")
+        self.cpp_info.set_property("cmake_target_name", "zenohc::lib")
+        self.cpp_info.set_property("cmake_target_aliases", [f"zenohc::{'shared' if self.options.shared else 'static'}"])
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["ws2_32", "crypt32", "secur32", "bcrypt", "ncrypt", "userenv", "ntdll", "iphlpapi", "runtimeobject"]
+        elif self.settings.os == "Linux":
+            self.cpp_info.system_libs = ["rt", "pthread", "m", "dl"]
+        elif self.settings.os == "Macos":
+            self.cpp_info.frameworks = ["Foundation", "Security"]

--- a/conan-recipes/from-source/all/conanfile.py
+++ b/conan-recipes/from-source/all/conanfile.py
@@ -26,7 +26,7 @@ class ZenohCPackageConan(ConanFile):
     license = "EPL-2.0 OR Apache-2.0"
     author = "ZettaScale Zenoh Team"
 
-    url = "https://github.com/conan-io/conan-center-index"
+    url = "https://github.com/eclipse-zenoh/zenoh-c"
     homepage = "https://github.com/eclipse-zenoh/zenoh-c"
 
     package_type = "library"

--- a/conan-recipes/from-source/all/conanfile.py
+++ b/conan-recipes/from-source/all/conanfile.py
@@ -1,3 +1,16 @@
+#
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+#
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import apply_conandata_patches, get, copy, export_conandata_patches

--- a/conan-recipes/from-source/all/conanfile.py
+++ b/conan-recipes/from-source/all/conanfile.py
@@ -37,6 +37,7 @@ class ZenohCPackageConan(ConanFile):
         "fPIC": [True, False],
         "ZENOHC_BUILD_WITH_LOGGER_AUTOINIT":[True, False],
         "ZENOHC_BUILD_WITH_SHARED_MEMORY":[True, False],
+        "ZENOHC_INSTALL_STATIC_LIBRARY":[True, False],
         "ZENOHC_CARGO_FLAGS": ["ANY"],
     }
 
@@ -45,6 +46,7 @@ class ZenohCPackageConan(ConanFile):
         "fPIC": True,
         "ZENOHC_BUILD_WITH_LOGGER_AUTOINIT": True,
         "ZENOHC_BUILD_WITH_SHARED_MEMORY": True,
+        "ZENOHC_INSTALL_STATIC_LIBRARY": False,
         "ZENOHC_CARGO_FLAGS": "",
     }
 
@@ -91,7 +93,6 @@ class ZenohCPackageConan(ConanFile):
         for opt, val in self.options.items():
             tc.variables[opt] = val
         tc.variables["ZENOHC_LIB_STATIC"] = str(not self.options.shared)
-        tc.variables["ZENOHC_INSTALL_STATIC_LIBRARY"] = tc.variables["ZENOHC_LIB_STATIC"]
     
         tc.generate()
         deps = CMakeDeps(self)

--- a/conan-recipes/from-source/all/patches/0001-cmakelists-patch-cargo-channel.patch
+++ b/conan-recipes/from-source/all/patches/0001-cmakelists-patch-cargo-channel.patch
@@ -16,8 +16,8 @@ index 419b583..81527fb 100644
  	COMMAND ${CMAKE_COMMAND} -E echo \"RUSTFLAGS = $$RUSTFLAGS\"
 -	COMMAND ${CMAKE_COMMAND} -E echo \"cargo +${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}\"
 -	COMMAND cargo +${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}
-+	COMMAND ${CMAKE_COMMAND} -E echo \"cargo build ${cargo_flags}\"
-+	COMMAND cargo build ${cargo_flags}
++	COMMAND ${CMAKE_COMMAND} -E echo \"cargo +1.72.0 build ${cargo_flags}\"
++	COMMAND cargo +1.72.0 build ${cargo_flags}
  	VERBATIM
  	COMMAND_EXPAND_LISTS
  	DEPENDS "${rust_sources}"

--- a/conan-recipes/from-source/all/patches/0001-cmakelists-remove-cargo-channel.patch
+++ b/conan-recipes/from-source/all/patches/0001-cmakelists-remove-cargo-channel.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 419b583..81527fb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -27,7 +27,6 @@ declare_cache_var_true_if_vscode(ZENOHC_BUILD_IN_SOURCE_TREE "Do build inside so
+ declare_cache_var(ZENOHC_BUILD_WITH_LOGGER_AUTOINIT TRUE BOOL "Enable logger-autoinit zenoh-c feature")
+ declare_cache_var(ZENOHC_BUILD_WITH_SHARED_MEMORY TRUE BOOL "Enable shared-memory zenoh-c feature")
+ declare_cache_var(ZENOHC_CUSTOM_TARGET "" STRING "Rust target for cross compilation, 'aarch64-unknown-linux-gnu' for example")
+-declare_cache_var(ZENOHC_CARGO_CHANNEL "stable" STRING "Cargo channel selected: stable or nightly")
+ declare_cache_var(ZENOHC_CARGO_FLAGS "" STRING "Additional cargo flags")
+ declare_cache_var(ZENOHC_LIB_STATIC FALSE BOOL "Alias zenohc::lib target to zenohc::static if TRUE, to zenohc::shared if FALSE")
+ 
+@@ -198,8 +197,8 @@ file(GLOB_RECURSE rust_sources "Cargo.toml.in" "src/*.rs" "build.rs" "splitguide
+ add_custom_command(
+ 	OUTPUT ${libs}
+ 	COMMAND ${CMAKE_COMMAND} -E echo \"RUSTFLAGS = $$RUSTFLAGS\"
+-	COMMAND ${CMAKE_COMMAND} -E echo \"cargo +${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}\"
+-	COMMAND cargo +${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}
++	COMMAND ${CMAKE_COMMAND} -E echo \"cargo build ${cargo_flags}\"
++	COMMAND cargo build ${cargo_flags}
+ 	VERBATIM
+ 	COMMAND_EXPAND_LISTS
+ 	DEPENDS "${rust_sources}"

--- a/conan-recipes/from-source/all/patches/0001-cmakelists-remove-cargo-channel.patch
+++ b/conan-recipes/from-source/all/patches/0001-cmakelists-remove-cargo-channel.patch
@@ -16,8 +16,8 @@ index 419b583..81527fb 100644
  	COMMAND ${CMAKE_COMMAND} -E echo \"RUSTFLAGS = $$RUSTFLAGS\"
 -	COMMAND ${CMAKE_COMMAND} -E echo \"cargo +${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}\"
 -	COMMAND cargo +${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}
-+	COMMAND ${CMAKE_COMMAND} -E echo \"cargo +1.72.0 build ${cargo_flags}\"
-+	COMMAND cargo +1.72.0 build ${cargo_flags}
++	COMMAND ${CMAKE_COMMAND} -E echo \"cargo build ${cargo_flags}\"
++	COMMAND cargo build ${cargo_flags}
  	VERBATIM
  	COMMAND_EXPAND_LISTS
  	DEPENDS "${rust_sources}"

--- a/conan-recipes/from-source/all/patches/0002-cmakelists-build-lib-only.patch
+++ b/conan-recipes/from-source/all/patches/0002-cmakelists-build-lib-only.patch
@@ -1,0 +1,70 @@
+diff --git a/examples/CMakeLists.txt b/examples/CMakeLists.txt
+index c2aecbd..e69de29 100644
+--- a/examples/CMakeLists.txt
++++ b/examples/CMakeLists.txt
+@@ -1,32 +0,0 @@
+-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+-    # Settings when 'examples' is the root projet
+-    cmake_minimum_required(VERSION 3.16)
+-    project(zenohc_examples LANGUAGES C)
+-    set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake" ${CMAKE_MODULE_PATH})
+-    include(helpers)
+-    set_default_build_type(Release)
+-    configure_include_project(ZENOHC zenohc zenohc::lib ".." zenohc "https://github.com/eclipse-zenoh/zenoh-c" "")
+-    add_custom_target(examples ALL)
+-else()
+-    message(STATUS "zenoh-c examples")
+-    add_custom_target(examples)
+-endif()
+-
+-file(GLOB files "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
+-
+-foreach(file ${files})
+-    get_filename_component(target ${file} NAME_WE)
+-
+-    if(NOT(UNIX) AND(${target} STREQUAL "z_ping" OR ${target} STREQUAL "z_pong"))
+-        continue()
+-    endif()
+-
+-    add_executable(${target} EXCLUDE_FROM_ALL ${file})
+-    add_dependencies(examples ${target})
+-
+-    add_dependencies(${target} zenohc::lib)
+-    target_link_libraries(${target} PRIVATE zenohc::lib)
+-    copy_dlls(${target})
+-
+-    set_property(TARGET ${target} PROPERTY C_STANDARD 11)
+-endforeach()
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 21695a4..e69de29 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -1,28 +0,0 @@
+-message(STATUS "zenoh-c tests")
+-
+-add_custom_target(tests)
+-
+-file(GLOB files "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
+-foreach(file ${files})
+-    get_filename_component(target ${file} NAME_WE)
+-    
+-    # Check the filename prefix to determine the test type
+-    if (${file} MATCHES "^.*z_api_.*$")
+-        set(test_type "unit")
+-    elseif (${file} MATCHES "^.*z_int_.*$")
+-        set(test_type "integration")
+-    elseif (${file} MATCHES "^.*z_build_.*$")
+-        set(test_type "build")
+-    else()
+-        message(FATAL_ERROR "Test file ${file} does not match any known type (z_api_ or z_int_ or z_build)")
+-    endif()
+-
+-    add_executable(${target} EXCLUDE_FROM_ALL ${file})
+-    add_dependencies(tests ${target})
+-    add_dependencies(${target} zenohc::lib)
+-    target_link_libraries(${target} PRIVATE zenohc::lib)
+-    copy_dlls(${target})
+-    set_property(TARGET ${target} PROPERTY C_STANDARD 11)
+-    add_test(NAME "${test_type}_${target}" COMMAND ${target})
+-endforeach()
+-

--- a/conan-recipes/from-source/all/test_package/CMakeLists.txt
+++ b/conan-recipes/from-source/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(test_package LANGUAGES C)
+
+find_package(zenohc REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE zenohc::lib)

--- a/conan-recipes/from-source/all/test_package/conanfile.py
+++ b/conan-recipes/from-source/all/test_package/conanfile.py
@@ -9,6 +9,9 @@ class ZenohCPackageTestConan(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+
     def requirements(self):
         self.requires(self.tested_reference_str)
 

--- a/conan-recipes/from-source/all/test_package/conanfile.py
+++ b/conan-recipes/from-source/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class ZenohCPackageTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def configure(self):
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")

--- a/conan-recipes/from-source/all/test_package/test_package.c
+++ b/conan-recipes/from-source/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include "zenoh.h"
+
+int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
+    z_owned_config_t config = z_config_default();
+    return EXIT_SUCCESS;
+}

--- a/conan-recipes/from-source/config.yml
+++ b/conan-recipes/from-source/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.10.1-rc":
+    folder: all


### PR DESCRIPTION
This PR adds a conan recipe that builds Zenoh-C from source.

Specifically, this recipe builds a zenoh-c version (currently only `0.10.1-rc`) from source using Rust compiler and cmake. 

**Note: The recipe assumes the appropriate Rust toolchain version is installed on the host (`1.72.0` in case of `0.10.1-rc`)**