### PR TITLE
Link tests to Threads::Threads

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ message(STATUS "zenoh-c tests")
 
 add_custom_target(tests)
 
+find_package(Threads REQUIRED)
+
 file(GLOB files "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
 foreach(file ${files})
     get_filename_component(target ${file} NAME_WE)
@@ -20,7 +22,7 @@ foreach(file ${files})
     add_executable(${target} EXCLUDE_FROM_ALL ${file})
     add_dependencies(tests ${target})
     add_dependencies(${target} zenohc::lib)
-    target_link_libraries(${target} PRIVATE zenohc::lib)
+    target_link_libraries(${target} PRIVATE zenohc::lib Threads::Threads)
     copy_dlls(${target})
     set_property(TARGET ${target} PROPERTY C_STANDARD 11)
     add_test(NAME "${test_type}_${target}" COMMAND ${target})


### PR DESCRIPTION
The test use functions such as `sem_wait` (https://man7.org/linux/man-pages/man3/sem_wait.3.html) that on Linux are contained in the `pthread` library. The classical way of linking to `pthread` in CMake is to use the `Threads::Threads` target, see https://cmake.org/cmake/help/v3.30/module/FindThreads.html .