### PR TITLE
rename z_keyexpr_to_string into z_keyexpr_as_view_string

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -222,7 +222,7 @@ Functions
 .. doxygenfunction:: z_view_keyexpr_check
 .. doxygenfunction:: z_keyexpr_drop
 
-.. doxygenfunction:: z_keyexpr_to_string
+.. doxygenfunction:: z_keyexpr_as_view_string
 
 .. doxygenfunction:: z_keyexpr_canonize
 .. doxygenfunction:: z_keyexpr_canonize_null_terminated

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -54,7 +54,7 @@ Subscribe
 
   void data_handler(const z_loaned_sample_t *sample, const void *arg) {
       z_view_str_t key_string;
-      z_keyexpr_to_string(z_sample_keyexpr(sample), &key_string);
+      z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
       z_owned_str_t payload_string;
       z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);
       printf(">> Received (%.*s, %.*s)\n", 
@@ -126,7 +126,7 @@ Query
           if (z_reply_is_ok(&reply)) {
               const z_loaned_sample_t* sample = z_reply_ok(&reply);
               z_view_str_t key_string;
-              z_keyexpr_to_string(z_sample_keyexpr(sample), &key_string);
+              z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
               z_owned_str_t payload_string;
               z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);
               printf(">> Received (%.*s, %.*s)\n",
@@ -154,7 +154,7 @@ Queryable
 
   void query_handler(const z_loaned_query_t *query, void *context) {
       z_view_str_t key_string;
-      z_keyexpr_to_string(z_query_keyexpr(query), &key_string);
+      z_keyexpr_as_view_string(z_query_keyexpr(query), &key_string);
 
       const z_loaned_bytes_t* payload =  z_value_payload(z_query_value(query));
       if (z_bytes_len(payload) > 0) {

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
             const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));
 
             z_view_string_t key_str;
-            z_view_string_from_keyexpr(&key_str, z_sample_keyexpr(sample));
+            z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_str);
 
             z_owned_string_t reply_str;
             z_bytes_decode_into_string(z_sample_payload(sample), &reply_str);

--- a/examples/z_get_liveliness.c
+++ b/examples/z_get_liveliness.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
         if (z_reply_is_ok(z_loan(reply))) {
             const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));
             z_view_string_t key_str;
-            z_view_string_from_keyexpr(&key_str, z_sample_keyexpr(sample));
+            z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_str);
             printf(">> Alive token ('%.*s')\n", (int)z_string_len(z_loan(key_str)), z_string_data(z_loan(key_str)));
         } else {
             printf("Received an error\n");

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
             const z_loaned_sample_t* sample = z_reply_ok(z_loan(reply));
             z_view_string_t key_str;
             z_owned_string_t payload_string;
-            z_view_string_from_keyexpr(&key_str, z_sample_keyexpr(sample));
+            z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_str);
             z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);
             printf(">> Received ('%.*s': '%.*s')\n", 
                (int)z_string_len(z_loan(key_str)), z_string_data(z_loan(key_str)),

--- a/examples/z_query_sub.c
+++ b/examples/z_query_sub.c
@@ -18,7 +18,7 @@ const char *kind_to_str(z_sample_kind_t kind);
 
 void data_handler(const z_loaned_sample_t *sample, void *arg) {
     z_view_string_t key_string;
-    z_view_string_from_keyexpr(&key_string, z_sample_keyexpr(sample));
+    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
 
     z_owned_string_t payload_string;
     z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -21,7 +21,7 @@ z_view_keyexpr_t ke;
 
 void query_handler(const z_loaned_query_t *query, void *context) {
     z_view_string_t key_string;
-    z_view_string_from_keyexpr(&key_string, z_query_keyexpr(query));
+    z_keyexpr_as_view_string(z_query_keyexpr(query), &key_string);
 
     z_view_string_t params;
     z_query_parameters(query, &params);

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
     for (z_call(z_loan(channel.recv), &oquery); z_check(oquery); z_call(z_loan(channel.recv), &oquery)) {
         const z_loaned_query_t* query = z_loan(oquery);
         z_view_string_t key_string;
-        z_view_string_from_keyexpr(&key_string, z_query_keyexpr(query));
+        z_keyexpr_as_view_string(z_query_keyexpr(query), &key_string);
 
         z_view_string_t params;
         z_query_parameters(query, &params);

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -18,7 +18,7 @@ const char *kind_to_str(z_sample_kind_t kind);
 
 void data_handler(const z_loaned_sample_t *sample, void *arg) {
     z_view_string_t key_string;
-    z_view_string_from_keyexpr(&key_string, z_sample_keyexpr(sample));
+    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
 
     z_owned_string_t payload_string;
     z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -19,7 +19,7 @@ const char *kind_to_str(z_sample_kind_t kind);
 
 void data_handler(const z_loaned_sample_t *sample, void *arg) {
     z_view_string_t key_string;
-    z_view_string_from_keyexpr(&key_string, z_sample_keyexpr(sample));
+    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
 
     z_owned_string_t payload_string;
     z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);

--- a/examples/z_sub_liveliness.c
+++ b/examples/z_sub_liveliness.c
@@ -16,7 +16,7 @@
 
 void data_handler(const z_loaned_sample_t *sample, void *arg) {
     z_view_string_t key_string;
-    z_view_string_from_keyexpr(&key_string, z_sample_keyexpr(sample));
+    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
     switch (z_sample_kind(sample)) {
         case Z_SAMPLE_KIND_PUT:
             printf(">> [LivelinessSubscriber] New alive token ('%.*s')\n",

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1475,6 +1475,12 @@ z_error_t z_info_routers_zid(const struct z_loaned_session_t *session,
  */
 ZENOHC_API struct z_id_t z_info_zid(const struct z_loaned_session_t *session);
 /**
+ * Constructs a non-owned non-null-terminated string from key expression.
+ */
+ZENOHC_API
+void z_keyexpr_as_view_string(const struct z_loaned_keyexpr_t *this_,
+                              struct z_view_string_t *out_string);
+/**
  * Canonizes the passed string in place, possibly shortening it by modifying `len`.
  *
  * May SEGFAULT if `start` is NULL or lies in read-only memory (as values initialized with string litterals do).
@@ -2615,12 +2621,6 @@ ZENOHC_API bool z_view_string_check(const struct z_view_string_t *this_);
  * Constructs an empty view string.
  */
 ZENOHC_API void z_view_string_empty(struct z_view_string_t *this_);
-/**
- * Constructs a non-owned non-null-terminated string from key expression.
- */
-ZENOHC_API
-z_error_t z_view_string_from_keyexpr(struct z_view_string_t *out_string,
-                                     const struct z_loaned_keyexpr_t *key_expr);
 /**
  * Constructs a view string to a specified substring of length `len`.
  *

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -416,19 +416,18 @@ pub unsafe extern "C" fn z_view_keyexpr_from_string_unchecked(
 /// Constructs a non-owned non-null-terminated string from key expression.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_view_string_from_keyexpr(
+pub unsafe extern "C" fn z_keyexpr_as_view_string(
+    this: &z_loaned_keyexpr_t,
     out_string: *mut MaybeUninit<z_view_string_t>,
-    key_expr: &z_loaned_keyexpr_t,
-) -> z_error_t {
-    let key_expr = key_expr.transmute_ref();
+) {
+    let this = this.transmute_ref();
     unsafe {
         z_view_string_from_substring(
             out_string,
-            key_expr.as_bytes().as_ptr() as _,
-            key_expr.as_bytes().len(),
+            this.as_bytes().as_ptr() as _,
+            this.as_bytes().len(),
         )
     };
-    errors::Z_OK
 }
 
 /// Constructs and declares a key expression on the network. This reduces key key expression to a numerical id,

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -45,7 +45,7 @@ void query_handler(const z_loaned_query_t *query, void *arg) {
 
     const z_loaned_keyexpr_t* query_ke = z_query_keyexpr(query);
     z_view_string_t k_str;
-    z_view_string_from_keyexpr(&k_str, query_ke);
+    z_keyexpr_as_view_string(query_ke, &k_str);
 #ifdef ZENOH_PICO
     if (k_str == NULL) {
         k_str = zp_keyexpr_resolve(*(z_loaned_session_t *)arg, z_query_keyexpr(query));
@@ -73,7 +73,7 @@ void reply_handler(const z_loaned_reply_t *reply, void *arg) {
         const z_loaned_sample_t* sample = z_reply_ok(reply);
 
         z_view_string_t k_str;
-        z_view_string_from_keyexpr(&k_str, z_sample_keyexpr(sample));
+        z_keyexpr_as_view_string(z_sample_keyexpr(sample), &k_str);
 #ifdef ZENOH_PICO
         if (k_str == NULL) {
             k_str = zp_keyexpr_resolve(*(z_loaned_session_t *)arg, sample.keyexpr);
@@ -90,7 +90,7 @@ void data_handler(const z_loaned_sample_t *sample, void *arg) {
     datas++;
 
     z_view_string_t k_str;
-    z_view_string_from_keyexpr(&k_str, z_sample_keyexpr(sample));
+    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &k_str);
 #ifdef ZENOH_PICO
     if (k_str == NULL) {
         k_str = zp_keyexpr_resolve(*(z_loaned_session_t *)arg, sample->keyexpr);

--- a/tests/z_api_keyexpr_drop_test.c
+++ b/tests/z_api_keyexpr_drop_test.c
@@ -36,7 +36,7 @@ void test_publisher() {
     z_view_keyexpr_from_string(&ke, keyexpr);
     const z_loaned_keyexpr_t* pub_ke = z_publisher_keyexpr(z_loan(pub));
     z_view_string_t pub_keyexpr; 
-    z_view_string_from_keyexpr(&pub_keyexpr, pub_ke);
+    z_keyexpr_as_view_string(pub_ke, &pub_keyexpr);
     assert(strncmp(z_string_data(z_loan(pub_keyexpr)), "foo/bar", z_string_len(z_loan(pub_keyexpr))) == 0);  // Check that publisher keeps the correct keyexpr
     z_undeclare_publisher(z_move(pub));
     z_close(z_move(s));
@@ -61,7 +61,7 @@ void test_subscriber() {
     z_view_keyexpr_from_string(&ke, keyexpr);
     const z_loaned_keyexpr_t* sub_ke = z_subscriber_keyexpr(z_loan(sub));
     z_view_string_t sub_keyexpr;
-    z_view_string_from_keyexpr(&sub_keyexpr, sub_ke);
+    z_keyexpr_as_view_string(sub_ke, &sub_keyexpr);
     assert(strncmp(z_string_data(z_loan(sub_keyexpr)), "foo/bar", z_string_len(z_loan(sub_keyexpr))) == 0);  // Check that subscriber keeps the correct keyexpr
     z_undeclare_subscriber(z_move(sub));
     z_close(z_move(s));

--- a/tests/z_api_keyexpr_test.c
+++ b/tests/z_api_keyexpr_test.c
@@ -48,7 +48,7 @@ void canonize() {
     assert(z_view_keyexpr_check(&key_expr_canonized) == true);
     assert(strcmp(keyexpr, "a/**/c") == 0);
     z_view_string_t key_exp_canonized_bytes;
-    z_view_string_from_keyexpr(&key_exp_canonized_bytes, z_loan(key_expr_canonized));
+    z_keyexpr_as_view_string(z_loan(key_expr_canonized), &key_exp_canonized_bytes);
     assert(z_string_len(z_loan(key_exp_canonized_bytes)) == len_new);
     assert(strncmp(z_string_data(z_loan(key_exp_canonized_bytes)), "a/**/c", len_new) == 0);
 
@@ -58,7 +58,7 @@ void canonize() {
     assert(res == 0);
     assert(len_new == len_old - 3);
     assert(strncmp(keyexpr, "a/**/c", len_new) == 0);
-    z_view_string_from_keyexpr(&key_exp_canonized_bytes, z_loan(key_expr_canonized));
+    z_keyexpr_as_view_string(z_loan(key_expr_canonized), &key_exp_canonized_bytes);
     assert(z_string_len(z_loan(key_exp_canonized_bytes)) == len_new);
     assert(strncmp(z_string_data(z_loan(key_exp_canonized_bytes)), "a/**/c", len_new) == 0);
 }

--- a/tests/z_int_pub_cache_query_sub_test.c
+++ b/tests/z_int_pub_cache_query_sub_test.c
@@ -94,7 +94,7 @@ int run_publisher() {
 void data_handler(const z_loaned_sample_t *sample, void *arg) {
     static int val_num = 0;
     z_view_string_t keystr;
-    z_view_string_from_keyexpr(&keystr, z_sample_keyexpr(sample));
+    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &keystr);
     if (strncmp(keyexpr, z_string_data(z_loan(keystr)), z_string_len(z_loan(keystr)))) {
         perror("Unexpected key received");
         exit(-1);

--- a/tests/z_int_pub_sub_attachment_test.c
+++ b/tests/z_int_pub_sub_attachment_test.c
@@ -133,7 +133,7 @@ int run_publisher() {
 void data_handler(const z_loaned_sample_t *sample, void *arg) {
     static int val_num = 0;
     z_view_string_t keystr;
-    z_view_string_from_keyexpr(&keystr, z_sample_keyexpr(sample));
+    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &keystr);
     if (strncmp(keyexpr, z_string_data(z_loan(keystr)), z_string_len(z_loan(keystr)))) {
         perror("Unexpected key received");
         exit(-1);

--- a/tests/z_int_pub_sub_test.c
+++ b/tests/z_int_pub_sub_test.c
@@ -67,7 +67,7 @@ int run_publisher() {
 void data_handler(const z_loaned_sample_t *sample, void *arg) {
     static int val_num = 0;
     z_view_string_t keystr;
-    z_view_string_from_keyexpr(&keystr, z_sample_keyexpr(sample));
+    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &keystr);
     if (strncmp(keyexpr, z_string_data(z_loan(keystr)), z_string_len(z_loan(keystr)))) {
         perror("Unexpected key received");
         exit(-1);


### PR DESCRIPTION
undo pr #413; 
rename z_keyexpr_to_string into z_keyexpr_as_view_string;