### PR TITLE
rename `(de/en)code` to `(de)serialize`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -132,39 +132,39 @@ Types
 Functions
 ^^^^^^^^^
 .. doxygenfunction:: z_bytes_len
-.. doxygenfunction:: z_bytes_encode_from_slice
-.. doxygenfunction:: z_bytes_encode_from_string
-.. doxygenfunction:: z_bytes_encode_from_slice_map
-.. doxygenfunction:: z_bytes_encode_from_iter
-.. doxygenfunction:: z_bytes_encode_from_pair
+.. doxygenfunction:: z_bytes_serialize_from_slice
+.. doxygenfunction:: z_bytes_serialize_from_string
+.. doxygenfunction:: z_bytes_serialize_from_slice_map
+.. doxygenfunction:: z_bytes_serialize_from_iter
+.. doxygenfunction:: z_bytes_serialize_from_pair
 
-.. doxygenfunction:: z_bytes_encode_from_uint8
-.. doxygenfunction:: z_bytes_encode_from_uint16
-.. doxygenfunction:: z_bytes_encode_from_uint32
-.. doxygenfunction:: z_bytes_encode_from_uint64
-.. doxygenfunction:: z_bytes_encode_from_int8
-.. doxygenfunction:: z_bytes_encode_from_int16
-.. doxygenfunction:: z_bytes_encode_from_int32
-.. doxygenfunction:: z_bytes_encode_from_int64
-.. doxygenfunction:: z_bytes_encode_from_float
-.. doxygenfunction:: z_bytes_encode_from_double
+.. doxygenfunction:: z_bytes_serialize_from_uint8
+.. doxygenfunction:: z_bytes_serialize_from_uint16
+.. doxygenfunction:: z_bytes_serialize_from_uint32
+.. doxygenfunction:: z_bytes_serialize_from_uint64
+.. doxygenfunction:: z_bytes_serialize_from_int8
+.. doxygenfunction:: z_bytes_serialize_from_int16
+.. doxygenfunction:: z_bytes_serialize_from_int32
+.. doxygenfunction:: z_bytes_serialize_from_int64
+.. doxygenfunction:: z_bytes_serialize_from_float
+.. doxygenfunction:: z_bytes_serialize_from_double
 
-.. doxygenfunction:: z_bytes_decode_into_slice
-.. doxygenfunction:: z_bytes_decode_into_string
-.. doxygenfunction:: z_bytes_decode_into_slice_map
-.. doxygenfunction:: z_bytes_decode_into_iter
-.. doxygenfunction:: z_bytes_decode_into_pair
+.. doxygenfunction:: z_bytes_deserialize_into_slice
+.. doxygenfunction:: z_bytes_deserialize_into_string
+.. doxygenfunction:: z_bytes_deserialize_into_slice_map
+.. doxygenfunction:: z_bytes_deserialize_into_iter
+.. doxygenfunction:: z_bytes_deserialize_into_pair
 
-.. doxygenfunction:: z_bytes_decode_into_uint8
-.. doxygenfunction:: z_bytes_decode_into_uint16
-.. doxygenfunction:: z_bytes_decode_into_uint32
-.. doxygenfunction:: z_bytes_decode_into_uint64
-.. doxygenfunction:: z_bytes_decode_into_int8
-.. doxygenfunction:: z_bytes_decode_into_int16
-.. doxygenfunction:: z_bytes_decode_into_int32
-.. doxygenfunction:: z_bytes_decode_into_int64
-.. doxygenfunction:: z_bytes_decode_into_float
-.. doxygenfunction:: z_bytes_decode_into_double
+.. doxygenfunction:: z_bytes_deserialize_into_uint8
+.. doxygenfunction:: z_bytes_deserialize_into_uint16
+.. doxygenfunction:: z_bytes_deserialize_into_uint32
+.. doxygenfunction:: z_bytes_deserialize_into_uint64
+.. doxygenfunction:: z_bytes_deserialize_into_int8
+.. doxygenfunction:: z_bytes_deserialize_into_int16
+.. doxygenfunction:: z_bytes_deserialize_into_int32
+.. doxygenfunction:: z_bytes_deserialize_into_int64
+.. doxygenfunction:: z_bytes_deserialize_into_float
+.. doxygenfunction:: z_bytes_deserialize_into_double
 
 .. doxygenfunction:: z_bytes_empty
 .. doxygenfunction:: z_bytes_clone

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -34,7 +34,7 @@ Publish
       }
       
       z_owned_bytes_t payload;
-      z_bytes_encode_from_string(&payload, "value");
+      z_bytes_serialize_from_string(&payload, "value");
       z_view_keyexpr_t key_expr;
       z_view_keyexpr_from_string(&key_expr, "key/expression");
 
@@ -56,7 +56,7 @@ Subscribe
       z_view_string_t key_string;
       z_keyexpr_to_string(z_sample_keyexpr(sample), &key_string);
       z_owned_string_t payload_string;
-      z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);
+      z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_string);
       printf(">> Received (%.*s, %.*s)\n", 
           (int)z_str_len(z_loan(key_string)), z_str_data(z_loan(key_string)), 
           (int)z_str_len(z_loan(payload_string)), z_str_data(z_loan(payload_string))
@@ -129,7 +129,7 @@ Query
               z_view_string_t key_string;
               z_keyexpr_to_string(z_sample_keyexpr(sample), &key_string);
               z_owned_string_t payload_string;
-              z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);
+              z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_string);
               printf(">> Received (%.*s, %.*s)\n",
                   (int)z_str_len(z_loan(key_string)), z_str_data(z_loan(key_string)),
                   (int)z_str_len(z_loan(payload_string)), z_str_data(z_loan(payload_string))
@@ -160,7 +160,7 @@ Queryable
       const z_loaned_bytes_t* payload =  z_value_payload(z_query_value(query));
       if (z_bytes_len(payload) > 0) {
           z_owned_string_t payload_string;
-          z_bytes_decode_into_string(payload, &payload_string);
+          z_bytes_deserialize_into_string(payload, &payload_string);
 
           printf(">> [Queryable ] Received Query '%.*s' with value '%.*s'\n", 
               (int)z_str_len(z_loan(key_string)), z_str_data(z_loan(key_string)),
@@ -171,7 +171,7 @@ Queryable
       }
 
       z_owned_bytes_t reply_payload;
-      z_bytes_encode_from_string(&reply_payload, "reply");
+      z_bytes_serialize_from_string(&reply_payload, "reply");
 
       z_view_keyexpr_t reply_keyexpr;
       z_view_keyexpr_from_string(&reply_keyexpr, (const char *)context);

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
 
     z_owned_bytes_t payload;
     if (value != NULL) {
-        z_bytes_encode_from_string(&payload, value);
+        z_bytes_serialize_from_string(&payload, value);
         opts.payload = &payload;
     }
     z_get(z_loan(s), z_loan(keyexpr), "", z_move(closure),
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
             z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_str);
 
             z_owned_string_t reply_str;
-            z_bytes_decode_into_string(z_sample_payload(sample), &reply_str);
+            z_bytes_deserialize_into_string(z_sample_payload(sample), &reply_str);
 
             printf(">> Received ('%.*s': '%.*s')\n", (int)z_string_len(z_loan(key_str)), z_string_data(z_loan(key_str)),
                    (int)z_string_len(z_loan(reply_str)), z_string_data(z_loan(reply_str)));

--- a/examples/z_get_shm.c
+++ b/examples/z_get_shm.c
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
 
     z_owned_bytes_t payload;
     if (value != NULL) {
-        z_bytes_encode_from_shm_copy(&payload, z_loan(shm));
+        z_bytes_serialize_from_shm_copy(&payload, z_loan(shm));
         opts.payload = &payload;
     }
     z_get(z_loan(s), z_loan(keyexpr), "", z_move(closure),
@@ -106,7 +106,7 @@ int main(int argc, char** argv) {
             z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_str);
 
             z_owned_string_t reply_str;
-            z_bytes_decode_into_string(z_sample_payload(sample), &reply_str);
+            z_bytes_deserialize_into_string(z_sample_payload(sample), &reply_str);
 
             printf(">> Received ('%.*s': '%.*s')\n", (int)z_string_len(z_loan(key_str)), z_string_data(z_loan(key_str)),
                    (int)z_string_len(z_loan(reply_str)), z_string_data(z_loan(reply_str)));

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
             z_view_string_t key_str;
             z_owned_string_t payload_string;
             z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_str);
-            z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);
+            z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_string);
             printf(">> Received ('%.*s': '%.*s')\n", (int)z_string_len(z_loan(key_str)), z_string_data(z_loan(key_str)),
                    (int)z_string_len(z_loan(payload_string)), z_string_data(z_loan(payload_string)));
             z_drop(z_move(payload_string));

--- a/examples/z_ping.c
+++ b/examples/z_ping.c
@@ -78,7 +78,7 @@ int main(int argc, char** argv) {
 
         unsigned long elapsed_us = 0;
         while (elapsed_us < args.warmup_ms * 1000) {
-            z_bytes_encode_from_slice(&payload, data, args.size);
+            z_bytes_serialize_from_slice(&payload, data, args.size);
             z_publisher_put(z_loan(pub), z_move(payload), NULL);
             int s = z_condvar_wait(z_loan(cond), z_loan_mut(mutex));
             if (s != 0) {
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
     }
     unsigned long* results = z_malloc(sizeof(unsigned long) * args.number_of_pings);
     for (int i = 0; i < args.number_of_pings; i++) {
-        z_bytes_encode_from_slice(&payload, data, args.size);
+        z_bytes_serialize_from_slice(&payload, data, args.size);
         z_clock_t measure_start = z_clock_now();
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
         int s = z_condvar_wait(z_loan(cond), z_loan_mut(mutex));

--- a/examples/z_ping_shm.c
+++ b/examples/z_ping_shm.c
@@ -102,7 +102,7 @@ int main(int argc, char** argv) {
 
         unsigned long elapsed_us = 0;
         while (elapsed_us < args.warmup_ms * 1000) {
-            z_bytes_encode_from_shm_copy(&payload, loaned_shm);
+            z_bytes_serialize_from_shm_copy(&payload, loaned_shm);
             z_publisher_put(z_loan(pub), z_move(payload), NULL);
             int s = z_condvar_wait(z_loan(cond), z_loan_mut(mutex));
             if (s != 0) {

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
         z_publisher_put_options_default(&options);
 
         z_owned_bytes_t payload;
-        z_bytes_encode_from_string(&payload, buf);
+        z_bytes_serialize_from_string(&payload, buf);
 
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -33,9 +33,9 @@ bool create_attachment_iter(z_owned_bytes_t* kv_pair, void* context) {
     if (kvs->current_idx >= kvs->len) {
         return false;
     } else {
-        z_bytes_encode_from_string(&k, kvs->data[kvs->current_idx].key);
-        z_bytes_encode_from_string(&v, kvs->data[kvs->current_idx].value);
-        z_bytes_encode_from_pair(kv_pair, z_move(k), z_move(v));
+        z_bytes_serialize_from_string(&k, kvs->data[kvs->current_idx].key);
+        z_bytes_serialize_from_string(&v, kvs->data[kvs->current_idx].value);
+        z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
         kvs->current_idx++;
         return true;
     }
@@ -95,13 +95,13 @@ int main(int argc, char** argv) {
         sprintf(buf_ind, "%d", idx);
         kvs[1] = (kv_pair_t){.key = "index", .value = buf_ind};
         kv_pairs_t ctx = (kv_pairs_t){.data = kvs, .current_idx = 0, .len = 2};
-        z_bytes_encode_from_iter(&attachment, create_attachment_iter, (void*)&ctx);
+        z_bytes_serialize_from_iter(&attachment, create_attachment_iter, (void*)&ctx);
         options.attachment = &attachment;
 
         sprintf(buf, "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
 
-        z_bytes_encode_from_string(&payload, buf);
+        z_bytes_serialize_from_string(&payload, buf);
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
 

--- a/examples/z_pub_cache.c
+++ b/examples/z_pub_cache.c
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
         sprintf(buf, "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
         z_owned_bytes_t payload;
-        z_bytes_encode_from_string(&payload, buf);
+        z_bytes_serialize_from_string(&payload, buf);
 
         z_put(z_loan(s), z_loan(ke), z_move(payload), NULL);
     }

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
             z_publisher_put_options_default(&options);
 
             z_owned_bytes_t payload;
-            z_bytes_encode_from_shm_mut(&payload, &shm_buf);
+            z_bytes_serialize_from_shm_mut(&payload, &shm_buf);
 
             z_publisher_put(z_loan(pub), z_move(payload), &options);
         } else {

--- a/examples/z_pub_shm_thr.c
+++ b/examples/z_pub_shm_thr.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
 
     z_owned_bytes_t payload;
     while (1) {
-        z_bytes_encode_from_shm_copy(&payload, loaned_shm);
+        z_bytes_serialize_from_shm_copy(&payload, loaned_shm);
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
     }
 

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
 
     z_owned_bytes_t payload;
     while (1) {
-        z_bytes_encode_from_slice(&payload, value, len);
+        z_bytes_serialize_from_slice(&payload, value, len);
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
     }
 

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -30,7 +30,7 @@ void handle_sample(const z_loaned_sample_t *sample) {
     z_view_string_t keystr;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &keystr);
     z_owned_string_t payload_value;
-    z_bytes_decode_into_string(z_sample_payload(sample), &payload_value);
+    z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_value);
     printf(">> [Subscriber] Received %s ('%.*s': '%.*s')\n", kind_to_str(z_sample_kind(sample)),
            (int)z_string_len(z_loan(keystr)), z_string_data(z_loan(keystr)), (int)z_string_len(z_loan(payload_value)),
            z_string_data(z_loan(payload_value)));

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -49,12 +49,12 @@ int main(int argc, char **argv) {
     z_view_keyexpr_from_string(&ke, keyexpr);
 
     z_owned_bytes_t payload;
-    z_bytes_encode_from_string(&payload, value);
+    z_bytes_serialize_from_string(&payload, value);
 
     z_owned_bytes_t attachment, key, val;
-    z_bytes_encode_from_string(&key, "hello");
-    z_bytes_encode_from_string(&val, "there");
-    z_bytes_encode_from_pair(&attachment, z_move(key), z_move(val));
+    z_bytes_serialize_from_string(&key, "hello");
+    z_bytes_serialize_from_string(&val, "there");
+    z_bytes_serialize_from_pair(&attachment, z_move(key), z_move(val));
 
     z_put_options_t options;
     z_put_options_default(&options);

--- a/examples/z_query_sub.c
+++ b/examples/z_query_sub.c
@@ -22,7 +22,7 @@ void data_handler(const z_loaned_sample_t *sample, void *arg) {
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
 
     z_owned_string_t payload_string;
-    z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);
+    z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_string);
 
     printf(">> [Subscriber] Received %s ('%.*s': '%.*s')\n", kind_to_str(z_sample_kind(sample)),
            (int)z_string_len(z_loan(key_string)), z_string_data(z_loan(key_string)),

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -30,7 +30,7 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     const z_loaned_bytes_t *payload = z_query_payload(query);
     if (z_bytes_len(payload) > 0) {
         z_owned_string_t payload_string;
-        z_bytes_decode_into_string(payload, &payload_string);
+        z_bytes_deserialize_into_string(payload, &payload_string);
 
         printf(">> [Queryable ] Received Query '%.*s?%.*s' with value '%.*s'\n", (int)z_string_len(z_loan(key_string)),
                z_string_data(z_loan(key_string)), (int)z_string_len(z_loan(params)), z_string_data(z_loan(params)),
@@ -44,7 +44,7 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     z_query_reply_options_default(&options);
 
     z_owned_bytes_t reply_payload;
-    z_bytes_encode_from_string(&reply_payload, value);
+    z_bytes_serialize_from_string(&reply_payload, value);
 
     z_view_keyexpr_t reply_keyexpr;
     z_view_keyexpr_from_string(&reply_keyexpr, (const char *)context);

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
         const z_loaned_bytes_t *payload = z_query_payload(query);
         if (z_bytes_len(payload) > 0) {
             z_owned_string_t payload_string;
-            z_bytes_decode_into_string(payload, &payload_string);
+            z_bytes_deserialize_into_string(payload, &payload_string);
 
             printf(">> [Queryable ] Received Query '%.*s?%.*s' with value '%.*s'\n",
                    (int)z_string_len(z_loan(key_string)), z_string_data(z_loan(key_string)),
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
         z_query_reply_options_default(&options);
 
         z_owned_bytes_t reply_payload;
-        z_bytes_encode_from_string(&reply_payload, value);
+        z_bytes_serialize_from_string(&reply_payload, value);
         z_query_reply(query, z_loan(ke), z_move(reply_payload), &options);
         z_drop(z_move(oquery));
     }

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -22,7 +22,7 @@ void data_handler(const z_loaned_sample_t *sample, void *arg) {
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
 
     z_owned_string_t payload_string;
-    z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);
+    z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_string);
 
     printf(">> [Subscriber] Received %s ('%.*s': '%.*s')\n", kind_to_str(z_sample_kind(sample)),
            (int)z_string_len(z_loan(key_string)), z_string_data(z_loan(key_string)),

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -23,7 +23,7 @@ void data_handler(const z_loaned_sample_t *sample, void *arg) {
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
 
     z_owned_string_t payload_string;
-    z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);
+    z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_string);
 
     printf(">> [Subscriber] Received %s ('%.*s': '%.*s')\n", kind_to_str(z_sample_kind(sample)),
            (int)z_string_len(z_loan(key_string)), z_string_data(z_loan(key_string)),
@@ -38,10 +38,10 @@ void data_handler(const z_loaned_sample_t *sample, void *arg) {
         while (z_bytes_iterator_next(&iter, &kv)) {
             z_owned_bytes_t k, v;
             z_owned_string_t key, value;
-            z_bytes_decode_into_pair(z_loan(kv), &k, &v);
+            z_bytes_deserialize_into_pair(z_loan(kv), &k, &v);
 
-            z_bytes_decode_into_string(z_loan(k), &key);
-            z_bytes_decode_into_string(z_loan(v), &value);
+            z_bytes_deserialize_into_string(z_loan(k), &key);
+            z_bytes_deserialize_into_string(z_loan(v), &value);
 
             printf("   attachment: %.*s: '%.*s'\n", (int)z_string_len(z_loan(key)), z_string_data(z_loan(key)),
                    (int)z_string_len(z_loan(value)), z_string_data(z_loan(value)));

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -756,13 +756,13 @@ typedef struct zc_context_t {
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 typedef struct zc_shm_provider_backend_callbacks_t {
-  void (*alloc_fn)(struct z_owned_chunk_alloc_result_t *out_result,
-                   const struct z_loaned_memory_layout_t *layout,
+  void (*alloc_fn)(z_owned_chunk_alloc_result_t *out_result,
+                   const z_loaned_memory_layout_t *layout,
                    void *context);
   void (*free_fn)(const struct z_chunk_descriptor_t *chunk, void *context);
   size_t (*defragment_fn)(void *context);
   size_t (*available_fn)(void *context);
-  void (*layout_for_fn)(struct z_owned_memory_layout_t *layout, void *context);
+  void (*layout_for_fn)(z_owned_memory_layout_t *layout, void *context);
 } zc_shm_provider_backend_callbacks_t;
 #endif
 typedef struct z_task_attr_t {
@@ -906,55 +906,54 @@ ZENOHC_API extern const char *Z_CONFIG_ADD_TIMESTAMP_KEY;
 ZENOHC_API extern const unsigned int Z_SHM_POSIX_PROTOCOL_ID;
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_alloc_layout_alloc(struct z_owned_buf_alloc_result_t *out_result,
-                          const struct z_loaned_alloc_layout_t *layout);
+void z_alloc_layout_alloc(z_owned_buf_alloc_result_t *out_result,
+                          const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_alloc_layout_alloc_gc(struct z_owned_buf_alloc_result_t *out_result,
-                             const struct z_loaned_alloc_layout_t *layout);
+void z_alloc_layout_alloc_gc(z_owned_buf_alloc_result_t *out_result,
+                             const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_alloc_layout_alloc_gc_defrag(struct z_owned_buf_alloc_result_t *out_result,
-                                    const struct z_loaned_alloc_layout_t *layout);
+void z_alloc_layout_alloc_gc_defrag(z_owned_buf_alloc_result_t *out_result,
+                                    const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_alloc_layout_alloc_gc_defrag_blocking(struct z_owned_buf_alloc_result_t *out_result,
-                                             const struct z_loaned_alloc_layout_t *layout);
+void z_alloc_layout_alloc_gc_defrag_blocking(z_owned_buf_alloc_result_t *out_result,
+                                             const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_alloc_layout_alloc_gc_defrag_dealloc(struct z_owned_buf_alloc_result_t *out_result,
-                                            const struct z_loaned_alloc_layout_t *layout);
+void z_alloc_layout_alloc_gc_defrag_dealloc(z_owned_buf_alloc_result_t *out_result,
+                                            const z_loaned_alloc_layout_t *layout);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_alloc_layout_check(const struct z_owned_alloc_layout_t *this_);
+ZENOHC_API bool z_alloc_layout_check(const z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Deletes Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_drop(struct z_owned_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_drop(z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Borrows Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-const struct z_loaned_alloc_layout_t *z_alloc_layout_loan(const struct z_owned_alloc_layout_t *this_);
+ZENOHC_API const z_loaned_alloc_layout_t *z_alloc_layout_loan(const z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Creates a new Alloc Layout for SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_alloc_layout_new(struct z_owned_alloc_layout_t *this_,
-                             const struct z_loaned_shm_provider_t *provider,
+z_error_t z_alloc_layout_new(z_owned_alloc_layout_t *this_,
+                             const z_loaned_shm_provider_t *provider,
                              size_t size,
                              struct z_alloc_alignment_t alignment);
 #endif
@@ -962,45 +961,45 @@ z_error_t z_alloc_layout_new(struct z_owned_alloc_layout_t *this_,
  * Constructs Alloc Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_null(struct z_owned_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_null(z_owned_alloc_layout_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_alloc_layout_threadsafe_alloc_gc_defrag_async(struct z_owned_buf_alloc_result_t *out_result,
-                                                          const struct z_loaned_alloc_layout_t *layout,
+z_error_t z_alloc_layout_threadsafe_alloc_gc_defrag_async(z_owned_buf_alloc_result_t *out_result,
+                                                          const z_loaned_alloc_layout_t *layout,
                                                           struct zc_threadsafe_context_t result_context,
                                                           void (*result_callback)(void*,
-                                                                                  struct z_owned_buf_alloc_result_t*));
+                                                                                  z_owned_buf_alloc_result_t*));
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_buf_alloc_result_check(const struct z_owned_buf_alloc_result_t *this_);
+ZENOHC_API bool z_buf_alloc_result_check(const z_owned_buf_alloc_result_t *this_);
 #endif
 /**
  * Deletes Buf Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_buf_alloc_result_drop(struct z_owned_buf_alloc_result_t *this_);
+ZENOHC_API void z_buf_alloc_result_drop(z_owned_buf_alloc_result_t *this_);
 #endif
 /**
  * Borrows Buf Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct z_loaned_buf_alloc_result_t *z_buf_alloc_result_loan(const struct z_owned_buf_alloc_result_t *this_);
+const z_loaned_buf_alloc_result_t *z_buf_alloc_result_loan(const z_owned_buf_alloc_result_t *this_);
 #endif
 /**
  * Constructs Buf Alloc Result in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_buf_alloc_result_null(struct z_owned_buf_alloc_result_t *this_);
+ZENOHC_API void z_buf_alloc_result_null(z_owned_buf_alloc_result_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_buf_alloc_result_unwrap(struct z_owned_buf_alloc_result_t *alloc_result,
-                                    struct z_owned_shm_mut_t *out_buf,
+z_error_t z_buf_alloc_result_unwrap(z_owned_buf_alloc_result_t *alloc_result,
+                                    z_owned_shm_mut_t *out_buf,
                                     enum z_alloc_error_t *out_error);
 #endif
 /**
@@ -1015,32 +1014,44 @@ ZENOHC_API void z_bytes_clone(const struct z_loaned_bytes_t *this_, struct z_own
  * Decodes into a signed integer.
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_error_t z_bytes_decode_into_double(const struct z_loaned_bytes_t *this_, double *dst);
+ZENOHC_API
+z_error_t z_bytes_deserialize_into_double(const struct z_loaned_bytes_t *this_,
+                                          double *dst);
 /**
  * Decodes into a float.
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_error_t z_bytes_decode_into_float(const struct z_loaned_bytes_t *this_, float *dst);
+ZENOHC_API
+z_error_t z_bytes_deserialize_into_float(const struct z_loaned_bytes_t *this_,
+                                         float *dst);
 /**
  * Decodes into a signed integer.
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_error_t z_bytes_decode_into_int16(const struct z_loaned_bytes_t *this_, int16_t *dst);
+ZENOHC_API
+z_error_t z_bytes_deserialize_into_int16(const struct z_loaned_bytes_t *this_,
+                                         int16_t *dst);
 /**
  * Decodes into a signed integer.
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_error_t z_bytes_decode_into_int32(const struct z_loaned_bytes_t *this_, int32_t *dst);
+ZENOHC_API
+z_error_t z_bytes_deserialize_into_int32(const struct z_loaned_bytes_t *this_,
+                                         int32_t *dst);
 /**
  * Decodes into a signed integer.
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_error_t z_bytes_decode_into_int64(const struct z_loaned_bytes_t *this_, int64_t *dst);
+ZENOHC_API
+z_error_t z_bytes_deserialize_into_int64(const struct z_loaned_bytes_t *this_,
+                                         int64_t *dst);
 /**
  * Decodes into a signed integer.
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_error_t z_bytes_decode_into_int8(const struct z_loaned_bytes_t *this_, int8_t *dst);
+ZENOHC_API
+z_error_t z_bytes_deserialize_into_int8(const struct z_loaned_bytes_t *this_,
+                                        int8_t *dst);
 /**
  * Decodes data into a loaned SHM buffer
  *
@@ -1049,8 +1060,8 @@ ZENOHC_API z_error_t z_bytes_decode_into_int8(const struct z_loaned_bytes_t *thi
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_bytes_decode_into_loaned_shm(const struct z_loaned_bytes_t *this_,
-                                         const struct z_loaned_shm_t **dst);
+z_error_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *this_,
+                                              const z_loaned_shm_t **dst);
 #endif
 /**
  * Decodes data into a mutably loaned SHM buffer
@@ -1060,8 +1071,8 @@ z_error_t z_bytes_decode_into_loaned_shm(const struct z_loaned_bytes_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_bytes_decode_into_mut_loaned_shm(struct z_loaned_bytes_t *this_,
-                                             struct z_loaned_shm_t **dst);
+z_error_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this_,
+                                                  z_loaned_shm_t **dst);
 #endif
 /**
  * Decodes data into an owned SHM buffer by copying it's shared reference
@@ -1071,17 +1082,17 @@ z_error_t z_bytes_decode_into_mut_loaned_shm(struct z_loaned_bytes_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_bytes_decode_into_owned_shm(const struct z_loaned_bytes_t *this_,
-                                        struct z_owned_shm_t *dst);
+z_error_t z_bytes_deserialize_into_owned_shm(const struct z_loaned_bytes_t *this_,
+                                             z_owned_shm_t *dst);
 #endif
 /**
  * Decodes into a pair of `z_owned_bytes` objects.
  * @return 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API
-z_error_t z_bytes_decode_into_pair(const struct z_loaned_bytes_t *this_,
-                                   struct z_owned_bytes_t *first,
-                                   struct z_owned_bytes_t *second);
+z_error_t z_bytes_deserialize_into_pair(const struct z_loaned_bytes_t *this_,
+                                        struct z_owned_bytes_t *first,
+                                        struct z_owned_bytes_t *second);
 /**
  * Decodes data into an owned slice.
  *
@@ -1089,8 +1100,8 @@ z_error_t z_bytes_decode_into_pair(const struct z_loaned_bytes_t *this_,
  * @param dst: An unitialized memory location where to construct a slice.
  */
 ZENOHC_API
-z_error_t z_bytes_decode_into_slice(const struct z_loaned_bytes_t *this_,
-                                    struct z_owned_slice_t *dst);
+z_error_t z_bytes_deserialize_into_slice(const struct z_loaned_bytes_t *this_,
+                                         struct z_owned_slice_t *dst);
 /**
  * Decodes data into an owned bytes map.
  *
@@ -1098,8 +1109,8 @@ z_error_t z_bytes_decode_into_slice(const struct z_loaned_bytes_t *this_,
  * @param dst: An unitialized memory location where to construct a decoded map.
  */
 ZENOHC_API
-z_error_t z_bytes_decode_into_slice_map(const struct z_loaned_bytes_t *this_,
-                                        struct z_owned_slice_map_t *dst);
+z_error_t z_bytes_deserialize_into_slice_map(const struct z_loaned_bytes_t *this_,
+                                             struct z_owned_slice_map_t *dst);
 /**
  * Decodes data into an owned non-null-terminated string.
  *
@@ -1107,34 +1118,36 @@ z_error_t z_bytes_decode_into_slice_map(const struct z_loaned_bytes_t *this_,
  * @param dst: An unitialized memory location where to construct a decoded string.
  */
 ZENOHC_API
-z_error_t z_bytes_decode_into_string(const struct z_loaned_bytes_t *this_,
-                                     struct z_owned_string_t *dst);
+z_error_t z_bytes_deserialize_into_string(const struct z_loaned_bytes_t *this_,
+                                          struct z_owned_string_t *dst);
 /**
  * Decodes into an unsigned integer.
  * @return 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API
-z_error_t z_bytes_decode_into_uint16(const struct z_loaned_bytes_t *this_,
-                                     uint16_t *dst);
+z_error_t z_bytes_deserialize_into_uint16(const struct z_loaned_bytes_t *this_,
+                                          uint16_t *dst);
 /**
  * Decodes into an unsigned integer.
  * @return 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API
-z_error_t z_bytes_decode_into_uint32(const struct z_loaned_bytes_t *this_,
-                                     uint32_t *dst);
+z_error_t z_bytes_deserialize_into_uint32(const struct z_loaned_bytes_t *this_,
+                                          uint32_t *dst);
 /**
  * Decodes into an unsigned integer.
  * @return 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API
-z_error_t z_bytes_decode_into_uint64(const struct z_loaned_bytes_t *this_,
-                                     uint64_t *dst);
+z_error_t z_bytes_deserialize_into_uint64(const struct z_loaned_bytes_t *this_,
+                                          uint64_t *dst);
 /**
  * Decodes into an unsigned integer.
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_error_t z_bytes_decode_into_uint8(const struct z_loaned_bytes_t *this_, uint8_t *dst);
+ZENOHC_API
+z_error_t z_bytes_deserialize_into_uint8(const struct z_loaned_bytes_t *this_,
+                                         uint8_t *dst);
 /**
  * Drops `this_`, resetting it to gravestone value. If there are any shallow copies
  * created by `z_bytes_clone()`, they would still stay valid.
@@ -1144,123 +1157,6 @@ ZENOHC_API void z_bytes_drop(struct z_owned_bytes_t *this_);
  * Constructs an empty instance of `z_owned_bytes_t`.
  */
 ZENOHC_API void z_bytes_empty(struct z_owned_bytes_t *this_);
-/**
- * Encodes a double.
- */
-ZENOHC_API void z_bytes_encode_from_double(struct z_owned_bytes_t *this_, double val);
-/**
- * Encodes a float.
- */
-ZENOHC_API void z_bytes_encode_from_float(struct z_owned_bytes_t *this_, float val);
-/**
- * Encodes a signed integer.
- */
-ZENOHC_API void z_bytes_encode_from_int16(struct z_owned_bytes_t *this_, int16_t val);
-/**
- * Encodes a signed integer.
- */
-ZENOHC_API void z_bytes_encode_from_int32(struct z_owned_bytes_t *this_, int32_t val);
-/**
- * Encodes a signed integer.
- */
-ZENOHC_API void z_bytes_encode_from_int64(struct z_owned_bytes_t *this_, int64_t val);
-/**
- * Encodes a signed integer.
- */
-ZENOHC_API void z_bytes_encode_from_int8(struct z_owned_bytes_t *this_, int8_t val);
-/**
- * Constructs payload from an iterator to `z_owned_bytes_t`.
- * @param this_: An uninitialized location in memery for `z_owned_bytes_t` will be constructed.
- * @param iterator_body: Iterator body function, providing data items. Returning false is treated as iteration end.
- * @param context: Arbitrary context that will be passed to iterator_body.
- * @return 0 in case of success, negative error code otherwise.
- */
-ZENOHC_API
-z_error_t z_bytes_encode_from_iter(struct z_owned_bytes_t *this_,
-                                   bool (*iterator_body)(struct z_owned_bytes_t *data, void *context),
-                                   void *context);
-/**
- * Encodes a pair of `z_owned_bytes` objects which are consumed in the process.
- * @return 0 in case of success, negative error code otherwise.
- */
-ZENOHC_API
-z_error_t z_bytes_encode_from_pair(struct z_owned_bytes_t *this_,
-                                   struct z_owned_bytes_t *first,
-                                   struct z_owned_bytes_t *second);
-/**
- * Encodes from an immutable SHM buffer consuming it
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-z_error_t z_bytes_encode_from_shm(struct z_owned_bytes_t *this_,
-                                  struct z_owned_shm_t *shm);
-#endif
-/**
- * Encodes from an immutable SHM buffer copying it
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-void z_bytes_encode_from_shm_copy(struct z_owned_bytes_t *this_,
-                                  const struct z_loaned_shm_t *shm);
-#endif
-/**
- * Encodes from a mutable SHM buffer consuming it
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-z_error_t z_bytes_encode_from_shm_mut(struct z_owned_bytes_t *this_,
-                                      struct z_owned_shm_mut_t *shm);
-#endif
-/**
- * Encodes a slice by aliasing.
- */
-ZENOHC_API
-void z_bytes_encode_from_slice(struct z_owned_bytes_t *this_,
-                               const uint8_t *data,
-                               size_t len);
-/**
- * Encodes a slice by copying.
- */
-ZENOHC_API
-void z_bytes_encode_from_slice_copy(struct z_owned_bytes_t *this_,
-                                    const uint8_t *data,
-                                    size_t len);
-/**
- * Encodes slice map by aliasing.
- */
-ZENOHC_API
-void z_bytes_encode_from_slice_map(struct z_owned_bytes_t *this_,
-                                   const struct z_loaned_slice_map_t *bytes_map);
-/**
- * Encodes slice map by copying.
- */
-ZENOHC_API
-void z_bytes_encode_from_slice_map_copy(struct z_owned_bytes_t *this_,
-                                        const struct z_loaned_slice_map_t *bytes_map);
-/**
- * Encodes a null-terminated string by aliasing.
- */
-ZENOHC_API void z_bytes_encode_from_string(struct z_owned_bytes_t *this_, const char *s);
-/**
- * Encodes a null-terminated string by copying.
- */
-ZENOHC_API void z_bytes_encode_from_string_copy(struct z_owned_bytes_t *this_, const char *s);
-/**
- * Encodes an unsigned integer.
- */
-ZENOHC_API void z_bytes_encode_from_uint16(struct z_owned_bytes_t *this_, uint16_t val);
-/**
- * Encodes an unsigned integer.
- */
-ZENOHC_API void z_bytes_encode_from_uint32(struct z_owned_bytes_t *this_, uint32_t val);
-/**
- * Encodes an unsigned integer.
- */
-ZENOHC_API void z_bytes_encode_from_uint64(struct z_owned_bytes_t *this_, uint64_t val);
-/**
- * Encodes an unsigned integer.
- */
-ZENOHC_API void z_bytes_encode_from_uint8(struct z_owned_bytes_t *this_, uint8_t val);
 /**
  * Returns an iterator for multi-piece serialized data.
  *
@@ -1342,6 +1238,122 @@ z_error_t z_bytes_reader_seek(struct z_bytes_reader_t *this_,
  */
 ZENOHC_API int64_t z_bytes_reader_tell(struct z_bytes_reader_t *this_);
 /**
+ * Encodes a double.
+ */
+ZENOHC_API void z_bytes_serialize_from_double(struct z_owned_bytes_t *this_, double val);
+/**
+ * Encodes a float.
+ */
+ZENOHC_API void z_bytes_serialize_from_float(struct z_owned_bytes_t *this_, float val);
+/**
+ * Encodes a signed integer.
+ */
+ZENOHC_API void z_bytes_serialize_from_int16(struct z_owned_bytes_t *this_, int16_t val);
+/**
+ * Encodes a signed integer.
+ */
+ZENOHC_API void z_bytes_serialize_from_int32(struct z_owned_bytes_t *this_, int32_t val);
+/**
+ * Encodes a signed integer.
+ */
+ZENOHC_API void z_bytes_serialize_from_int64(struct z_owned_bytes_t *this_, int64_t val);
+/**
+ * Encodes a signed integer.
+ */
+ZENOHC_API void z_bytes_serialize_from_int8(struct z_owned_bytes_t *this_, int8_t val);
+/**
+ * Constructs payload from an iterator to `z_owned_bytes_t`.
+ * @param this_: An uninitialized location in memery for `z_owned_bytes_t` will be constructed.
+ * @param iterator_body: Iterator body function, providing data items. Returning false is treated as iteration end.
+ * @param context: Arbitrary context that will be passed to iterator_body.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+ZENOHC_API
+z_error_t z_bytes_serialize_from_iter(struct z_owned_bytes_t *this_,
+                                      bool (*iterator_body)(struct z_owned_bytes_t *data,
+                                                            void *context),
+                                      void *context);
+/**
+ * Encodes a pair of `z_owned_bytes` objects which are consumed in the process.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+ZENOHC_API
+z_error_t z_bytes_serialize_from_pair(struct z_owned_bytes_t *this_,
+                                      struct z_owned_bytes_t *first,
+                                      struct z_owned_bytes_t *second);
+/**
+ * Encodes from an immutable SHM buffer consuming it
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+ZENOHC_API z_error_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_, z_owned_shm_t *shm);
+#endif
+/**
+ * Encodes from an immutable SHM buffer copying it
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+ZENOHC_API
+void z_bytes_serialize_from_shm_copy(struct z_owned_bytes_t *this_,
+                                     const z_loaned_shm_t *shm);
+#endif
+/**
+ * Encodes from a mutable SHM buffer consuming it
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+ZENOHC_API
+z_error_t z_bytes_serialize_from_shm_mut(struct z_owned_bytes_t *this_,
+                                         z_owned_shm_mut_t *shm);
+#endif
+/**
+ * Encodes a slice by aliasing.
+ */
+ZENOHC_API
+void z_bytes_serialize_from_slice(struct z_owned_bytes_t *this_,
+                                  const uint8_t *data,
+                                  size_t len);
+/**
+ * Encodes a slice by copying.
+ */
+ZENOHC_API
+void z_bytes_serialize_from_slice_copy(struct z_owned_bytes_t *this_,
+                                       const uint8_t *data,
+                                       size_t len);
+/**
+ * Encodes slice map by aliasing.
+ */
+ZENOHC_API
+void z_bytes_serialize_from_slice_map(struct z_owned_bytes_t *this_,
+                                      const struct z_loaned_slice_map_t *bytes_map);
+/**
+ * Encodes slice map by copying.
+ */
+ZENOHC_API
+void z_bytes_serialize_from_slice_map_copy(struct z_owned_bytes_t *this_,
+                                           const struct z_loaned_slice_map_t *bytes_map);
+/**
+ * Encodes a null-terminated string by aliasing.
+ */
+ZENOHC_API void z_bytes_serialize_from_string(struct z_owned_bytes_t *this_, const char *s);
+/**
+ * Encodes a null-terminated string by copying.
+ */
+ZENOHC_API void z_bytes_serialize_from_string_copy(struct z_owned_bytes_t *this_, const char *s);
+/**
+ * Encodes an unsigned integer.
+ */
+ZENOHC_API void z_bytes_serialize_from_uint16(struct z_owned_bytes_t *this_, uint16_t val);
+/**
+ * Encodes an unsigned integer.
+ */
+ZENOHC_API void z_bytes_serialize_from_uint32(struct z_owned_bytes_t *this_, uint32_t val);
+/**
+ * Encodes an unsigned integer.
+ */
+ZENOHC_API void z_bytes_serialize_from_uint64(struct z_owned_bytes_t *this_, uint64_t val);
+/**
+ * Encodes an unsigned integer.
+ */
+ZENOHC_API void z_bytes_serialize_from_uint8(struct z_owned_bytes_t *this_, uint8_t val);
+/**
  * Returns ``true`` if `this_` is in a valid state, ``false`` if it is in a gravestone state.
  */
 ZENOHC_API bool z_bytes_writer_check(const struct z_owned_bytes_writer_t *this_);
@@ -1376,27 +1388,27 @@ z_error_t z_bytes_writer_write(struct z_loaned_bytes_writer_t *this_,
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_chunk_alloc_result_check(const struct z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API bool z_chunk_alloc_result_check(const z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Deletes Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_drop(struct z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API void z_chunk_alloc_result_drop(z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Borrows Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const struct z_owned_chunk_alloc_result_t *this_);
+const z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Creates a new Chunk Alloc Result with Error value
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
+void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
                                     enum z_alloc_error_t alloc_error);
 #endif
 /**
@@ -1404,14 +1416,14 @@ void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_chunk_alloc_result_new_ok(struct z_owned_chunk_alloc_result_t *this_,
+void z_chunk_alloc_result_new_ok(z_owned_chunk_alloc_result_t *this_,
                                  struct z_allocated_chunk_t allocated_chunk);
 #endif
 /**
  * Constructs Chunk Alloc Result in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_null(struct z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API void z_chunk_alloc_result_null(z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Get number of milliseconds passed since creation of `time`.
@@ -2135,13 +2147,13 @@ enum z_keyexpr_intersection_level_t z_keyexpr_relation_to(const struct z_loaned_
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_memory_layout_check(const struct z_owned_memory_layout_t *this_);
+ZENOHC_API bool z_memory_layout_check(const z_owned_memory_layout_t *this_);
 #endif
 /**
  * Deletes Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_drop(struct z_owned_memory_layout_t *this_);
+ZENOHC_API void z_memory_layout_drop(z_owned_memory_layout_t *this_);
 #endif
 /**
  * Deletes Memory Layout
@@ -2150,21 +2162,21 @@ ZENOHC_API void z_memory_layout_drop(struct z_owned_memory_layout_t *this_);
 ZENOHC_API
 void z_memory_layout_get_data(size_t *out_size,
                               struct z_alloc_alignment_t *out_alignment,
-                              const struct z_loaned_memory_layout_t *this_);
+                              const z_loaned_memory_layout_t *this_);
 #endif
 /**
  * Borrows Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct z_loaned_memory_layout_t *z_memory_layout_loan(const struct z_owned_memory_layout_t *this_);
+const z_loaned_memory_layout_t *z_memory_layout_loan(const z_owned_memory_layout_t *this_);
 #endif
 /**
  * Creates a new Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_memory_layout_new(struct z_owned_memory_layout_t *this_,
+z_error_t z_memory_layout_new(z_owned_memory_layout_t *this_,
                               size_t size,
                               struct z_alloc_alignment_t alignment);
 #endif
@@ -2172,7 +2184,7 @@ z_error_t z_memory_layout_new(struct z_owned_memory_layout_t *this_,
  * Constructs Memory Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_null(struct z_owned_memory_layout_t *this_);
+ZENOHC_API void z_memory_layout_null(z_owned_memory_layout_t *this_);
 #endif
 /**
  * Returns ``true`` if mutex is valid, ``false`` otherwise.
@@ -2228,21 +2240,21 @@ z_error_t z_open(struct z_owned_session_t *this_,
 ZENOHC_API
 z_error_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
                                          struct z_owned_config_t *config,
-                                         const struct z_loaned_shm_client_storage_t *shm_clients);
+                                         const z_loaned_shm_client_storage_t *shm_clients);
 #endif
 /**
  * Creates a new POSIX SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_error_t z_posix_shm_client_new(struct z_owned_shm_client_t *this_);
+ZENOHC_API z_error_t z_posix_shm_client_new(z_owned_shm_client_t *this_);
 #endif
 /**
  * Creates a new threadsafe SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_posix_shm_provider_new(struct z_owned_shm_provider_t *this_,
-                                   const struct z_loaned_memory_layout_t *layout);
+z_error_t z_posix_shm_provider_new(z_owned_shm_provider_t *this_,
+                                   const z_loaned_memory_layout_t *layout);
 #endif
 /**
  * Returns the default value of #z_priority_t.
@@ -2532,7 +2544,7 @@ ZENOHC_API uint64_t z_random_u64(void);
  */
 ZENOHC_API uint8_t z_random_u8(void);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_error_t z_ref_shm_client_storage_global(struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API z_error_t z_ref_shm_client_storage_global(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Returns ``true`` if `reply` is valid, ``false`` otherwise.
@@ -2829,26 +2841,26 @@ ZENOHC_API void z_session_null(struct z_owned_session_t *this_);
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_check(const struct z_owned_shm_t *this_);
+ZENOHC_API bool z_shm_check(const z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_check(const struct z_owned_shm_client_t *this_);
+ZENOHC_API bool z_shm_client_check(const z_owned_shm_client_t *this_);
 #endif
 /**
  * Deletes SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_drop(struct z_owned_shm_client_t *this_);
+ZENOHC_API void z_shm_client_drop(z_owned_shm_client_t *this_);
 #endif
 /**
  * Creates a new SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_client_new(struct z_owned_shm_client_t *this_,
+z_error_t z_shm_client_new(z_owned_shm_client_t *this_,
                            struct zc_threadsafe_context_t context,
                            struct zc_shm_client_callbacks_t callbacks);
 #endif
@@ -2856,212 +2868,209 @@ z_error_t z_shm_client_new(struct z_owned_shm_client_t *this_,
  * Constructs SHM client in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_null(struct z_owned_shm_client_t *this_);
+ZENOHC_API void z_shm_client_null(z_owned_shm_client_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_storage_check(const struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API bool z_shm_client_storage_check(const z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Derefs SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_drop(struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_drop(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Borrows SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const struct z_owned_shm_client_storage_t *this_);
+const z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const z_owned_shm_client_storage_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_client_storage_new(struct z_owned_shm_client_storage_t *this_,
-                                   const struct zc_loaned_shm_client_list_t *clients,
+z_error_t z_shm_client_storage_new(z_owned_shm_client_storage_t *this_,
+                                   const zc_loaned_shm_client_list_t *clients,
                                    bool add_default_client_set);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_error_t z_shm_client_storage_new_default(struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API z_error_t z_shm_client_storage_new_default(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Constructs SHM Client Storage in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_null(struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_null(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Converts borrowed ZShm slice to owned ZShm slice by performing a shallow SHM reference copy
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_clone(const struct z_loaned_shm_t *this_, struct z_owned_shm_t *out);
+ZENOHC_API void z_shm_clone(const z_loaned_shm_t *this_, z_owned_shm_t *out);
 #endif
 /**
  * @return the pointer of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const unsigned char *z_shm_data(const struct z_loaned_shm_t *this_);
+ZENOHC_API const unsigned char *z_shm_data(const z_loaned_shm_t *this_);
 #endif
 /**
  * Deletes ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_drop(struct z_owned_shm_t *this_);
+ZENOHC_API void z_shm_drop(z_owned_shm_t *this_);
 #endif
 /**
  * Constructs ZShm slice from ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_from_mut(struct z_owned_shm_t *this_, struct z_owned_shm_mut_t *that);
+ZENOHC_API void z_shm_from_mut(z_owned_shm_t *this_, z_owned_shm_mut_t *that);
 #endif
 /**
  * @return the length of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_len(const struct z_loaned_shm_t *this_);
+ZENOHC_API size_t z_shm_len(const z_loaned_shm_t *this_);
 #endif
 /**
  * Borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const struct z_loaned_shm_t *z_shm_loan(const struct z_owned_shm_t *this_);
+ZENOHC_API const z_loaned_shm_t *z_shm_loan(const z_owned_shm_t *this_);
 #endif
 /**
  * Mutably borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_t *z_shm_loan_mut(struct z_owned_shm_t *this_);
+ZENOHC_API z_loaned_shm_t *z_shm_loan_mut(z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_mut_check(const struct z_owned_shm_mut_t *this_);
+ZENOHC_API bool z_shm_mut_check(const z_owned_shm_mut_t *this_);
 #endif
 /**
  * @return the mutable pointer of the ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API unsigned char *z_shm_mut_data_mut(struct z_loaned_shm_mut_t *this_);
+ZENOHC_API unsigned char *z_shm_mut_data_mut(z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Deletes ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_drop(struct z_owned_shm_mut_t *this_);
+ZENOHC_API void z_shm_mut_drop(z_owned_shm_mut_t *this_);
 #endif
 /**
  * @return the length of the ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_mut_len(const struct z_loaned_shm_mut_t *this_);
+ZENOHC_API size_t z_shm_mut_len(const z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Borrows ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_mut_t *z_shm_mut_loan_mut(struct z_owned_shm_mut_t *this_);
+ZENOHC_API z_loaned_shm_mut_t *z_shm_mut_loan_mut(z_owned_shm_mut_t *this_);
 #endif
 /**
  * Constructs ZShmMut slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_null(struct z_owned_shm_mut_t *this_);
+ZENOHC_API void z_shm_mut_null(z_owned_shm_mut_t *this_);
 #endif
 /**
  * Tries to construct ZShmMut slice from ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-void z_shm_mut_try_from_immut(struct z_owned_shm_mut_t *this_,
-                              struct z_owned_shm_t *that);
+ZENOHC_API void z_shm_mut_try_from_immut(z_owned_shm_mut_t *this_, z_owned_shm_t *that);
 #endif
 /**
  * Constructs ZShm slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_null(struct z_owned_shm_t *this_);
+ZENOHC_API void z_shm_null(z_owned_shm_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc(struct z_owned_buf_alloc_result_t *out_result,
-                               const struct z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc(z_owned_buf_alloc_result_t *out_result,
+                               const z_loaned_shm_provider_t *provider,
                                size_t size,
                                struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc_gc(struct z_owned_buf_alloc_result_t *out_result,
-                                  const struct z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc_gc(z_owned_buf_alloc_result_t *out_result,
+                                  const z_loaned_shm_provider_t *provider,
                                   size_t size,
                                   struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc_gc_defrag(struct z_owned_buf_alloc_result_t *out_result,
-                                         const struct z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc_gc_defrag(z_owned_buf_alloc_result_t *out_result,
+                                         const z_loaned_shm_provider_t *provider,
                                          size_t size,
                                          struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc_gc_defrag_async(struct z_owned_buf_alloc_result_t *out_result,
-                                               const struct z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc_gc_defrag_async(z_owned_buf_alloc_result_t *out_result,
+                                               const z_loaned_shm_provider_t *provider,
                                                size_t size,
                                                struct z_alloc_alignment_t alignment,
                                                struct zc_threadsafe_context_t result_context,
                                                void (*result_callback)(void*,
                                                                        z_error_t,
-                                                                       struct z_owned_buf_alloc_result_t*));
+                                                                       z_owned_buf_alloc_result_t*));
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc_gc_defrag_blocking(struct z_owned_buf_alloc_result_t *out_result,
-                                                  const struct z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc_gc_defrag_blocking(z_owned_buf_alloc_result_t *out_result,
+                                                  const z_loaned_shm_provider_t *provider,
                                                   size_t size,
                                                   struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc_gc_defrag_dealloc(struct z_owned_buf_alloc_result_t *out_result,
-                                                 const struct z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc_gc_defrag_dealloc(z_owned_buf_alloc_result_t *out_result,
+                                                 const z_loaned_shm_provider_t *provider,
                                                  size_t size,
                                                  struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_available(const struct z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_available(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_provider_check(const struct z_owned_shm_provider_t *this_);
+ZENOHC_API bool z_shm_provider_check(const z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_defragment(const struct z_loaned_shm_provider_t *provider);
+ZENOHC_API void z_shm_provider_defragment(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Deletes SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_drop(struct z_owned_shm_provider_t *this_);
+ZENOHC_API void z_shm_provider_drop(z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_garbage_collect(const struct z_loaned_shm_provider_t *provider);
+ZENOHC_API void z_shm_provider_garbage_collect(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Borrows SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-const struct z_loaned_shm_provider_t *z_shm_provider_loan(const struct z_owned_shm_provider_t *this_);
+ZENOHC_API const z_loaned_shm_provider_t *z_shm_provider_loan(const z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
-                        const struct z_loaned_shm_provider_t *provider,
+void z_shm_provider_map(z_owned_shm_mut_t *out_result,
+                        const z_loaned_shm_provider_t *provider,
                         struct z_allocated_chunk_t allocated_chunk,
                         size_t len);
 #endif
@@ -3070,7 +3079,7 @@ void z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
+void z_shm_provider_new(z_owned_shm_provider_t *this_,
                         z_protocol_id_t id,
                         struct zc_context_t context,
                         struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3079,14 +3088,14 @@ void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
  * Constructs SHM Provider in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_null(struct z_owned_shm_provider_t *this_);
+ZENOHC_API void z_shm_provider_null(z_owned_shm_provider_t *this_);
 #endif
 /**
  * Creates a new threadsafe SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
+void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
                                    z_protocol_id_t id,
                                    struct zc_threadsafe_context_t context,
                                    struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3095,13 +3104,13 @@ void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
  * Mutably borrows ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_mut(struct z_owned_shm_t *this_);
+ZENOHC_API z_loaned_shm_mut_t *z_shm_try_mut(z_owned_shm_t *this_);
 #endif
 /**
  * Tries to reborrow mutably-borrowed ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_reloan_mut(struct z_loaned_shm_t *this_);
+ZENOHC_API z_loaned_shm_mut_t *z_shm_try_reloan_mut(z_loaned_shm_t *this_);
 #endif
 /**
  * Puts current thread to sleep for specified amount of milliseconds.
@@ -3823,46 +3832,46 @@ void zc_session_clone(const struct z_loaned_session_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_error_t zc_shm_client_list_add_client(z_protocol_id_t id,
-                                        struct z_owned_shm_client_t *client,
-                                        struct zc_loaned_shm_client_list_t *list);
+                                        z_owned_shm_client_t *client,
+                                        zc_loaned_shm_client_list_t *list);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool zc_shm_client_list_check(const struct zc_owned_shm_client_list_t *this_);
+ZENOHC_API bool zc_shm_client_list_check(const zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Deletes list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_drop(struct zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_drop(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const struct zc_owned_shm_client_list_t *this_);
+const zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Mutably borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(struct zc_owned_shm_client_list_t *this_);
+zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Creates a new empty list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_error_t zc_shm_client_list_new(struct zc_owned_shm_client_list_t *this_);
+ZENOHC_API z_error_t zc_shm_client_list_new(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Constructs SHM client list in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_null(struct zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_null(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Calls the closure. Calling an uninitialized closure is a no-op.

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -6,11 +6,8 @@
 
 #define z_loan(x) \
     _Generic((x), \
-        z_owned_alloc_layout_t : z_alloc_layout_loan, \
-        z_owned_buf_alloc_result_t : z_buf_alloc_result_loan, \
         z_owned_bytes_t : z_bytes_loan, \
         z_owned_bytes_writer_t : z_bytes_writer_loan, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_loan, \
         z_owned_closure_hello_t : z_closure_hello_loan, \
         z_owned_closure_owned_query_t : z_closure_owned_query_loan, \
         z_owned_closure_query_t : z_closure_query_loan, \
@@ -25,7 +22,6 @@
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_loan, \
         z_owned_hello_t : z_hello_loan, \
         z_owned_keyexpr_t : z_keyexpr_loan, \
-        z_owned_memory_layout_t : z_memory_layout_loan, \
         z_owned_publisher_t : z_publisher_loan, \
         z_owned_query_t : z_query_loan, \
         z_owned_queryable_t : z_queryable_loan, \
@@ -36,9 +32,6 @@
         z_owned_ring_handler_sample_t : z_ring_handler_sample_loan, \
         z_owned_sample_t : z_sample_loan, \
         z_owned_session_t : z_session_loan, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_loan, \
-        z_owned_shm_t : z_shm_loan, \
-        z_owned_shm_provider_t : z_shm_provider_loan, \
         z_owned_slice_t : z_slice_loan, \
         z_owned_slice_map_t : z_slice_map_loan, \
         z_owned_source_info_t : z_source_info_loan, \
@@ -49,7 +42,6 @@
         z_view_slice_t : z_view_slice_loan, \
         z_view_string_t : z_view_string_loan, \
         zc_owned_liveliness_token_t : zc_liveliness_token_loan, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_loan, \
         zcu_owned_closure_matching_status_t : zcu_closure_matching_status_loan, \
         ze_owned_querying_subscriber_t : ze_querying_subscriber_loan \
     )(&x)
@@ -62,20 +54,14 @@
         z_owned_config_t : z_config_loan_mut, \
         z_owned_mutex_t : z_mutex_loan_mut, \
         z_owned_publisher_t : z_publisher_loan_mut, \
-        z_owned_shm_t : z_shm_loan_mut, \
-        z_owned_shm_mut_t : z_shm_mut_loan_mut, \
         z_owned_slice_map_t : z_slice_map_loan_mut, \
-        z_owned_string_array_t : z_string_array_loan_mut, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_loan_mut \
+        z_owned_string_array_t : z_string_array_loan_mut \
     )(&x)
 
 #define z_drop(x) \
     _Generic((x), \
-        z_owned_alloc_layout_t* : z_alloc_layout_drop, \
-        z_owned_buf_alloc_result_t* : z_buf_alloc_result_drop, \
         z_owned_bytes_t* : z_bytes_drop, \
         z_owned_bytes_writer_t* : z_bytes_writer_drop, \
-        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_drop, \
         z_owned_closure_hello_t* : z_closure_hello_drop, \
         z_owned_closure_owned_query_t* : z_closure_owned_query_drop, \
         z_owned_closure_query_t* : z_closure_query_drop, \
@@ -90,7 +76,6 @@
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_drop, \
         z_owned_hello_t* : z_hello_drop, \
         z_owned_keyexpr_t* : z_keyexpr_drop, \
-        z_owned_memory_layout_t* : z_memory_layout_drop, \
         z_owned_mutex_t* : z_mutex_drop, \
         z_owned_publisher_t* : z_publisher_drop, \
         z_owned_query_t* : z_query_drop, \
@@ -102,11 +87,6 @@
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_drop, \
         z_owned_sample_t* : z_sample_drop, \
         z_owned_session_t* : z_session_drop, \
-        z_owned_shm_client_t* : z_shm_client_drop, \
-        z_owned_shm_client_storage_t* : z_shm_client_storage_drop, \
-        z_owned_shm_t* : z_shm_drop, \
-        z_owned_shm_mut_t* : z_shm_mut_drop, \
-        z_owned_shm_provider_t* : z_shm_provider_drop, \
         z_owned_slice_t* : z_slice_drop, \
         z_owned_slice_map_t* : z_slice_map_drop, \
         z_owned_source_info_t* : z_source_info_drop, \
@@ -114,7 +94,6 @@
         z_owned_string_t* : z_string_drop, \
         z_owned_subscriber_t* : z_subscriber_drop, \
         zc_owned_liveliness_token_t* : zc_liveliness_token_drop, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_drop, \
         zcu_owned_closure_matching_status_t* : zcu_closure_matching_status_drop, \
         ze_owned_publication_cache_t* : ze_publication_cache_drop, \
         ze_owned_querying_subscriber_t* : ze_querying_subscriber_drop \
@@ -124,11 +103,8 @@
 
 #define z_null(x) \
     _Generic((x), \
-        z_owned_alloc_layout_t* : z_alloc_layout_null, \
-        z_owned_buf_alloc_result_t* : z_buf_alloc_result_null, \
         z_owned_bytes_t* : z_bytes_null, \
         z_owned_bytes_writer_t* : z_bytes_writer_null, \
-        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_null, \
         z_owned_closure_hello_t* : z_closure_hello_null, \
         z_owned_closure_query_t* : z_closure_query_null, \
         z_owned_closure_reply_t* : z_closure_reply_null, \
@@ -142,7 +118,6 @@
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_null, \
         z_owned_hello_t* : z_hello_null, \
         z_owned_keyexpr_t* : z_keyexpr_null, \
-        z_owned_memory_layout_t* : z_memory_layout_null, \
         z_owned_mutex_t* : z_mutex_null, \
         z_owned_publisher_t* : z_publisher_null, \
         z_owned_query_t* : z_query_null, \
@@ -154,11 +129,6 @@
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_null, \
         z_owned_sample_t* : z_sample_null, \
         z_owned_session_t* : z_session_null, \
-        z_owned_shm_client_t* : z_shm_client_null, \
-        z_owned_shm_client_storage_t* : z_shm_client_storage_null, \
-        z_owned_shm_mut_t* : z_shm_mut_null, \
-        z_owned_shm_t* : z_shm_null, \
-        z_owned_shm_provider_t* : z_shm_provider_null, \
         z_owned_slice_map_t* : z_slice_map_null, \
         z_owned_slice_t* : z_slice_null, \
         z_owned_source_info_t* : z_source_info_null, \
@@ -170,7 +140,6 @@
         z_view_slice_t* : z_view_slice_null, \
         z_view_string_t* : z_view_string_null, \
         zc_owned_liveliness_token_t* : zc_liveliness_token_null, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_null, \
         zcu_owned_closure_matching_status_t* : zcu_closure_matching_status_null, \
         ze_owned_publication_cache_t* : ze_publication_cache_null, \
         ze_owned_querying_subscriber_t* : ze_querying_subscriber_null \
@@ -178,11 +147,8 @@
 
 #define z_check(x) \
     _Generic((x), \
-        z_owned_alloc_layout_t : z_alloc_layout_check, \
-        z_owned_buf_alloc_result_t : z_buf_alloc_result_check, \
         z_owned_bytes_t : z_bytes_check, \
         z_owned_bytes_writer_t : z_bytes_writer_check, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_check, \
         z_owned_closure_hello_t : z_closure_hello_check, \
         z_owned_closure_query_t : z_closure_query_check, \
         z_owned_closure_reply_t : z_closure_reply_check, \
@@ -196,7 +162,6 @@
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_check, \
         z_owned_hello_t : z_hello_check, \
         z_owned_keyexpr_t : z_keyexpr_check, \
-        z_owned_memory_layout_t : z_memory_layout_check, \
         z_owned_mutex_t : z_mutex_check, \
         z_owned_publisher_t : z_publisher_check, \
         z_owned_query_t : z_query_check, \
@@ -208,11 +173,6 @@
         z_owned_ring_handler_sample_t : z_ring_handler_sample_check, \
         z_owned_sample_t : z_sample_check, \
         z_owned_session_t : z_session_check, \
-        z_owned_shm_t : z_shm_check, \
-        z_owned_shm_client_t : z_shm_client_check, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_check, \
-        z_owned_shm_mut_t : z_shm_mut_check, \
-        z_owned_shm_provider_t : z_shm_provider_check, \
         z_owned_slice_t : z_slice_check, \
         z_owned_slice_map_t : z_slice_map_check, \
         z_owned_source_info_t : z_source_info_check, \
@@ -224,7 +184,6 @@
         z_view_slice_t : z_view_slice_check, \
         z_view_string_t : z_view_string_check, \
         zc_owned_liveliness_token_t : zc_liveliness_token_check, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_check, \
         zcu_owned_closure_matching_status_t : zcu_closure_matching_status_check, \
         ze_owned_publication_cache_t : ze_publication_cache_check, \
         ze_owned_querying_subscriber_t : ze_querying_subscriber_check \
@@ -267,11 +226,8 @@
 
 
 
-inline const z_loaned_alloc_layout_t* z_loan(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_loan(&this_); };
-inline const z_loaned_buf_alloc_result_t* z_loan(const z_owned_buf_alloc_result_t& this_) { return z_buf_alloc_result_loan(&this_); };
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& this_) { return z_bytes_loan(&this_); };
 inline const z_loaned_bytes_writer_t* z_loan(const z_owned_bytes_writer_t& this_) { return z_bytes_writer_loan(&this_); };
-inline const z_loaned_chunk_alloc_result_t* z_loan(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_loan(&this_); };
 inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t& closure) { return z_closure_hello_loan(&closure); };
 inline const z_loaned_closure_owned_query_t* z_loan(const z_owned_closure_owned_query_t& closure) { return z_closure_owned_query_loan(&closure); };
 inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t& closure) { return z_closure_query_loan(&closure); };
@@ -286,7 +242,6 @@ inline const z_loaned_fifo_handler_reply_t* z_loan(const z_owned_fifo_handler_re
 inline const z_loaned_fifo_handler_sample_t* z_loan(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_loan(&this_); };
 inline const z_loaned_hello_t* z_loan(const z_owned_hello_t& this_) { return z_hello_loan(&this_); };
 inline const z_loaned_keyexpr_t* z_loan(const z_owned_keyexpr_t& this_) { return z_keyexpr_loan(&this_); };
-inline const z_loaned_memory_layout_t* z_loan(const z_owned_memory_layout_t& this_) { return z_memory_layout_loan(&this_); };
 inline const z_loaned_publisher_t* z_loan(const z_owned_publisher_t& this_) { return z_publisher_loan(&this_); };
 inline const z_loaned_query_t* z_loan(const z_owned_query_t& this_) { return z_query_loan(&this_); };
 inline const z_loaned_queryable_t* z_loan(const z_owned_queryable_t& this_) { return z_queryable_loan(&this_); };
@@ -297,9 +252,6 @@ inline const z_loaned_ring_handler_reply_t* z_loan(const z_owned_ring_handler_re
 inline const z_loaned_ring_handler_sample_t* z_loan(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_loan(&this_); };
 inline const z_loaned_sample_t* z_loan(const z_owned_sample_t& this_) { return z_sample_loan(&this_); };
 inline const z_loaned_session_t* z_loan(const z_owned_session_t& this_) { return z_session_loan(&this_); };
-inline const z_loaned_shm_client_storage_t* z_loan(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_loan(&this_); };
-inline const z_loaned_shm_t* z_loan(const z_owned_shm_t& this_) { return z_shm_loan(&this_); };
-inline const z_loaned_shm_provider_t* z_loan(const z_owned_shm_provider_t& this_) { return z_shm_provider_loan(&this_); };
 inline const z_loaned_slice_t* z_loan(const z_owned_slice_t& this_) { return z_slice_loan(&this_); };
 inline const z_loaned_slice_map_t* z_loan(const z_owned_slice_map_t& this_) { return z_slice_map_loan(&this_); };
 inline const z_loaned_source_info_t* z_loan(const z_owned_source_info_t& this_) { return z_source_info_loan(&this_); };
@@ -310,7 +262,6 @@ inline const z_loaned_keyexpr_t* z_loan(const z_view_keyexpr_t& this_) { return 
 inline const z_loaned_slice_t* z_loan(const z_view_slice_t& this_) { return z_view_slice_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_view_string_t& this_) { return z_view_string_loan(&this_); };
 inline const zc_loaned_liveliness_token_t* z_loan(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_loan(&this_); };
-inline const zc_loaned_shm_client_list_t* z_loan(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan(&this_); };
 inline const zcu_loaned_closure_matching_status_t* z_loan(const zcu_owned_closure_matching_status_t& closure) { return zcu_closure_matching_status_loan(&closure); };
 inline const ze_loaned_querying_subscriber_t* z_loan(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_loan(&this_); };
 
@@ -321,18 +272,12 @@ inline z_loaned_condvar_t* z_loan_mut(z_owned_condvar_t& this_) { return z_condv
 inline z_loaned_config_t* z_loan_mut(z_owned_config_t& this_) { return z_config_loan_mut(&this_); };
 inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t& this_) { return z_mutex_loan_mut(&this_); };
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& this_) { return z_publisher_loan_mut(&this_); };
-inline z_loaned_shm_t* z_loan_mut(z_owned_shm_t& this_) { return z_shm_loan_mut(&this_); };
-inline z_loaned_shm_mut_t* z_loan_mut(z_owned_shm_mut_t& this_) { return z_shm_mut_loan_mut(&this_); };
 inline z_loaned_slice_map_t* z_loan_mut(z_owned_slice_map_t& this_) { return z_slice_map_loan_mut(&this_); };
 inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { return z_string_array_loan_mut(&this_); };
-inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan_mut(&this_); };
 
 
-inline void z_drop(z_owned_alloc_layout_t* this_) { return z_alloc_layout_drop(this_); };
-inline void z_drop(z_owned_buf_alloc_result_t* this_) { return z_buf_alloc_result_drop(this_); };
 inline void z_drop(z_owned_bytes_t* this_) { return z_bytes_drop(this_); };
 inline void z_drop(z_owned_bytes_writer_t* this_) { return z_bytes_writer_drop(this_); };
-inline void z_drop(z_owned_chunk_alloc_result_t* this_) { return z_chunk_alloc_result_drop(this_); };
 inline void z_drop(z_owned_closure_hello_t* closure) { return z_closure_hello_drop(closure); };
 inline void z_drop(z_owned_closure_owned_query_t* closure) { return z_closure_owned_query_drop(closure); };
 inline void z_drop(z_owned_closure_query_t* closure) { return z_closure_query_drop(closure); };
@@ -347,7 +292,6 @@ inline void z_drop(z_owned_fifo_handler_reply_t* this_) { return z_fifo_handler_
 inline void z_drop(z_owned_fifo_handler_sample_t* this_) { return z_fifo_handler_sample_drop(this_); };
 inline void z_drop(z_owned_hello_t* this_) { return z_hello_drop(this_); };
 inline void z_drop(z_owned_keyexpr_t* this_) { return z_keyexpr_drop(this_); };
-inline void z_drop(z_owned_memory_layout_t* this_) { return z_memory_layout_drop(this_); };
 inline void z_drop(z_owned_mutex_t* this_) { return z_mutex_drop(this_); };
 inline void z_drop(z_owned_publisher_t* this_) { return z_publisher_drop(this_); };
 inline void z_drop(z_owned_query_t* this_) { return z_query_drop(this_); };
@@ -359,11 +303,6 @@ inline void z_drop(z_owned_ring_handler_reply_t* this_) { return z_ring_handler_
 inline void z_drop(z_owned_ring_handler_sample_t* this_) { return z_ring_handler_sample_drop(this_); };
 inline void z_drop(z_owned_sample_t* this_) { return z_sample_drop(this_); };
 inline void z_drop(z_owned_session_t* this_) { return z_session_drop(this_); };
-inline void z_drop(z_owned_shm_client_t* this_) { return z_shm_client_drop(this_); };
-inline void z_drop(z_owned_shm_client_storage_t* this_) { return z_shm_client_storage_drop(this_); };
-inline void z_drop(z_owned_shm_t* this_) { return z_shm_drop(this_); };
-inline void z_drop(z_owned_shm_mut_t* this_) { return z_shm_mut_drop(this_); };
-inline void z_drop(z_owned_shm_provider_t* this_) { return z_shm_provider_drop(this_); };
 inline void z_drop(z_owned_slice_t* this_) { return z_slice_drop(this_); };
 inline void z_drop(z_owned_slice_map_t* this_) { return z_slice_map_drop(this_); };
 inline void z_drop(z_owned_source_info_t* this_) { return z_source_info_drop(this_); };
@@ -371,17 +310,13 @@ inline void z_drop(z_owned_string_array_t* this_) { return z_string_array_drop(t
 inline void z_drop(z_owned_string_t* this_) { return z_string_drop(this_); };
 inline void z_drop(z_owned_subscriber_t* this_) { return z_subscriber_drop(this_); };
 inline void z_drop(zc_owned_liveliness_token_t* this_) { return zc_liveliness_token_drop(this_); };
-inline void z_drop(zc_owned_shm_client_list_t* this_) { return zc_shm_client_list_drop(this_); };
 inline void z_drop(zcu_owned_closure_matching_status_t* closure) { return zcu_closure_matching_status_drop(closure); };
 inline void z_drop(ze_owned_publication_cache_t* this_) { return ze_publication_cache_drop(this_); };
 inline void z_drop(ze_owned_querying_subscriber_t* this_) { return ze_querying_subscriber_drop(this_); };
 
 
-inline z_owned_alloc_layout_t* z_move(z_owned_alloc_layout_t& this_) { return (&this_); };
-inline z_owned_buf_alloc_result_t* z_move(z_owned_buf_alloc_result_t& this_) { return (&this_); };
 inline z_owned_bytes_t* z_move(z_owned_bytes_t& this_) { return (&this_); };
 inline z_owned_bytes_writer_t* z_move(z_owned_bytes_writer_t& this_) { return (&this_); };
-inline z_owned_chunk_alloc_result_t* z_move(z_owned_chunk_alloc_result_t& this_) { return (&this_); };
 inline z_owned_closure_hello_t* z_move(z_owned_closure_hello_t& closure) { return (&closure); };
 inline z_owned_closure_owned_query_t* z_move(z_owned_closure_owned_query_t& closure) { return (&closure); };
 inline z_owned_closure_query_t* z_move(z_owned_closure_query_t& closure) { return (&closure); };
@@ -396,7 +331,6 @@ inline z_owned_fifo_handler_reply_t* z_move(z_owned_fifo_handler_reply_t& this_)
 inline z_owned_fifo_handler_sample_t* z_move(z_owned_fifo_handler_sample_t& this_) { return (&this_); };
 inline z_owned_hello_t* z_move(z_owned_hello_t& this_) { return (&this_); };
 inline z_owned_keyexpr_t* z_move(z_owned_keyexpr_t& this_) { return (&this_); };
-inline z_owned_memory_layout_t* z_move(z_owned_memory_layout_t& this_) { return (&this_); };
 inline z_owned_mutex_t* z_move(z_owned_mutex_t& this_) { return (&this_); };
 inline z_owned_publisher_t* z_move(z_owned_publisher_t& this_) { return (&this_); };
 inline z_owned_query_t* z_move(z_owned_query_t& this_) { return (&this_); };
@@ -408,11 +342,6 @@ inline z_owned_ring_handler_reply_t* z_move(z_owned_ring_handler_reply_t& this_)
 inline z_owned_ring_handler_sample_t* z_move(z_owned_ring_handler_sample_t& this_) { return (&this_); };
 inline z_owned_sample_t* z_move(z_owned_sample_t& this_) { return (&this_); };
 inline z_owned_session_t* z_move(z_owned_session_t& this_) { return (&this_); };
-inline z_owned_shm_client_t* z_move(z_owned_shm_client_t& this_) { return (&this_); };
-inline z_owned_shm_client_storage_t* z_move(z_owned_shm_client_storage_t& this_) { return (&this_); };
-inline z_owned_shm_t* z_move(z_owned_shm_t& this_) { return (&this_); };
-inline z_owned_shm_mut_t* z_move(z_owned_shm_mut_t& this_) { return (&this_); };
-inline z_owned_shm_provider_t* z_move(z_owned_shm_provider_t& this_) { return (&this_); };
 inline z_owned_slice_t* z_move(z_owned_slice_t& this_) { return (&this_); };
 inline z_owned_slice_map_t* z_move(z_owned_slice_map_t& this_) { return (&this_); };
 inline z_owned_source_info_t* z_move(z_owned_source_info_t& this_) { return (&this_); };
@@ -420,17 +349,13 @@ inline z_owned_string_array_t* z_move(z_owned_string_array_t& this_) { return (&
 inline z_owned_string_t* z_move(z_owned_string_t& this_) { return (&this_); };
 inline z_owned_subscriber_t* z_move(z_owned_subscriber_t& this_) { return (&this_); };
 inline zc_owned_liveliness_token_t* z_move(zc_owned_liveliness_token_t& this_) { return (&this_); };
-inline zc_owned_shm_client_list_t* z_move(zc_owned_shm_client_list_t& this_) { return (&this_); };
 inline zcu_owned_closure_matching_status_t* z_move(zcu_owned_closure_matching_status_t& closure) { return (&closure); };
 inline ze_owned_publication_cache_t* z_move(ze_owned_publication_cache_t& this_) { return (&this_); };
 inline ze_owned_querying_subscriber_t* z_move(ze_owned_querying_subscriber_t& this_) { return (&this_); };
 
 
-inline void z_null(z_owned_alloc_layout_t* this_) { return z_alloc_layout_null(this_); };
-inline void z_null(z_owned_buf_alloc_result_t* this_) { return z_buf_alloc_result_null(this_); };
 inline void z_null(z_owned_bytes_t* this_) { return z_bytes_null(this_); };
 inline void z_null(z_owned_bytes_writer_t* this_) { return z_bytes_writer_null(this_); };
-inline void z_null(z_owned_chunk_alloc_result_t* this_) { return z_chunk_alloc_result_null(this_); };
 inline void z_null(z_owned_closure_hello_t* this_) { return z_closure_hello_null(this_); };
 inline void z_null(z_owned_closure_query_t* this_) { return z_closure_query_null(this_); };
 inline void z_null(z_owned_closure_reply_t* this_) { return z_closure_reply_null(this_); };
@@ -444,7 +369,6 @@ inline void z_null(z_owned_fifo_handler_reply_t* this_) { return z_fifo_handler_
 inline void z_null(z_owned_fifo_handler_sample_t* this_) { return z_fifo_handler_sample_null(this_); };
 inline void z_null(z_owned_hello_t* this_) { return z_hello_null(this_); };
 inline void z_null(z_owned_keyexpr_t* this_) { return z_keyexpr_null(this_); };
-inline void z_null(z_owned_memory_layout_t* this_) { return z_memory_layout_null(this_); };
 inline void z_null(z_owned_mutex_t* this_) { return z_mutex_null(this_); };
 inline void z_null(z_owned_publisher_t* this_) { return z_publisher_null(this_); };
 inline void z_null(z_owned_query_t* this_) { return z_query_null(this_); };
@@ -456,11 +380,6 @@ inline void z_null(z_owned_ring_handler_reply_t* this_) { return z_ring_handler_
 inline void z_null(z_owned_ring_handler_sample_t* this_) { return z_ring_handler_sample_null(this_); };
 inline void z_null(z_owned_sample_t* this_) { return z_sample_null(this_); };
 inline void z_null(z_owned_session_t* this_) { return z_session_null(this_); };
-inline void z_null(z_owned_shm_client_t* this_) { return z_shm_client_null(this_); };
-inline void z_null(z_owned_shm_client_storage_t* this_) { return z_shm_client_storage_null(this_); };
-inline void z_null(z_owned_shm_mut_t* this_) { return z_shm_mut_null(this_); };
-inline void z_null(z_owned_shm_t* this_) { return z_shm_null(this_); };
-inline void z_null(z_owned_shm_provider_t* this_) { return z_shm_provider_null(this_); };
 inline void z_null(z_owned_slice_map_t* this_) { return z_slice_map_null(this_); };
 inline void z_null(z_owned_slice_t* this_) { return z_slice_null(this_); };
 inline void z_null(z_owned_source_info_t* this_) { return z_source_info_null(this_); };
@@ -472,17 +391,13 @@ inline void z_null(z_view_keyexpr_t* this_) { return z_view_keyexpr_null(this_);
 inline void z_null(z_view_slice_t* this_) { return z_view_slice_null(this_); };
 inline void z_null(z_view_string_t* this_) { return z_view_string_null(this_); };
 inline void z_null(zc_owned_liveliness_token_t* this_) { return zc_liveliness_token_null(this_); };
-inline void z_null(zc_owned_shm_client_list_t* this_) { return zc_shm_client_list_null(this_); };
 inline void z_null(zcu_owned_closure_matching_status_t* this_) { return zcu_closure_matching_status_null(this_); };
 inline void z_null(ze_owned_publication_cache_t* this_) { return ze_publication_cache_null(this_); };
 inline void z_null(ze_owned_querying_subscriber_t* this_) { return ze_querying_subscriber_null(this_); };
 
 
-inline bool z_check(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_check(&this_); };
-inline bool z_check(const z_owned_buf_alloc_result_t& this_) { return z_buf_alloc_result_check(&this_); };
 inline bool z_check(const z_owned_bytes_t& this_) { return z_bytes_check(&this_); };
 inline bool z_check(const z_owned_bytes_writer_t& this_) { return z_bytes_writer_check(&this_); };
-inline bool z_check(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_check(&this_); };
 inline bool z_check(const z_owned_closure_hello_t& this_) { return z_closure_hello_check(&this_); };
 inline bool z_check(const z_owned_closure_query_t& this_) { return z_closure_query_check(&this_); };
 inline bool z_check(const z_owned_closure_reply_t& this_) { return z_closure_reply_check(&this_); };
@@ -496,7 +411,6 @@ inline bool z_check(const z_owned_fifo_handler_reply_t& this_) { return z_fifo_h
 inline bool z_check(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_hello_t& this_) { return z_hello_check(&this_); };
 inline bool z_check(const z_owned_keyexpr_t& this_) { return z_keyexpr_check(&this_); };
-inline bool z_check(const z_owned_memory_layout_t& this_) { return z_memory_layout_check(&this_); };
 inline bool z_check(const z_owned_mutex_t& this_) { return z_mutex_check(&this_); };
 inline bool z_check(const z_owned_publisher_t& this_) { return z_publisher_check(&this_); };
 inline bool z_check(const z_owned_query_t& query) { return z_query_check(&query); };
@@ -508,11 +422,6 @@ inline bool z_check(const z_owned_ring_handler_reply_t& this_) { return z_ring_h
 inline bool z_check(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_sample_t& this_) { return z_sample_check(&this_); };
 inline bool z_check(const z_owned_session_t& this_) { return z_session_check(&this_); };
-inline bool z_check(const z_owned_shm_t& this_) { return z_shm_check(&this_); };
-inline bool z_check(const z_owned_shm_client_t& this_) { return z_shm_client_check(&this_); };
-inline bool z_check(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_check(&this_); };
-inline bool z_check(const z_owned_shm_mut_t& this_) { return z_shm_mut_check(&this_); };
-inline bool z_check(const z_owned_shm_provider_t& this_) { return z_shm_provider_check(&this_); };
 inline bool z_check(const z_owned_slice_t& this_) { return z_slice_check(&this_); };
 inline bool z_check(const z_owned_slice_map_t& map) { return z_slice_map_check(&map); };
 inline bool z_check(const z_owned_source_info_t& this_) { return z_source_info_check(&this_); };
@@ -524,7 +433,6 @@ inline bool z_check(const z_view_keyexpr_t& this_) { return z_view_keyexpr_check
 inline bool z_check(const z_view_slice_t& this_) { return z_view_slice_check(&this_); };
 inline bool z_check(const z_view_string_t& this_) { return z_view_string_check(&this_); };
 inline bool z_check(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_check(&this_); };
-inline bool z_check(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_check(&this_); };
 inline bool z_check(const zcu_owned_closure_matching_status_t& this_) { return zcu_closure_matching_status_check(&this_); };
 inline bool z_check(const ze_owned_publication_cache_t& this_) { return ze_publication_cache_check(&this_); };
 inline bool z_check(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_check(&this_); };
@@ -659,16 +567,10 @@ inline bool z_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sample_t
 
 template<class T> struct z_loaned_to_owned_type_t {};
 template<class T> struct z_owned_to_loaned_type_t {};
-template<> struct z_loaned_to_owned_type_t<z_loaned_alloc_layout_t> { typedef z_owned_alloc_layout_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_alloc_layout_t> { typedef z_loaned_alloc_layout_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_buf_alloc_result_t> { typedef z_owned_buf_alloc_result_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_buf_alloc_result_t> { typedef z_loaned_buf_alloc_result_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_t> { typedef z_owned_bytes_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_t> { typedef z_loaned_bytes_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_writer_t> { typedef z_owned_bytes_writer_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_writer_t> { typedef z_loaned_bytes_writer_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_chunk_alloc_result_t> { typedef z_owned_chunk_alloc_result_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_chunk_alloc_result_t> { typedef z_loaned_chunk_alloc_result_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_hello_t> { typedef z_owned_closure_hello_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_hello_t> { typedef z_loaned_closure_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_owned_query_t> { typedef z_owned_closure_owned_query_t type; };
@@ -697,8 +599,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_hello_t> { typedef z_owned_h
 template<> struct z_owned_to_loaned_type_t<z_owned_hello_t> { typedef z_loaned_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_keyexpr_t> { typedef z_owned_keyexpr_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_keyexpr_t> { typedef z_loaned_keyexpr_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_memory_layout_t> { typedef z_owned_memory_layout_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_memory_layout_t> { typedef z_loaned_memory_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_publisher_t> { typedef z_owned_publisher_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_publisher_t> { typedef z_loaned_publisher_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_query_t> { typedef z_owned_query_t type; };
@@ -719,12 +619,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_sample_t> { typedef z_owned_
 template<> struct z_owned_to_loaned_type_t<z_owned_sample_t> { typedef z_loaned_sample_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_session_t> { typedef z_owned_session_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_session_t> { typedef z_loaned_session_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_client_storage_t> { typedef z_owned_shm_client_storage_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_client_storage_t> { typedef z_loaned_shm_client_storage_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_t> { typedef z_owned_shm_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_t> { typedef z_loaned_shm_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_provider_t> { typedef z_owned_shm_provider_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_provider_t> { typedef z_loaned_shm_provider_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_slice_t> { typedef z_owned_slice_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_slice_t> { typedef z_loaned_slice_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_slice_map_t> { typedef z_owned_slice_map_t type; };
@@ -739,14 +633,10 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_subscriber_t> { typedef z_ow
 template<> struct z_owned_to_loaned_type_t<z_owned_subscriber_t> { typedef z_loaned_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<zc_loaned_liveliness_token_t> { typedef zc_owned_liveliness_token_t type; };
 template<> struct z_owned_to_loaned_type_t<zc_owned_liveliness_token_t> { typedef zc_loaned_liveliness_token_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_shm_client_list_t> { typedef zc_owned_shm_client_list_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_shm_client_list_t> { typedef zc_loaned_shm_client_list_t type; };
 template<> struct z_loaned_to_owned_type_t<zcu_loaned_closure_matching_status_t> { typedef zcu_owned_closure_matching_status_t type; };
 template<> struct z_owned_to_loaned_type_t<zcu_owned_closure_matching_status_t> { typedef zcu_loaned_closure_matching_status_t type; };
 template<> struct z_loaned_to_owned_type_t<ze_loaned_querying_subscriber_t> { typedef ze_owned_querying_subscriber_t type; };
 template<> struct z_owned_to_loaned_type_t<ze_owned_querying_subscriber_t> { typedef ze_loaned_querying_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_mutex_t> { typedef z_owned_mutex_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_mutex_t> { typedef z_loaned_mutex_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_mut_t> { typedef z_owned_shm_mut_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_mut_t> { typedef z_loaned_shm_mut_t type; };
 #endif  // #ifndef __cplusplus

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -99,7 +99,7 @@ extern "C" fn z_bytes_len(this: &z_loaned_bytes_t) -> usize {
 /// @param dst: An unitialized memory location where to construct a decoded string.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_decode_into_string(
+pub unsafe extern "C" fn z_bytes_deserialize_into_string(
     this: &z_loaned_bytes_t,
     dst: *mut MaybeUninit<z_owned_string_t>,
 ) -> z_error_t {
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn z_bytes_decode_into_string(
 /// @param dst: An unitialized memory location where to construct a decoded map.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_decode_into_slice_map(
+pub unsafe extern "C" fn z_bytes_deserialize_into_slice_map(
     this: &z_loaned_bytes_t,
     dst: *mut MaybeUninit<z_owned_slice_map_t>,
 ) -> z_error_t {
@@ -146,7 +146,7 @@ pub unsafe extern "C" fn z_bytes_decode_into_slice_map(
 /// @param dst: An unitialized memory location where to construct a slice.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_decode_into_slice(
+pub unsafe extern "C" fn z_bytes_deserialize_into_slice(
     this: &z_loaned_bytes_t,
     dst: *mut MaybeUninit<z_owned_slice_t>,
 ) -> z_error_t {
@@ -171,7 +171,7 @@ pub unsafe extern "C" fn z_bytes_decode_into_slice(
 /// @param dst: An unitialized memory location where to construct a decoded string.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_decode_into_owned_shm(
+pub unsafe extern "C" fn z_bytes_deserialize_into_owned_shm(
     this: &z_loaned_bytes_t,
     dst: *mut MaybeUninit<z_owned_shm_t>,
 ) -> z_error_t {
@@ -198,7 +198,7 @@ pub unsafe extern "C" fn z_bytes_decode_into_owned_shm(
 /// @param dst: An unitialized memory location where to construct a decoded string.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_decode_into_loaned_shm(
+pub unsafe extern "C" fn z_bytes_deserialize_into_loaned_shm(
     this: &z_loaned_bytes_t,
     dst: *mut MaybeUninit<&'static z_loaned_shm_t>,
 ) -> z_error_t {
@@ -224,7 +224,7 @@ pub unsafe extern "C" fn z_bytes_decode_into_loaned_shm(
 /// @param dst: An unitialized memory location where to construct a decoded string.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_decode_into_mut_loaned_shm(
+pub unsafe extern "C" fn z_bytes_deserialize_into_mut_loaned_shm(
     this: &mut z_loaned_bytes_t,
     dst: *mut MaybeUninit<&'static mut z_loaned_shm_t>,
 ) -> z_error_t {
@@ -271,7 +271,7 @@ impl From<CSlice> for ZBytes {
     }
 }
 
-fn z_bytes_encode_from_arithmetic<T>(this: *mut MaybeUninit<z_owned_bytes_t>, val: T)
+fn z_bytes_serialize_from_arithmetic<T>(this: *mut MaybeUninit<z_owned_bytes_t>, val: T)
 where
     ZSerde: Serialize<T, Output = ZBytes>,
 {
@@ -280,7 +280,7 @@ where
     Inplace::init(this, payload);
 }
 
-fn z_bytes_decode_into_arithmetic<T>(this: &z_loaned_bytes_t, val: &mut T) -> z_error_t
+fn z_bytes_deserialize_into_arithmetic<T>(this: &z_loaned_bytes_t, val: &mut T) -> z_error_t
 where
     ZSerde: Deserialize<'static, T, Input = &'static ZBytes>,
     <ZSerde as Deserialize<'static, T>>::Error: fmt::Debug,
@@ -299,137 +299,167 @@ where
 
 /// Encodes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_uint8(this: *mut MaybeUninit<z_owned_bytes_t>, val: u8) {
-    z_bytes_encode_from_arithmetic::<u8>(this, val);
+pub extern "C" fn z_bytes_serialize_from_uint8(this: *mut MaybeUninit<z_owned_bytes_t>, val: u8) {
+    z_bytes_serialize_from_arithmetic::<u8>(this, val);
 }
 
 /// Encodes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_uint16(this: *mut MaybeUninit<z_owned_bytes_t>, val: u16) {
-    z_bytes_encode_from_arithmetic::<u16>(this, val);
+pub extern "C" fn z_bytes_serialize_from_uint16(this: *mut MaybeUninit<z_owned_bytes_t>, val: u16) {
+    z_bytes_serialize_from_arithmetic::<u16>(this, val);
 }
 
 /// Encodes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_uint32(this: *mut MaybeUninit<z_owned_bytes_t>, val: u32) {
-    z_bytes_encode_from_arithmetic::<u32>(this, val);
+pub extern "C" fn z_bytes_serialize_from_uint32(this: *mut MaybeUninit<z_owned_bytes_t>, val: u32) {
+    z_bytes_serialize_from_arithmetic::<u32>(this, val);
 }
 
 /// Encodes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_uint64(this: *mut MaybeUninit<z_owned_bytes_t>, val: u64) {
-    z_bytes_encode_from_arithmetic::<u64>(this, val);
+pub extern "C" fn z_bytes_serialize_from_uint64(this: *mut MaybeUninit<z_owned_bytes_t>, val: u64) {
+    z_bytes_serialize_from_arithmetic::<u64>(this, val);
 }
 
 /// Encodes a signed integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_int8(this: *mut MaybeUninit<z_owned_bytes_t>, val: i8) {
-    z_bytes_encode_from_arithmetic::<i8>(this, val);
+pub extern "C" fn z_bytes_serialize_from_int8(this: *mut MaybeUninit<z_owned_bytes_t>, val: i8) {
+    z_bytes_serialize_from_arithmetic::<i8>(this, val);
 }
 
 /// Encodes a signed integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_int16(this: *mut MaybeUninit<z_owned_bytes_t>, val: i16) {
-    z_bytes_encode_from_arithmetic::<i16>(this, val);
+pub extern "C" fn z_bytes_serialize_from_int16(this: *mut MaybeUninit<z_owned_bytes_t>, val: i16) {
+    z_bytes_serialize_from_arithmetic::<i16>(this, val);
 }
 
 /// Encodes a signed integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_int32(this: *mut MaybeUninit<z_owned_bytes_t>, val: i32) {
-    z_bytes_encode_from_arithmetic::<i32>(this, val);
+pub extern "C" fn z_bytes_serialize_from_int32(this: *mut MaybeUninit<z_owned_bytes_t>, val: i32) {
+    z_bytes_serialize_from_arithmetic::<i32>(this, val);
 }
 
 /// Encodes a signed integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_int64(this: *mut MaybeUninit<z_owned_bytes_t>, val: i64) {
-    z_bytes_encode_from_arithmetic::<i64>(this, val);
+pub extern "C" fn z_bytes_serialize_from_int64(this: *mut MaybeUninit<z_owned_bytes_t>, val: i64) {
+    z_bytes_serialize_from_arithmetic::<i64>(this, val);
 }
 
 /// Encodes a float.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_float(this: *mut MaybeUninit<z_owned_bytes_t>, val: f32) {
-    z_bytes_encode_from_arithmetic::<f32>(this, val);
+pub extern "C" fn z_bytes_serialize_from_float(this: *mut MaybeUninit<z_owned_bytes_t>, val: f32) {
+    z_bytes_serialize_from_arithmetic::<f32>(this, val);
 }
 
 /// Encodes a double.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_double(this: *mut MaybeUninit<z_owned_bytes_t>, val: f64) {
-    z_bytes_encode_from_arithmetic::<f64>(this, val);
+pub extern "C" fn z_bytes_serialize_from_double(this: *mut MaybeUninit<z_owned_bytes_t>, val: f64) {
+    z_bytes_serialize_from_arithmetic::<f64>(this, val);
 }
 /// Decodes into an unsigned integer.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_decode_into_uint8(this: &z_loaned_bytes_t, dst: &mut u8) -> z_error_t {
-    z_bytes_decode_into_arithmetic::<u8>(this, dst)
-}
-
-/// Decodes into an unsigned integer.
-/// @return 0 in case of success, negative error code otherwise.
-#[no_mangle]
-pub extern "C" fn z_bytes_decode_into_uint16(this: &z_loaned_bytes_t, dst: &mut u16) -> z_error_t {
-    z_bytes_decode_into_arithmetic::<u16>(this, dst)
+pub extern "C" fn z_bytes_deserialize_into_uint8(
+    this: &z_loaned_bytes_t,
+    dst: &mut u8,
+) -> z_error_t {
+    z_bytes_deserialize_into_arithmetic::<u8>(this, dst)
 }
 
 /// Decodes into an unsigned integer.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_decode_into_uint32(this: &z_loaned_bytes_t, dst: &mut u32) -> z_error_t {
-    z_bytes_decode_into_arithmetic::<u32>(this, dst)
+pub extern "C" fn z_bytes_deserialize_into_uint16(
+    this: &z_loaned_bytes_t,
+    dst: &mut u16,
+) -> z_error_t {
+    z_bytes_deserialize_into_arithmetic::<u16>(this, dst)
 }
 
 /// Decodes into an unsigned integer.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_decode_into_uint64(this: &z_loaned_bytes_t, dst: &mut u64) -> z_error_t {
-    z_bytes_decode_into_arithmetic::<u64>(this, dst)
+pub extern "C" fn z_bytes_deserialize_into_uint32(
+    this: &z_loaned_bytes_t,
+    dst: &mut u32,
+) -> z_error_t {
+    z_bytes_deserialize_into_arithmetic::<u32>(this, dst)
+}
+
+/// Decodes into an unsigned integer.
+/// @return 0 in case of success, negative error code otherwise.
+#[no_mangle]
+pub extern "C" fn z_bytes_deserialize_into_uint64(
+    this: &z_loaned_bytes_t,
+    dst: &mut u64,
+) -> z_error_t {
+    z_bytes_deserialize_into_arithmetic::<u64>(this, dst)
 }
 
 /// Decodes into a signed integer.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_decode_into_int8(this: &z_loaned_bytes_t, dst: &mut i8) -> z_error_t {
-    z_bytes_decode_into_arithmetic::<i8>(this, dst)
+pub extern "C" fn z_bytes_deserialize_into_int8(
+    this: &z_loaned_bytes_t,
+    dst: &mut i8,
+) -> z_error_t {
+    z_bytes_deserialize_into_arithmetic::<i8>(this, dst)
 }
 
 /// Decodes into a signed integer.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_decode_into_int16(this: &z_loaned_bytes_t, dst: &mut i16) -> z_error_t {
-    z_bytes_decode_into_arithmetic::<i16>(this, dst)
+pub extern "C" fn z_bytes_deserialize_into_int16(
+    this: &z_loaned_bytes_t,
+    dst: &mut i16,
+) -> z_error_t {
+    z_bytes_deserialize_into_arithmetic::<i16>(this, dst)
 }
 
 /// Decodes into a signed integer.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_decode_into_int32(this: &z_loaned_bytes_t, dst: &mut i32) -> z_error_t {
-    z_bytes_decode_into_arithmetic::<i32>(this, dst)
+pub extern "C" fn z_bytes_deserialize_into_int32(
+    this: &z_loaned_bytes_t,
+    dst: &mut i32,
+) -> z_error_t {
+    z_bytes_deserialize_into_arithmetic::<i32>(this, dst)
 }
 
 /// Decodes into a signed integer.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_decode_into_int64(this: &z_loaned_bytes_t, dst: &mut i64) -> z_error_t {
-    z_bytes_decode_into_arithmetic::<i64>(this, dst)
+pub extern "C" fn z_bytes_deserialize_into_int64(
+    this: &z_loaned_bytes_t,
+    dst: &mut i64,
+) -> z_error_t {
+    z_bytes_deserialize_into_arithmetic::<i64>(this, dst)
 }
 
 /// Decodes into a float.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_decode_into_float(this: &z_loaned_bytes_t, dst: &mut f32) -> z_error_t {
-    z_bytes_decode_into_arithmetic::<f32>(this, dst)
+pub extern "C" fn z_bytes_deserialize_into_float(
+    this: &z_loaned_bytes_t,
+    dst: &mut f32,
+) -> z_error_t {
+    z_bytes_deserialize_into_arithmetic::<f32>(this, dst)
 }
 
 /// Decodes into a signed integer.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_decode_into_double(this: &z_loaned_bytes_t, dst: &mut f64) -> z_error_t {
-    z_bytes_decode_into_arithmetic::<f64>(this, dst)
+pub extern "C" fn z_bytes_deserialize_into_double(
+    this: &z_loaned_bytes_t,
+    dst: &mut f64,
+) -> z_error_t {
+    z_bytes_deserialize_into_arithmetic::<f64>(this, dst)
 }
 
 /// Encodes a slice by aliasing.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_encode_from_slice(
+pub unsafe extern "C" fn z_bytes_serialize_from_slice(
     this: *mut MaybeUninit<z_owned_bytes_t>,
     data: *const u8,
     len: usize,
@@ -443,7 +473,7 @@ pub unsafe extern "C" fn z_bytes_encode_from_slice(
 /// Encodes a slice by copying.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_encode_from_slice_copy(
+pub unsafe extern "C" fn z_bytes_serialize_from_slice_copy(
     this: *mut MaybeUninit<z_owned_bytes_t>,
     data: *const u8,
     len: usize,
@@ -457,7 +487,7 @@ pub unsafe extern "C" fn z_bytes_encode_from_slice_copy(
 /// Encodes slice map by aliasing.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_encode_from_slice_map(
+pub unsafe extern "C" fn z_bytes_serialize_from_slice_map(
     this: *mut MaybeUninit<z_owned_bytes_t>,
     bytes_map: &z_loaned_slice_map_t,
 ) {
@@ -475,7 +505,7 @@ pub unsafe extern "C" fn z_bytes_encode_from_slice_map(
 /// Encodes slice map by copying.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_encode_from_slice_map_copy(
+pub unsafe extern "C" fn z_bytes_serialize_from_slice_map_copy(
     this: *mut MaybeUninit<z_owned_bytes_t>,
     bytes_map: &z_loaned_slice_map_t,
 ) {
@@ -493,27 +523,27 @@ pub unsafe extern "C" fn z_bytes_encode_from_slice_map_copy(
 /// Encodes a null-terminated string by aliasing.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_encode_from_string(
+pub unsafe extern "C" fn z_bytes_serialize_from_string(
     this: *mut MaybeUninit<z_owned_bytes_t>,
     s: *const libc::c_char,
 ) {
-    z_bytes_encode_from_slice(this, s as *const u8, libc::strlen(s));
+    z_bytes_serialize_from_slice(this, s as *const u8, libc::strlen(s));
 }
 
 /// Encodes a null-terminated string by copying.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_encode_from_string_copy(
+pub unsafe extern "C" fn z_bytes_serialize_from_string_copy(
     this: *mut MaybeUninit<z_owned_bytes_t>,
     s: *const libc::c_char,
 ) {
-    z_bytes_encode_from_slice_copy(this, s as *const u8, libc::strlen(s));
+    z_bytes_serialize_from_slice_copy(this, s as *const u8, libc::strlen(s));
 }
 
 /// Encodes a pair of `z_owned_bytes` objects which are consumed in the process.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_pair(
+pub extern "C" fn z_bytes_serialize_from_pair(
     this: *mut MaybeUninit<z_owned_bytes_t>,
     first: &mut z_owned_bytes_t,
     second: &mut z_owned_bytes_t,
@@ -530,7 +560,7 @@ pub extern "C" fn z_bytes_encode_from_pair(
 /// Decodes into a pair of `z_owned_bytes` objects.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_decode_into_pair(
+pub extern "C" fn z_bytes_deserialize_into_pair(
     this: &z_loaned_bytes_t,
     first: *mut MaybeUninit<z_owned_bytes_t>,
     second: *mut MaybeUninit<z_owned_bytes_t>,
@@ -575,7 +605,7 @@ impl Iterator for ZBytesInIterator {
 /// @param context: Arbitrary context that will be passed to iterator_body.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_bytes_encode_from_iter(
+pub extern "C" fn z_bytes_serialize_from_iter(
     this: *mut MaybeUninit<z_owned_bytes_t>,
     iterator_body: extern "C" fn(
         data: &mut MaybeUninit<z_owned_bytes_t>,
@@ -652,7 +682,7 @@ pub extern "C" fn z_bytes_iter(
 /// Encodes from an immutable SHM buffer consuming it
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_encode_from_shm(
+pub unsafe extern "C" fn z_bytes_serialize_from_shm(
     this: *mut MaybeUninit<z_owned_bytes_t>,
     shm: &mut z_owned_shm_t,
 ) -> z_error_t {
@@ -670,7 +700,7 @@ pub unsafe extern "C" fn z_bytes_encode_from_shm(
 /// Encodes from an immutable SHM buffer copying it
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_encode_from_shm_copy(
+pub unsafe extern "C" fn z_bytes_serialize_from_shm_copy(
     this: *mut MaybeUninit<z_owned_bytes_t>,
     shm: &z_loaned_shm_t,
 ) {
@@ -682,7 +712,7 @@ pub unsafe extern "C" fn z_bytes_encode_from_shm_copy(
 /// Encodes from a mutable SHM buffer consuming it
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_encode_from_shm_mut(
+pub unsafe extern "C" fn z_bytes_serialize_from_shm_mut(
     this: *mut MaybeUninit<z_owned_bytes_t>,
     shm: &mut z_owned_shm_mut_t,
 ) -> z_error_t {

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -64,7 +64,7 @@ void query_handler(const z_loaned_query_t *query, void *arg) {
     z_query_reply_options_default(&_ret_qreply_opt);
 
     z_owned_bytes_t payload;
-    z_bytes_encode_from_string(&payload, value);
+    z_bytes_serialize_from_string(&payload, value);
     z_query_reply(query, query_ke, z_move(payload), &_ret_qreply_opt);
 }
 
@@ -281,7 +281,7 @@ int main(int argc, char **argv) {
     // TODO: set encoding option
 
     z_owned_bytes_t payload;
-    z_bytes_encode_from_string(&payload, value);
+    z_bytes_serialize_from_string(&payload, value);
     _ret_int8 = z_put(z_loan(s1), z_loan(_ret_expr), z_move(payload), &_ret_put_opt);
     assert(_ret_int8 == 0);
 

--- a/tests/z_api_drop_options.c
+++ b/tests/z_api_drop_options.c
@@ -36,9 +36,9 @@ void put() {
     z_put_options_t opts;
     z_put_options_default(&opts);
     z_owned_bytes_t payload, attachment;
-    z_bytes_encode_from_int32(&attachment, 16);
+    z_bytes_serialize_from_int32(&attachment, 16);
     opts.attachment = &attachment;
-    z_bytes_encode_from_int32(&payload, 16);
+    z_bytes_serialize_from_int32(&payload, 16);
     z_put(z_loan(s), z_loan(ke), z_move(payload), &opts);
     assert(!z_check(payload));
     assert(!z_check(attachment));
@@ -60,9 +60,9 @@ void get() {
     z_get_options_t opts;
     z_get_options_default(&opts);
     z_owned_bytes_t payload, attachment;
-    z_bytes_encode_from_int32(&attachment, 16);
+    z_bytes_serialize_from_int32(&attachment, 16);
     opts.payload = &payload;
-    z_bytes_encode_from_int32(&payload, 16);
+    z_bytes_serialize_from_int32(&payload, 16);
     opts.attachment = &attachment;
     z_owned_closure_reply_t closure;
     z_closure(&closure, cb, drop, NULL);

--- a/tests/z_api_map_test.c
+++ b/tests/z_api_map_test.c
@@ -34,7 +34,7 @@ void writting_by_alias_read_by_get() {
     z_slice_map_insert_by_alias(z_loan_mut(map), z_loan(k1), z_loan(v1));
     z_slice_map_insert_by_alias(z_loan_mut(map), z_loan(k2), z_loan(v2));
     z_owned_bytes_t attachment;
-    z_bytes_encode_from_slice_map(&attachment, z_loan(map));
+    z_bytes_serialize_from_slice_map(&attachment, z_loan(map));
 
     // Elements check
 

--- a/tests/z_api_payload_test.c
+++ b/tests/z_api_payload_test.c
@@ -26,7 +26,7 @@ void test_reader_seek() {
     uint8_t data_out[10] = {0};
 
     z_owned_bytes_t payload;
-    z_bytes_encode_from_slice(&payload, data, 10);
+    z_bytes_serialize_from_slice(&payload, data, 10);
 
     z_bytes_reader_t reader = z_bytes_get_reader(z_loan(payload));
     assert(z_bytes_reader_tell(&reader) == 0);
@@ -57,7 +57,7 @@ void test_reader_read() {
     uint8_t data_out[10] = {0};
 
     z_owned_bytes_t payload;
-    z_bytes_encode_from_slice(&payload, data, 10);
+    z_bytes_serialize_from_slice(&payload, data, 10);
     z_bytes_reader_t reader = z_bytes_get_reader(z_loan(payload));
 
     assert(5 == z_bytes_reader_read(&reader, data_out, 5));
@@ -106,19 +106,19 @@ void test_slice() {
     uint8_t data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
     z_owned_bytes_t payload;
-    z_bytes_encode_from_slice(&payload, data, 10);
+    z_bytes_serialize_from_slice(&payload, data, 10);
 
     z_owned_slice_t out;
     data[5] = 0;
-    z_bytes_decode_into_slice(z_loan(payload), &out);
+    z_bytes_deserialize_into_slice(z_loan(payload), &out);
 
     assert(!memcmp(data, z_slice_data(z_loan(out)), 10));
 
     z_owned_bytes_t payload2;
-    z_bytes_encode_from_slice_copy(&payload2, data, 10);
+    z_bytes_serialize_from_slice_copy(&payload2, data, 10);
     data[5] = 5;
     z_owned_slice_t out2;
-    z_bytes_decode_into_slice(z_loan(payload2), &out2);
+    z_bytes_deserialize_into_slice(z_loan(payload2), &out2);
     data[5] = 0;
     assert(!memcmp(data, z_slice_data(z_loan(out2)), 10));
 
@@ -128,14 +128,14 @@ void test_slice() {
     z_drop(z_move(out2));
 }
 
-#define TEST_ARITHMETIC(TYPE, EXT, VAL)                   \
-    {                                                     \
-        TYPE in = VAL, out;                               \
-        z_owned_bytes_t payload;                          \
-        z_bytes_encode_from_##EXT(&payload, in);          \
-        z_bytes_decode_into_##EXT(z_loan(payload), &out); \
-        assert(in == out);                                \
-        z_drop(z_move(payload));                          \
+#define TEST_ARITHMETIC(TYPE, EXT, VAL)                        \
+    {                                                          \
+        TYPE in = VAL, out;                                    \
+        z_owned_bytes_t payload;                               \
+        z_bytes_serialize_from_##EXT(&payload, in);            \
+        z_bytes_deserialize_into_##EXT(z_loan(payload), &out); \
+        assert(in == out);                                     \
+        z_drop(z_move(payload));                               \
     }
 
 void test_arithmetic() {
@@ -158,7 +158,7 @@ bool iter_body(z_owned_bytes_t* b, void* context) {
     if (*val >= 10) {
         return false;
     } else {
-        z_bytes_encode_from_uint8(b, *val);
+        z_bytes_serialize_from_uint8(b, *val);
     }
     *val = *val + 1;
     return true;
@@ -169,7 +169,7 @@ void test_iter() {
 
     z_owned_bytes_t payload;
     uint8_t context = 0;
-    z_bytes_encode_from_iter(&payload, iter_body, (void*)(&context));
+    z_bytes_serialize_from_iter(&payload, iter_body, (void*)(&context));
 
     z_bytes_iterator_t it = z_bytes_get_iterator(z_loan(payload));
 
@@ -177,7 +177,7 @@ void test_iter() {
     z_owned_bytes_t out;
     while (z_bytes_iterator_next(&it, &out)) {
         uint8_t res;
-        z_bytes_decode_into_uint8(z_loan(out), &res);
+        z_bytes_deserialize_into_uint8(z_loan(out), &res);
         assert(res == data_out[i]);
         i++;
         z_drop(z_move(out));
@@ -188,16 +188,16 @@ void test_iter() {
 
 void test_pair() {
     z_owned_bytes_t payload, payload1, payload2, payload1_out, payload2_out;
-    z_bytes_encode_from_int16(&payload1, -500);
-    z_bytes_encode_from_double(&payload2, 123.45);
-    z_bytes_encode_from_pair(&payload, z_move(payload1), z_move(payload2));
+    z_bytes_serialize_from_int16(&payload1, -500);
+    z_bytes_serialize_from_double(&payload2, 123.45);
+    z_bytes_serialize_from_pair(&payload, z_move(payload1), z_move(payload2));
 
-    z_bytes_decode_into_pair(z_loan(payload), &payload1_out, &payload2_out);
+    z_bytes_deserialize_into_pair(z_loan(payload), &payload1_out, &payload2_out);
 
     int16_t i;
     double d;
-    z_bytes_decode_into_int16(z_loan(payload1_out), &i);
-    z_bytes_decode_into_double(z_loan(payload2_out), &d);
+    z_bytes_deserialize_into_int16(z_loan(payload1_out), &i);
+    z_bytes_deserialize_into_double(z_loan(payload2_out), &d);
 
     assert(i == -500);
     assert(d == 123.45);

--- a/tests/z_int_pub_cache_query_sub_test.c
+++ b/tests/z_int_pub_cache_query_sub_test.c
@@ -66,7 +66,7 @@ int run_publisher() {
     // values for cache
     for (int i = 0; i < values_count / 2; ++i) {
         z_owned_bytes_t payload;
-        z_bytes_encode_from_string(&payload, values[i]);
+        z_bytes_serialize_from_string(&payload, values[i]);
         z_put(z_loan(s), z_loan(ke), z_move(payload), NULL);
     }
 
@@ -77,7 +77,7 @@ int run_publisher() {
     // values for subscribe
     for (int i = values_count / 2; i < values_count; ++i) {
         z_owned_bytes_t payload;
-        z_bytes_encode_from_string(&payload, values[i]);
+        z_bytes_serialize_from_string(&payload, values[i]);
         z_put(z_loan(s), z_loan(ke), z_move(payload), NULL);
     }
 
@@ -100,7 +100,7 @@ void data_handler(const z_loaned_sample_t *sample, void *arg) {
         exit(-1);
     }
     z_owned_string_t payload_str;
-    z_bytes_decode_into_string(z_sample_payload(sample), &payload_str);
+    z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_str);
     if (strncmp(values[val_num], z_string_data(z_loan(payload_str)), z_string_len(z_loan(payload_str)))) {
         perror("Unexpected value received");
         z_drop(z_move(payload_str));

--- a/tests/z_int_pub_sub_attachment_test.c
+++ b/tests/z_int_pub_sub_attachment_test.c
@@ -44,11 +44,11 @@ bool create_attachement_it(z_owned_bytes_t *kv_pair, void *context) {
     if (ctx->iteration_index >= ctx->num_items) {
         return false;
     } else {
-        z_bytes_encode_from_string(&k, ctx->keys[ctx->iteration_index]);
-        z_bytes_encode_from_string(&v, ctx->values[ctx->iteration_index]);
+        z_bytes_serialize_from_string(&k, ctx->keys[ctx->iteration_index]);
+        z_bytes_serialize_from_string(&v, ctx->values[ctx->iteration_index]);
     }
 
-    z_bytes_encode_from_pair(kv_pair, z_move(k), z_move(v));
+    z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
     ctx->iteration_index++;
     return true;
 };
@@ -61,13 +61,13 @@ z_error_t check_attachement(const z_loaned_bytes_t *attachement, const attacheme
             perror("Not enough elements in the attachment\n");
             return -1;
         }
-        if (z_bytes_decode_into_pair(z_loan(kv), &k, &v) != 0) {
+        if (z_bytes_deserialize_into_pair(z_loan(kv), &k, &v) != 0) {
             perror("Can not decode attachment elemnt into kv-pair\n");
             return -1;
         }
         z_owned_string_t k_str, v_str;
-        z_bytes_decode_into_string(z_loan(k), &k_str);
-        z_bytes_decode_into_string(z_loan(v), &v_str);
+        z_bytes_deserialize_into_string(z_loan(k), &k_str);
+        z_bytes_deserialize_into_string(z_loan(v), &v_str);
 
         if (strncmp(ctx->keys[i], z_string_data(z_loan(k_str)), z_string_len(z_loan(k_str))) != 0) {
             perror("Incorrect attachment key\n");
@@ -113,14 +113,14 @@ int run_publisher() {
             .keys = {K_CONST, K_VAR}, .values = {V_CONST, values[i]}, .num_items = 2, .iteration_index = 0};
 
         z_owned_bytes_t attachment;
-        z_bytes_encode_from_iter(&attachment, create_attachement_it, (void *)&out_attachment_context);
+        z_bytes_serialize_from_iter(&attachment, create_attachement_it, (void *)&out_attachment_context);
 
         options.attachment = &attachment;
 
         z_view_slice_t v_var;
         z_view_slice_from_str(&v_var, values[i]);
         z_owned_bytes_t payload;
-        z_bytes_encode_from_slice(&payload, z_slice_data(z_loan(v_var)), z_slice_len(z_loan(v_var)));
+        z_bytes_serialize_from_slice(&payload, z_slice_data(z_loan(v_var)), z_slice_len(z_loan(v_var)));
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
 
@@ -139,7 +139,7 @@ void data_handler(const z_loaned_sample_t *sample, void *arg) {
     }
 
     z_owned_string_t payload_str;
-    z_bytes_decode_into_string(z_sample_payload(sample), &payload_str);
+    z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_str);
     if (strncmp(values[val_num], z_string_data(z_loan(payload_str)), z_string_len(z_loan(payload_str)))) {
         perror("Unexpected value received");
         z_drop(z_move(payload_str));

--- a/tests/z_int_pub_sub_test.c
+++ b/tests/z_int_pub_sub_test.c
@@ -72,7 +72,7 @@ int run_publisher() {
         options.timestamp = &ts;
 
         z_owned_bytes_t payload;
-        z_bytes_encode_from_string(&payload, values[i]);
+        z_bytes_serialize_from_string(&payload, values[i]);
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
 
@@ -91,7 +91,7 @@ void data_handler(const z_loaned_sample_t *sample, void *arg) {
     }
 
     z_owned_string_t payload_str;
-    z_bytes_decode_into_string(z_sample_payload(sample), &payload_str);
+    z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_str);
     if (strncmp(values[val_num], z_string_data(z_loan(payload_str)), z_string_len(z_loan(payload_str)))) {
         perror("Unexpected value received");
         z_drop(z_move(payload_str));

--- a/tests/z_int_queryable_attachment_test.c
+++ b/tests/z_int_queryable_attachment_test.c
@@ -42,11 +42,11 @@ bool create_attachement_it(z_owned_bytes_t *kv_pair, void *context) {
     if (ctx->iteration_index >= ctx->num_items) {
         return false;
     } else {
-        z_bytes_encode_from_string(&k, ctx->keys[ctx->iteration_index]);
-        z_bytes_encode_from_string(&v, ctx->values[ctx->iteration_index]);
+        z_bytes_serialize_from_string(&k, ctx->keys[ctx->iteration_index]);
+        z_bytes_serialize_from_string(&v, ctx->values[ctx->iteration_index]);
     }
 
-    z_bytes_encode_from_pair(kv_pair, z_move(k), z_move(v));
+    z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
     ctx->iteration_index++;
     return true;
 };
@@ -59,13 +59,13 @@ z_error_t check_attachement(const z_loaned_bytes_t *attachement, const attacheme
             perror("Not enough elements in the attachment\n");
             return -1;
         }
-        if (z_bytes_decode_into_pair(z_loan(kv), &k, &v) != 0) {
+        if (z_bytes_deserialize_into_pair(z_loan(kv), &k, &v) != 0) {
             perror("Can not decode attachment elemnt into kv-pair\n");
             return -1;
         }
         z_owned_string_t k_str, v_str;
-        z_bytes_decode_into_string(z_loan(k), &k_str);
-        z_bytes_decode_into_string(z_loan(v), &v_str);
+        z_bytes_deserialize_into_string(z_loan(k), &k_str);
+        z_bytes_deserialize_into_string(z_loan(v), &v_str);
 
         if (strncmp(ctx->keys[i], z_string_data(z_loan(k_str)), z_string_len(z_loan(k_str))) != 0) {
             perror("Incorrect attachment key\n");
@@ -109,12 +109,12 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     z_owned_bytes_t reply_attachment;
     attachement_context_t out_attachment_context =
         (attachement_context_t){.keys = {K_CONST}, .values = {V_CONST}, .num_items = 1, .iteration_index = 0};
-    z_bytes_encode_from_iter(&reply_attachment, create_attachement_it, (void *)&out_attachment_context);
+    z_bytes_serialize_from_iter(&reply_attachment, create_attachement_it, (void *)&out_attachment_context);
 
     options.attachment = &reply_attachment;
 
     z_owned_bytes_t payload;
-    z_bytes_encode_from_string(&payload, values[value_num]);
+    z_bytes_serialize_from_string(&payload, values[value_num]);
 
     z_view_keyexpr_t reply_ke;
     z_view_keyexpr_from_string(&reply_ke, (const char *)context);
@@ -180,7 +180,7 @@ int run_get() {
         z_fifo_channel_reply_new(&closure, &handler, 16);
 
         z_owned_bytes_t attachment;
-        z_bytes_encode_from_iter(&attachment, create_attachement_it, (void *)&out_attachment_context);
+        z_bytes_serialize_from_iter(&attachment, create_attachement_it, (void *)&out_attachment_context);
 
         opts.attachment = &attachment;
         z_get(z_loan(s), z_loan(ke), "", z_move(closure), &opts);
@@ -190,7 +190,7 @@ int run_get() {
 
             const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));
             z_owned_string_t payload_str;
-            z_bytes_decode_into_string(z_sample_payload(sample), &payload_str);
+            z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_str);
             if (strncmp(values[val_num], z_string_data(z_loan(payload_str)), z_string_len(z_loan(payload_str)))) {
                 perror("Unexpected value received");
                 z_drop(z_move(payload_str));

--- a/tests/z_int_queryable_test.c
+++ b/tests/z_int_queryable_test.c
@@ -54,7 +54,7 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     options.timestamp = &ts;
 
     z_owned_bytes_t payload;
-    z_bytes_encode_from_string(&payload, values[value_num]);
+    z_bytes_serialize_from_string(&payload, values[value_num]);
 
     z_view_keyexpr_t reply_ke;
     z_view_keyexpr_from_string(&reply_ke, (const char *)context);
@@ -120,7 +120,7 @@ int run_get() {
 
             const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));
             z_owned_string_t payload_string;
-            z_bytes_decode_into_string(z_sample_payload(sample), &payload_string);
+            z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_string);
             if (strncmp(values[val_num], z_string_data(z_loan(payload_string)), z_string_len(z_loan(payload_string)))) {
                 perror("Unexpected value received");
                 z_drop(z_move(payload_string));


### PR DESCRIPTION
fix for https://github.com/eclipse-zenoh/zenoh-c/issues/451