### PR TITLE
Add timestamp and allowed_destination properties

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -565,6 +565,14 @@ typedef struct z_put_options_t {
    */
   bool is_express;
   /**
+   * The timestamp of this message.
+   */
+  struct z_timestamp_t *timestamp;
+  /**
+   * The allowed destination of this message.
+   */
+  enum zcu_locality_t allowed_destination;
+  /**
    * The source info for the message.
    */
   struct z_owned_source_info_t *source_info;

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -3339,6 +3339,13 @@ const char *z_time_now_as_str(const char *buf,
  */
 ZENOHC_API struct z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
 /**
+ * Create timestamp
+ */
+ZENOHC_API
+z_error_t z_timestamp_new(struct z_timestamp_t *this_,
+                          const struct z_id_t *zid,
+                          uint64_t npt64_time);
+/**
  * Returns NPT64 time associated with this timestamp.
  */
 ZENOHC_API uint64_t z_timestamp_npt64_time(const struct z_timestamp_t *this_);

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -433,6 +433,10 @@ typedef struct z_publisher_options_t {
    * If true, Zenoh will not wait to batch this message with others to reduce the bandwith
    */
   bool is_express;
+  /**
+   * The allowed destination for thsi publisher.
+   */
+  enum zcu_locality_t allowed_destination;
 } z_publisher_options_t;
 /**
  * Options passed to the `z_declare_queryable()` function.
@@ -468,6 +472,14 @@ typedef struct z_delete_options_t {
    * If true, Zenoh will not wait to batch this operation with others to reduce the bandwith.
    */
   bool is_express;
+  /**
+   * The timestamp of this message.
+   */
+  struct z_timestamp_t *timestamp;
+  /**
+   * The allowed destination of this message.
+   */
+  enum zcu_locality_t allowed_destination;
 } z_delete_options_t;
 /**
  * An entity gloabal id.
@@ -525,7 +537,10 @@ typedef struct z_get_options_t {
  * whenever issued via `z_publisher_delete()`.
  */
 typedef struct z_publisher_delete_options_t {
-  uint8_t __dummy;
+  /**
+   * The timestamp of this message.
+   */
+  struct z_timestamp_t *timestamp;
 } z_publisher_delete_options_t;
 /**
  * Options passed to the `z_publisher_put()` function.
@@ -535,6 +550,10 @@ typedef struct z_publisher_put_options_t {
    *  The encoding of the data to publish.
    */
   struct z_owned_encoding_t *encoding;
+  /**
+   * The timestamp of the publication.
+   */
+  struct z_timestamp_t *timestamp;
   /**
    * The source info for the publication.
    */
@@ -2194,7 +2213,7 @@ ZENOHC_API bool z_publisher_check(const struct z_owned_publisher_t *this_);
  */
 ZENOHC_API
 z_error_t z_publisher_delete(const struct z_loaned_publisher_t *publisher,
-                             const struct z_publisher_delete_options_t *_options);
+                             const struct z_publisher_delete_options_t *options);
 /**
  * Constructs the default values for the delete operation via a publisher entity.
  */

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -83,6 +83,21 @@ impl From<z_sample_kind_t> for SampleKind {
 use crate::opaque_types::z_timestamp_t;
 decl_transmute_copy!(Timestamp, z_timestamp_t);
 
+/// Create timestamp
+#[no_mangle]
+pub extern "C" fn z_timestamp_new(
+    this: &mut z_timestamp_t,
+    zid: &z_id_t,
+    npt64_time: u64,
+) -> errors::z_error_t {
+    let timestamp = Timestamp::new(
+        zenoh::time::NTP64(npt64_time),
+        (&zid.transmute_copy()).into(),
+    );
+    *this = timestamp.transmute_copy();
+    errors::Z_OK
+}
+
 /// Returns NPT64 time associated with this timestamp.
 #[no_mangle]
 pub extern "C" fn z_timestamp_npt64_time(this: &z_timestamp_t) -> u64 {


### PR DESCRIPTION
Add:
 - `timestamp` to the: `z_delete_options_t`, `z_publisher_delete_options_t`, `z_publisher_put_options_t`, `z_put_options_t`
 - `allowed_destination` to the: `z_publisher_options_t`, `z_delete_options_t`, `z_put_options_t` 
 - `z_timestamp_new` method to create timestamp

Closes: https://github.com/eclipse-zenoh/zenoh-c/issues/384

NB: `congestion_control` already present for put, but for publisher it should be added as `z_publisher_set_congestion_control`, it will be done in separate PR