### PR TITLE
fix: Support jq 1.6 in `bump-and-tag.bash` scripy

### DIFF
--- a/ci/scripts/bump-and-tag.bash
+++ b/ci/scripts/bump-and-tag.bash
@@ -42,7 +42,7 @@ git commit version.txt Cargo.toml Cargo.toml.in Cargo.lock -m "chore: Bump versi
 
 # Select all package dependencies that match $bump_deps_pattern and bump them to $bump_deps_version
 if [[ "$bump_deps_pattern" != '' ]]; then
-  deps=$(toml get Cargo.toml dependencies | jq -r "keys.[] | select(test(\"$bump_deps_pattern\"))")
+  deps=$(toml get Cargo.toml dependencies | jq -r "keys[] | select(test(\"$bump_deps_pattern\"))")
   for dep in $deps; do
     if [[ -n $bump_deps_version ]]; then
       toml_set_in_place Cargo.toml "dependencies.$dep.version" "$bump_deps_version"


### PR DESCRIPTION
ubuntu-22.04 runners use jq 1.6 which doesn't recognize a dot for `[]` value iterator.

See: jqlang/jq#1168.
