### PR TITLE
Replace `-rc` with `-pre` and document versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if(NOT DEFINED PROJECT_VERSION_TWEAK)
 elseif(PROJECT_VERSION_TWEAK EQUAL 0)
 	set(project_version "${project_version}-dev")
 elseif(PROJECT_VERSION_TWEAK GREATER 1)
-	set(project_version "${project_version}-rc.${PROJECT_VERSION_TWEAK}")
+	set(project_version "${project_version}-pre.${PROJECT_VERSION_TWEAK}")
 endif()
 status_print(project_version)
 

--- a/README.md
+++ b/README.md
@@ -260,3 +260,16 @@ Available features can be found in Zenoh [Cargo.toml](https://github.com/eclipse
 ```bash
 cmake ../zenoh-c -DZENOHC_CARGO_FLAGS="--no-default-features;--features=zenoh/transport_tcp,zenoh/transport_udp"
 ```
+
+## Versioning
+
+Being a CMake project, zenoh-c is limited to the `MAJOR.MINOR.PATCH.TWEAK` version scheme [inherent
+to CMake](https://gitlab.kitware.com/cmake/cmake/-/issues/16716). However, zenoh-c also incorporates
+a Cargo package which cannot be versionned with the `MAJOR.MINOR.PATCH.TWEAK` version scheme (not
+SemVer compatible). Hence zenoh-c uses a one-to-one mapping between CMake versions and SemVer versions:
+
+| CMake version           | SemVer equivalent | Meaning              |
+|-------------------------|-------------------|----------------------|
+| `1.2.3`                 | `1.2.3`           | Release version      |
+| `1.2.3.0`               | `1.2.3-dev`       | Developement version |
+| `1.2.3.x if x >= 1`     | `1.2.3-pre.x`     | Pre-release version  |


### PR DESCRIPTION
We will be releasing `alpha/beta/rc` versions in eclipse-zenoh/zenoh. Those versions cannot all be mapped into the CMake version tweak. This pull request suggests using the umbrella suffix `pre` to means any of `alpha/beta/rc` so we can still have a one-to-one map between CMake versions and SemVer versions.