### PR TITLE
Ensure that find_package(zenohc) can be called two times

### DIFF
--- a/install/PackageConfig.cmake.in
+++ b/install/PackageConfig.cmake.in
@@ -23,29 +23,35 @@ if(_IMPORT_PREFIX STREQUAL "/")
   set(_IMPORT_PREFIX "")
 endif()
 
-add_library(__zenohc_static STATIC IMPORTED GLOBAL)
-add_library(zenohc::static ALIAS __zenohc_static)
-target_link_libraries(__zenohc_static INTERFACE @NATIVE_STATIC_LIBS@)
-set_target_properties(__zenohc_static PROPERTIES
-    IMPORTED_LOCATION "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@STATICLIB@"
-    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
-)
+if(NOT TARGET __zenohc_static)
+  add_library(__zenohc_static STATIC IMPORTED GLOBAL)
+  add_library(zenohc::static ALIAS __zenohc_static)
+  target_link_libraries(__zenohc_static INTERFACE @NATIVE_STATIC_LIBS@)
+  set_target_properties(__zenohc_static PROPERTIES
+      IMPORTED_LOCATION "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@STATICLIB@"
+      INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
+  )
+endif()
 
-add_library(__zenohc_shared SHARED IMPORTED GLOBAL)
-add_library(zenohc::shared ALIAS __zenohc_shared)
-set_target_properties(__zenohc_shared PROPERTIES
-    IMPORTED_NO_SONAME TRUE
-    INTERFACE_COMPILE_DEFINITION ZENOHC_DYN_LIB
-    IMPORTED_LOCATION "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@DYLIB@"
-    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
-)
+if(NOT TARGET __zenohc_shared)
+  add_library(__zenohc_shared SHARED IMPORTED GLOBAL)
+  add_library(zenohc::shared ALIAS __zenohc_shared)
+  set_target_properties(__zenohc_shared PROPERTIES
+      IMPORTED_NO_SONAME TRUE
+      INTERFACE_COMPILE_DEFINITION ZENOHC_DYN_LIB
+      IMPORTED_LOCATION "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@DYLIB@"
+      INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
+  )
+endif()
 
 if(NOT ("@IMPLIB@" STREQUAL ""))
     set_property(TARGET __zenohc_shared PROPERTY IMPORTED_IMPLIB "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@IMPLIB@")
 endif()
 
-if(ZENOHC_LIB_STATIC)
+if(NOT TARGET zenohc::lib)
+  if(ZENOHC_LIB_STATIC)
     add_library(zenohc::lib ALIAS __zenohc_static)
-else()
+  else()
     add_library(zenohc::lib ALIAS __zenohc_shared)
+  endif()
 endif()


### PR DESCRIPTION
As `find_package(zenohc)` can be called transitively by the `<pkg>-config.cmake` files of `<pkg>` that depends publicly on `zenohc`, it is important to ensure that `find_package(zenohc)` can be called two or more times. At the moment, if one calls two times `find_package(zenohc)` , the following error appears:

~~~
CMake Error at /Users/runner/Miniforge3/conda-bld/libzenohc_1719163375604/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/cmake/zenohc/zenohcConfig.cmake:50 (add_library):
  add_library cannot create imported target "__zenohc_static" because another
  target with the same name already exists.
Call Stack (most recent call first):
  CMakeLists.txt:7 (find_package)


CMake Error at /Users/runner/Miniforge3/conda-bld/libzenohc_1719163375604/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/cmake/zenohc/zenohcConfig.cmake:51 (add_library):
  add_library cannot create ALIAS target "zenohc::static" because another
  target with the same name already exists.
Call Stack (most recent call first):
  CMakeLists.txt:7 (find_package)


CMake Error at /Users/runner/Miniforge3/conda-bld/libzenohc_1719163375604/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/cmake/zenohc/zenohcConfig.cmake:58 (add_library):
  add_library cannot create imported target "__zenohc_shared" because another
  target with the same name already exists.
Call Stack (most recent call first):
  CMakeLists.txt:7 (find_package)


CMake Error at /Users/runner/Miniforge3/conda-bld/libzenohc_1719163375604/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/cmake/zenohc/zenohcConfig.cmake:59 (add_library):
  add_library cannot create ALIAS target "zenohc::lib" because another target
  with the same name already exists.
Call Stack (most recent call first):
  CMakeLists.txt:7 (find_package)

~~~

Add the target only if it is not defined should avoid this errors.