### PR TITLE
Move protection

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1083,14 +1083,14 @@ pub fn find_loan_mut_functions(path_in: &str) -> Vec<FunctionSignature> {
 
 pub fn find_drop_functions(path_in: &str) -> Vec<FunctionSignature> {
     let bindings = std::fs::read_to_string(path_in).unwrap();
-    let re = Regex::new(r"(\w+)_drop\(struct (\w+) \*(\w+)\);").unwrap();
+    let re = Regex::new(r"(\w+)_drop\(struct (\w+) (\w+)\);").unwrap();
     let mut res = Vec::<FunctionSignature>::new();
 
     for (_, [func_name, arg_type, arg_name]) in re.captures_iter(&bindings).map(|c| c.extract()) {
         let f = FunctionSignature {
             return_type: Ctype::new("void"),
             func_name: func_name.to_string() + "_drop",
-            args: vec![FuncArg::new(&(arg_type.to_string() + "*"), arg_name)],
+            args: vec![FuncArg::new(arg_type, arg_name)],
         };
         res.push(f);
     }

--- a/build.rs
+++ b/build.rs
@@ -922,7 +922,8 @@ pub fn create_generics_header(path_in: &str, path_out: &str) {
     file_out.write_all(out.as_bytes()).unwrap();
     file_out.write_all("\n\n".as_bytes()).unwrap();
 
-    let out = generate_generic_move_c(&type_name_to_drop_func);
+    let type_name_to_move_func = make_move_macros(path_in);
+    let out = generate_generic_move_c(&type_name_to_move_func);
     file_out.write_all(out.as_bytes()).unwrap();
     file_out.write_all("\n\n".as_bytes()).unwrap();
 
@@ -998,6 +999,26 @@ pub fn create_generics_header(path_in: &str, path_out: &str) {
     file_out
         .write_all("\n#endif  // #ifndef __cplusplus".as_bytes())
         .unwrap();
+}
+
+pub fn make_move_macros(path_in: &str) -> Vec<FunctionSignature> {
+    let bindings = std::fs::read_to_string(path_in).unwrap();
+    let re = Regex::new(r"(\w+)_drop\(struct z_owned_(\w+) \*(\w+)\);").unwrap();
+    let mut res = Vec::<FunctionSignature>::new();
+
+    for (_, [func_name_prefix, arg_type_suffix, arg_name]) in
+        re.captures_iter(&bindings).map(|c| c.extract())
+    {
+        let z_moved_type = "z_moved_".to_string() + arg_type_suffix;
+        let z_owned_type = "z_owned_".to_string() + arg_type_suffix;
+        let f = FunctionSignature {
+            return_type: Ctype::new(&z_moved_type),
+            func_name: func_name_prefix.to_string() + "_move",
+            args: vec![FuncArg::new(&z_owned_type, arg_name)],
+        };
+        res.push(f);
+    }
+    res
 }
 
 pub fn find_loan_functions(path_in: &str) -> Vec<FunctionSignature> {
@@ -1140,6 +1161,21 @@ pub fn find_recv_functions(path_in: &str) -> Vec<FunctionSignature> {
     res
 }
 
+pub fn generate_generic_c_move_macro(macro_func: &[FunctionSignature]) -> String {
+    let mut out = "#define z_move_(x) \\
+    _Generic((x)"
+        .to_string();
+    for func in macro_func {
+        let z_moved_type = &func.return_type.typename;
+        let z_owned_type = &func.args[0].typename.typename;
+        out += ", \\\n";
+        out += &format!("        {z_owned_type} : ({z_moved_type}){{({z_owned_type}*)&x}}");
+    }
+    out += " \\\n";
+    out += "    )";
+    out
+}
+
 pub fn generate_generic_c(
     macro_func: &[FunctionSignature],
     generic_name: &str,
@@ -1191,8 +1227,24 @@ pub fn generate_generic_drop_c(macro_func: &[FunctionSignature]) -> String {
     generate_generic_c(macro_func, "z_drop", false)
 }
 
-pub fn generate_generic_move_c(_macro_func: &[FunctionSignature]) -> String {
-    "#define z_move(x) (&x)".to_string()
+pub fn generate_generic_move_c(macro_func: &[FunctionSignature]) -> String {
+    let mut out = String::new();
+    for sig in macro_func {
+        let z_moved_type = &sig.return_type.typename;
+        let z_owned_type = &sig.args[0].typename.typename;
+        out += &format!(
+            "typedef struct {z_moved_type} {{ struct {z_owned_type}* ptr; }} {z_moved_type};\n"
+        );
+    }
+    for sig in macro_func {
+        out += &format!(
+            "#define {}(x) ({}){{&x}}\n",
+            sig.func_name, sig.return_type.typename
+        );
+    }
+    out += generate_generic_c_move_macro(macro_func).as_str();
+    out += "\n#define z_move(x) (&x)";
+    out
 }
 
 pub fn generate_generic_null_c(macro_func: &[FunctionSignature]) -> String {

--- a/build.rs
+++ b/build.rs
@@ -194,8 +194,8 @@ pub struct {type_name} {{
             let moved_type_name = format!("{}{}", moved_type_prefix, postfix);
             s += format!(
                 "#[repr(C)]
-pub struct {moved_type_name}<'a> {{
-    pub ptr: &'a mut {type_name},
+pub struct {moved_type_name} {{
+    pub ptr: &'static mut {type_name},
 }}
 "
             )

--- a/build.rs
+++ b/build.rs
@@ -1186,7 +1186,7 @@ pub fn find_recv_functions(path_in: &str) -> Vec<FunctionSignature> {
 }
 
 pub fn generate_generic_c_move_macro(macro_func: &[FunctionSignature]) -> String {
-    let mut out = "#define z_move_(x) \\
+    let mut out = "#define z_move(x) \\
     _Generic((x)"
         .to_string();
     for func in macro_func {

--- a/examples/z_get_shm.c
+++ b/examples/z_get_shm.c
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
         opts.payload = &payload;
     }
     z_get(z_loan(s), z_loan(keyexpr), "", z_move(closure),
-          z_move(opts));  // here, the send is moved and will be dropped by zenoh when adequate
+          &opts);  // here, the send is moved and will be dropped by zenoh when adequate
     z_owned_reply_t reply;
 
     for (z_recv(z_loan(handler), &reply); z_check(reply); z_recv(z_loan(handler), &reply)) {

--- a/include/zenoh.h
+++ b/include/zenoh.h
@@ -30,6 +30,7 @@ extern "C" {
 
 // clang-format off
 // include order is important
+#include "zenoh_macros.h"
 #include "zenoh_concrete.h"
 #include "zenoh_opaque.h"
 #include "zenoh_commons.h"
@@ -38,6 +39,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#include "zenoh_macros.h"
 #include "zenoh_memory.h"
 #endif

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -418,6 +418,9 @@ typedef struct z_owned_closure_zid_t {
    */
   void (*drop)(void *context);
 } z_owned_closure_zid_t;
+typedef struct z_moved_config_t {
+  struct z_owned_config_t *ptr;
+} z_moved_config_t;
 /**
  * Options passed to the `z_declare_publisher()` function.
  */
@@ -756,13 +759,13 @@ typedef struct zc_context_t {
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 typedef struct zc_shm_provider_backend_callbacks_t {
-  void (*alloc_fn)(z_owned_chunk_alloc_result_t *out_result,
-                   const z_loaned_memory_layout_t *layout,
+  void (*alloc_fn)(struct z_owned_chunk_alloc_result_t *out_result,
+                   const struct z_loaned_memory_layout_t *layout,
                    void *context);
   void (*free_fn)(const struct z_chunk_descriptor_t *chunk, void *context);
   size_t (*defragment_fn)(void *context);
   size_t (*available_fn)(void *context);
-  void (*layout_for_fn)(z_owned_memory_layout_t *layout, void *context);
+  void (*layout_for_fn)(struct z_owned_memory_layout_t *layout, void *context);
 } zc_shm_provider_backend_callbacks_t;
 #endif
 typedef struct z_task_attr_t {
@@ -906,54 +909,55 @@ ZENOHC_API extern const char *Z_CONFIG_ADD_TIMESTAMP_KEY;
 ZENOHC_API extern const unsigned int Z_SHM_POSIX_PROTOCOL_ID;
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_alloc_layout_alloc(z_owned_buf_alloc_result_t *out_result,
-                          const z_loaned_alloc_layout_t *layout);
+void z_alloc_layout_alloc(struct z_owned_buf_alloc_result_t *out_result,
+                          const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_alloc_layout_alloc_gc(z_owned_buf_alloc_result_t *out_result,
-                             const z_loaned_alloc_layout_t *layout);
+void z_alloc_layout_alloc_gc(struct z_owned_buf_alloc_result_t *out_result,
+                             const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_alloc_layout_alloc_gc_defrag(z_owned_buf_alloc_result_t *out_result,
-                                    const z_loaned_alloc_layout_t *layout);
+void z_alloc_layout_alloc_gc_defrag(struct z_owned_buf_alloc_result_t *out_result,
+                                    const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_alloc_layout_alloc_gc_defrag_blocking(z_owned_buf_alloc_result_t *out_result,
-                                             const z_loaned_alloc_layout_t *layout);
+void z_alloc_layout_alloc_gc_defrag_blocking(struct z_owned_buf_alloc_result_t *out_result,
+                                             const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_alloc_layout_alloc_gc_defrag_dealloc(z_owned_buf_alloc_result_t *out_result,
-                                            const z_loaned_alloc_layout_t *layout);
+void z_alloc_layout_alloc_gc_defrag_dealloc(struct z_owned_buf_alloc_result_t *out_result,
+                                            const struct z_loaned_alloc_layout_t *layout);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_alloc_layout_check(const z_owned_alloc_layout_t *this_);
+ZENOHC_API bool z_alloc_layout_check(const struct z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Deletes Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_drop(z_owned_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_drop(struct z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Borrows Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_alloc_layout_t *z_alloc_layout_loan(const z_owned_alloc_layout_t *this_);
+ZENOHC_API
+const struct z_loaned_alloc_layout_t *z_alloc_layout_loan(const struct z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Creates a new Alloc Layout for SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_alloc_layout_new(z_owned_alloc_layout_t *this_,
-                             const z_loaned_shm_provider_t *provider,
+z_error_t z_alloc_layout_new(struct z_owned_alloc_layout_t *this_,
+                             const struct z_loaned_shm_provider_t *provider,
                              size_t size,
                              struct z_alloc_alignment_t alignment);
 #endif
@@ -961,45 +965,45 @@ z_error_t z_alloc_layout_new(z_owned_alloc_layout_t *this_,
  * Constructs Alloc Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_null(z_owned_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_null(struct z_owned_alloc_layout_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_alloc_layout_threadsafe_alloc_gc_defrag_async(z_owned_buf_alloc_result_t *out_result,
-                                                          const z_loaned_alloc_layout_t *layout,
+z_error_t z_alloc_layout_threadsafe_alloc_gc_defrag_async(struct z_owned_buf_alloc_result_t *out_result,
+                                                          const struct z_loaned_alloc_layout_t *layout,
                                                           struct zc_threadsafe_context_t result_context,
                                                           void (*result_callback)(void*,
-                                                                                  z_owned_buf_alloc_result_t*));
+                                                                                  struct z_owned_buf_alloc_result_t*));
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_buf_alloc_result_check(const z_owned_buf_alloc_result_t *this_);
+ZENOHC_API bool z_buf_alloc_result_check(const struct z_owned_buf_alloc_result_t *this_);
 #endif
 /**
  * Deletes Buf Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_buf_alloc_result_drop(z_owned_buf_alloc_result_t *this_);
+ZENOHC_API void z_buf_alloc_result_drop(struct z_owned_buf_alloc_result_t *this_);
 #endif
 /**
  * Borrows Buf Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_buf_alloc_result_t *z_buf_alloc_result_loan(const z_owned_buf_alloc_result_t *this_);
+const struct z_loaned_buf_alloc_result_t *z_buf_alloc_result_loan(const struct z_owned_buf_alloc_result_t *this_);
 #endif
 /**
  * Constructs Buf Alloc Result in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_buf_alloc_result_null(z_owned_buf_alloc_result_t *this_);
+ZENOHC_API void z_buf_alloc_result_null(struct z_owned_buf_alloc_result_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_buf_alloc_result_unwrap(z_owned_buf_alloc_result_t *alloc_result,
-                                    z_owned_shm_mut_t *out_buf,
+z_error_t z_buf_alloc_result_unwrap(struct z_owned_buf_alloc_result_t *alloc_result,
+                                    struct z_owned_shm_mut_t *out_buf,
                                     enum z_alloc_error_t *out_error);
 #endif
 /**
@@ -1061,7 +1065,7 @@ z_error_t z_bytes_deserialize_into_int8(const struct z_loaned_bytes_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_error_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *this_,
-                                              const z_loaned_shm_t **dst);
+                                              const struct z_loaned_shm_t **dst);
 #endif
 /**
  * Deserializes data into a mutably loaned SHM buffer
@@ -1072,7 +1076,7 @@ z_error_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *thi
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_error_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this_,
-                                                  z_loaned_shm_t **dst);
+                                                  struct z_loaned_shm_t **dst);
 #endif
 /**
  * Deserializes data into an owned SHM buffer by copying it's shared reference
@@ -1083,7 +1087,7 @@ z_error_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this_
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_error_t z_bytes_deserialize_into_owned_shm(const struct z_loaned_bytes_t *this_,
-                                             z_owned_shm_t *dst);
+                                             struct z_owned_shm_t *dst);
 #endif
 /**
  * Deserializes into a pair of `z_owned_bytes_t` objects.
@@ -1285,7 +1289,9 @@ z_error_t z_bytes_serialize_from_pair(struct z_owned_bytes_t *this_,
  * Serializes from an immutable SHM buffer consuming it
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_error_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_, z_owned_shm_t *shm);
+ZENOHC_API
+z_error_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_,
+                                     struct z_owned_shm_t *shm);
 #endif
 /**
  * Serializes from an immutable SHM buffer copying it
@@ -1293,7 +1299,7 @@ ZENOHC_API z_error_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_, z
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_bytes_serialize_from_shm_copy(struct z_owned_bytes_t *this_,
-                                     const z_loaned_shm_t *shm);
+                                     const struct z_loaned_shm_t *shm);
 #endif
 /**
  * Serializes from a mutable SHM buffer consuming it
@@ -1301,7 +1307,7 @@ void z_bytes_serialize_from_shm_copy(struct z_owned_bytes_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_error_t z_bytes_serialize_from_shm_mut(struct z_owned_bytes_t *this_,
-                                         z_owned_shm_mut_t *shm);
+                                         struct z_owned_shm_mut_t *shm);
 #endif
 /**
  * Serializes a slice by aliasing.
@@ -1388,27 +1394,27 @@ z_error_t z_bytes_writer_write(struct z_loaned_bytes_writer_t *this_,
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_chunk_alloc_result_check(const z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API bool z_chunk_alloc_result_check(const struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Deletes Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_drop(z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API void z_chunk_alloc_result_drop(struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Borrows Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const z_owned_chunk_alloc_result_t *this_);
+const struct z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Creates a new Chunk Alloc Result with Error value
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
+void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
                                     enum z_alloc_error_t alloc_error);
 #endif
 /**
@@ -1416,14 +1422,14 @@ void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_chunk_alloc_result_new_ok(z_owned_chunk_alloc_result_t *this_,
+void z_chunk_alloc_result_new_ok(struct z_owned_chunk_alloc_result_t *this_,
                                  struct z_allocated_chunk_t allocated_chunk);
 #endif
 /**
  * Constructs Chunk Alloc Result in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_null(z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API void z_chunk_alloc_result_null(struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Get number of milliseconds passed since creation of `time`.
@@ -1651,7 +1657,7 @@ ZENOHC_API void z_config_default(struct z_owned_config_t *this_);
 /**
  * Frees `config`, and resets it to its gravestone state.
  */
-ZENOHC_API void z_config_drop(struct z_owned_config_t *this_);
+ZENOHC_API void z_config_drop(struct z_moved_config_t this_);
 /**
  * Borrows config.
  */
@@ -2147,13 +2153,13 @@ enum z_keyexpr_intersection_level_t z_keyexpr_relation_to(const struct z_loaned_
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_memory_layout_check(const z_owned_memory_layout_t *this_);
+ZENOHC_API bool z_memory_layout_check(const struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * Deletes Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_drop(z_owned_memory_layout_t *this_);
+ZENOHC_API void z_memory_layout_drop(struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * Deletes Memory Layout
@@ -2162,21 +2168,21 @@ ZENOHC_API void z_memory_layout_drop(z_owned_memory_layout_t *this_);
 ZENOHC_API
 void z_memory_layout_get_data(size_t *out_size,
                               struct z_alloc_alignment_t *out_alignment,
-                              const z_loaned_memory_layout_t *this_);
+                              const struct z_loaned_memory_layout_t *this_);
 #endif
 /**
  * Borrows Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_memory_layout_t *z_memory_layout_loan(const z_owned_memory_layout_t *this_);
+const struct z_loaned_memory_layout_t *z_memory_layout_loan(const struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * Creates a new Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_memory_layout_new(z_owned_memory_layout_t *this_,
+z_error_t z_memory_layout_new(struct z_owned_memory_layout_t *this_,
                               size_t size,
                               struct z_alloc_alignment_t alignment);
 #endif
@@ -2184,7 +2190,7 @@ z_error_t z_memory_layout_new(z_owned_memory_layout_t *this_,
  * Constructs Memory Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_null(z_owned_memory_layout_t *this_);
+ZENOHC_API void z_memory_layout_null(struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * Returns ``true`` if mutex is valid, ``false`` otherwise.
@@ -2240,21 +2246,21 @@ z_error_t z_open(struct z_owned_session_t *this_,
 ZENOHC_API
 z_error_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
                                          struct z_owned_config_t *config,
-                                         const z_loaned_shm_client_storage_t *shm_clients);
+                                         const struct z_loaned_shm_client_storage_t *shm_clients);
 #endif
 /**
  * Creates a new POSIX SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_error_t z_posix_shm_client_new(z_owned_shm_client_t *this_);
+ZENOHC_API z_error_t z_posix_shm_client_new(struct z_owned_shm_client_t *this_);
 #endif
 /**
  * Creates a new threadsafe SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_posix_shm_provider_new(z_owned_shm_provider_t *this_,
-                                   const z_loaned_memory_layout_t *layout);
+z_error_t z_posix_shm_provider_new(struct z_owned_shm_provider_t *this_,
+                                   const struct z_loaned_memory_layout_t *layout);
 #endif
 /**
  * Returns the default value of #z_priority_t.
@@ -2544,7 +2550,7 @@ ZENOHC_API uint64_t z_random_u64(void);
  */
 ZENOHC_API uint8_t z_random_u8(void);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_error_t z_ref_shm_client_storage_global(z_owned_shm_client_storage_t *this_);
+ZENOHC_API z_error_t z_ref_shm_client_storage_global(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Returns ``true`` if `reply` is valid, ``false`` otherwise.
@@ -2841,26 +2847,26 @@ ZENOHC_API void z_session_null(struct z_owned_session_t *this_);
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_check(const z_owned_shm_t *this_);
+ZENOHC_API bool z_shm_check(const struct z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_check(const z_owned_shm_client_t *this_);
+ZENOHC_API bool z_shm_client_check(const struct z_owned_shm_client_t *this_);
 #endif
 /**
  * Deletes SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_drop(z_owned_shm_client_t *this_);
+ZENOHC_API void z_shm_client_drop(struct z_owned_shm_client_t *this_);
 #endif
 /**
  * Creates a new SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_client_new(z_owned_shm_client_t *this_,
+z_error_t z_shm_client_new(struct z_owned_shm_client_t *this_,
                            struct zc_threadsafe_context_t context,
                            struct zc_shm_client_callbacks_t callbacks);
 #endif
@@ -2868,209 +2874,212 @@ z_error_t z_shm_client_new(z_owned_shm_client_t *this_,
  * Constructs SHM client in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_null(z_owned_shm_client_t *this_);
+ZENOHC_API void z_shm_client_null(struct z_owned_shm_client_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_storage_check(const z_owned_shm_client_storage_t *this_);
+ZENOHC_API bool z_shm_client_storage_check(const struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Derefs SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_drop(z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_drop(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Borrows SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const z_owned_shm_client_storage_t *this_);
+const struct z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const struct z_owned_shm_client_storage_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_client_storage_new(z_owned_shm_client_storage_t *this_,
-                                   const zc_loaned_shm_client_list_t *clients,
+z_error_t z_shm_client_storage_new(struct z_owned_shm_client_storage_t *this_,
+                                   const struct zc_loaned_shm_client_list_t *clients,
                                    bool add_default_client_set);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_error_t z_shm_client_storage_new_default(z_owned_shm_client_storage_t *this_);
+ZENOHC_API z_error_t z_shm_client_storage_new_default(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Constructs SHM Client Storage in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_null(z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_null(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Converts borrowed ZShm slice to owned ZShm slice by performing a shallow SHM reference copy
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_clone(const z_loaned_shm_t *this_, z_owned_shm_t *out);
+ZENOHC_API void z_shm_clone(const struct z_loaned_shm_t *this_, struct z_owned_shm_t *out);
 #endif
 /**
  * @return the pointer of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const unsigned char *z_shm_data(const z_loaned_shm_t *this_);
+ZENOHC_API const unsigned char *z_shm_data(const struct z_loaned_shm_t *this_);
 #endif
 /**
  * Deletes ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_drop(z_owned_shm_t *this_);
+ZENOHC_API void z_shm_drop(struct z_owned_shm_t *this_);
 #endif
 /**
  * Constructs ZShm slice from ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_from_mut(z_owned_shm_t *this_, z_owned_shm_mut_t *that);
+ZENOHC_API void z_shm_from_mut(struct z_owned_shm_t *this_, struct z_owned_shm_mut_t *that);
 #endif
 /**
  * @return the length of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_len(const z_loaned_shm_t *this_);
+ZENOHC_API size_t z_shm_len(const struct z_loaned_shm_t *this_);
 #endif
 /**
  * Borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_shm_t *z_shm_loan(const z_owned_shm_t *this_);
+ZENOHC_API const struct z_loaned_shm_t *z_shm_loan(const struct z_owned_shm_t *this_);
 #endif
 /**
  * Mutably borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_t *z_shm_loan_mut(z_owned_shm_t *this_);
+ZENOHC_API struct z_loaned_shm_t *z_shm_loan_mut(struct z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_mut_check(const z_owned_shm_mut_t *this_);
+ZENOHC_API bool z_shm_mut_check(const struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * @return the mutable pointer of the ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API unsigned char *z_shm_mut_data_mut(z_loaned_shm_mut_t *this_);
+ZENOHC_API unsigned char *z_shm_mut_data_mut(struct z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Deletes ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_drop(z_owned_shm_mut_t *this_);
+ZENOHC_API void z_shm_mut_drop(struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * @return the length of the ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_mut_len(const z_loaned_shm_mut_t *this_);
+ZENOHC_API size_t z_shm_mut_len(const struct z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Borrows ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_mut_t *z_shm_mut_loan_mut(z_owned_shm_mut_t *this_);
+ZENOHC_API struct z_loaned_shm_mut_t *z_shm_mut_loan_mut(struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * Constructs ZShmMut slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_null(z_owned_shm_mut_t *this_);
+ZENOHC_API void z_shm_mut_null(struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * Tries to construct ZShmMut slice from ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_try_from_immut(z_owned_shm_mut_t *this_, z_owned_shm_t *that);
+ZENOHC_API
+void z_shm_mut_try_from_immut(struct z_owned_shm_mut_t *this_,
+                              struct z_owned_shm_t *that);
 #endif
 /**
  * Constructs ZShm slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_null(z_owned_shm_t *this_);
+ZENOHC_API void z_shm_null(struct z_owned_shm_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc(z_owned_buf_alloc_result_t *out_result,
-                               const z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc(struct z_owned_buf_alloc_result_t *out_result,
+                               const struct z_loaned_shm_provider_t *provider,
                                size_t size,
                                struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc_gc(z_owned_buf_alloc_result_t *out_result,
-                                  const z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc_gc(struct z_owned_buf_alloc_result_t *out_result,
+                                  const struct z_loaned_shm_provider_t *provider,
                                   size_t size,
                                   struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc_gc_defrag(z_owned_buf_alloc_result_t *out_result,
-                                         const z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc_gc_defrag(struct z_owned_buf_alloc_result_t *out_result,
+                                         const struct z_loaned_shm_provider_t *provider,
                                          size_t size,
                                          struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc_gc_defrag_async(z_owned_buf_alloc_result_t *out_result,
-                                               const z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc_gc_defrag_async(struct z_owned_buf_alloc_result_t *out_result,
+                                               const struct z_loaned_shm_provider_t *provider,
                                                size_t size,
                                                struct z_alloc_alignment_t alignment,
                                                struct zc_threadsafe_context_t result_context,
                                                void (*result_callback)(void*,
                                                                        z_error_t,
-                                                                       z_owned_buf_alloc_result_t*));
+                                                                       struct z_owned_buf_alloc_result_t*));
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc_gc_defrag_blocking(z_owned_buf_alloc_result_t *out_result,
-                                                  const z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc_gc_defrag_blocking(struct z_owned_buf_alloc_result_t *out_result,
+                                                  const struct z_loaned_shm_provider_t *provider,
                                                   size_t size,
                                                   struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_error_t z_shm_provider_alloc_gc_defrag_dealloc(z_owned_buf_alloc_result_t *out_result,
-                                                 const z_loaned_shm_provider_t *provider,
+z_error_t z_shm_provider_alloc_gc_defrag_dealloc(struct z_owned_buf_alloc_result_t *out_result,
+                                                 const struct z_loaned_shm_provider_t *provider,
                                                  size_t size,
                                                  struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_available(const z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_available(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_provider_check(const z_owned_shm_provider_t *this_);
+ZENOHC_API bool z_shm_provider_check(const struct z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_defragment(const z_loaned_shm_provider_t *provider);
+ZENOHC_API void z_shm_provider_defragment(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Deletes SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_drop(z_owned_shm_provider_t *this_);
+ZENOHC_API void z_shm_provider_drop(struct z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_garbage_collect(const z_loaned_shm_provider_t *provider);
+ZENOHC_API void z_shm_provider_garbage_collect(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Borrows SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_shm_provider_t *z_shm_provider_loan(const z_owned_shm_provider_t *this_);
+ZENOHC_API
+const struct z_loaned_shm_provider_t *z_shm_provider_loan(const struct z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_map(z_owned_shm_mut_t *out_result,
-                        const z_loaned_shm_provider_t *provider,
+void z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
+                        const struct z_loaned_shm_provider_t *provider,
                         struct z_allocated_chunk_t allocated_chunk,
                         size_t len);
 #endif
@@ -3079,7 +3088,7 @@ void z_shm_provider_map(z_owned_shm_mut_t *out_result,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_new(z_owned_shm_provider_t *this_,
+void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
                         z_protocol_id_t id,
                         struct zc_context_t context,
                         struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3088,14 +3097,14 @@ void z_shm_provider_new(z_owned_shm_provider_t *this_,
  * Constructs SHM Provider in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_null(z_owned_shm_provider_t *this_);
+ZENOHC_API void z_shm_provider_null(struct z_owned_shm_provider_t *this_);
 #endif
 /**
  * Creates a new threadsafe SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
+void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
                                    z_protocol_id_t id,
                                    struct zc_threadsafe_context_t context,
                                    struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3104,13 +3113,13 @@ void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
  * Mutably borrows ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_mut_t *z_shm_try_mut(z_owned_shm_t *this_);
+ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_mut(struct z_owned_shm_t *this_);
 #endif
 /**
  * Tries to reborrow mutably-borrowed ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_mut_t *z_shm_try_reloan_mut(z_loaned_shm_t *this_);
+ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_reloan_mut(struct z_loaned_shm_t *this_);
 #endif
 /**
  * Puts current thread to sleep for specified amount of milliseconds.
@@ -3832,46 +3841,46 @@ void zc_session_clone(const struct z_loaned_session_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_error_t zc_shm_client_list_add_client(z_protocol_id_t id,
-                                        z_owned_shm_client_t *client,
-                                        zc_loaned_shm_client_list_t *list);
+                                        struct z_owned_shm_client_t *client,
+                                        struct zc_loaned_shm_client_list_t *list);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool zc_shm_client_list_check(const zc_owned_shm_client_list_t *this_);
+ZENOHC_API bool zc_shm_client_list_check(const struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Deletes list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_drop(zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_drop(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const zc_owned_shm_client_list_t *this_);
+const struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Mutably borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(zc_owned_shm_client_list_t *this_);
+struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Creates a new empty list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_error_t zc_shm_client_list_new(zc_owned_shm_client_list_t *this_);
+ZENOHC_API z_error_t zc_shm_client_list_new(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Constructs SHM client list in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_null(zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_null(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Calls the closure. Calling an uninitialized closure is a no-op.

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1430,8 +1430,8 @@ z_error_t z_bytes_serialize_from_iter(struct z_owned_bytes_t *this_,
  */
 ZENOHC_API
 z_error_t z_bytes_serialize_from_pair(struct z_owned_bytes_t *this_,
-                                      struct z_owned_bytes_t *first,
-                                      struct z_owned_bytes_t *second);
+                                      struct z_moved_bytes_t first,
+                                      struct z_moved_bytes_t second);
 /**
  * Serializes from an immutable SHM buffer consuming it
  */
@@ -2478,7 +2478,7 @@ ZENOHC_API void z_publisher_options_default(struct z_publisher_options_t *this_)
  */
 ZENOHC_API
 z_error_t z_publisher_put(const struct z_loaned_publisher_t *this_,
-                          struct z_owned_bytes_t *payload,
+                          struct z_moved_bytes_t payload,
                           struct z_publisher_put_options_t *options);
 /**
  * Constructs the default value for `z_publisher_put_options_t`.
@@ -2497,7 +2497,7 @@ ZENOHC_API void z_publisher_put_options_default(struct z_publisher_put_options_t
 ZENOHC_API
 z_error_t z_put(const struct z_loaned_session_t *session,
                 const struct z_loaned_keyexpr_t *key_expr,
-                struct z_owned_bytes_t *payload,
+                struct z_moved_bytes_t payload,
                 struct z_put_options_t *options);
 /**
  * Constructs the default value for `z_put_options_t`.
@@ -2608,7 +2608,7 @@ const struct z_loaned_bytes_t *z_query_payload(const struct z_loaned_query_t *th
 ZENOHC_API
 z_error_t z_query_reply(const struct z_loaned_query_t *this_,
                         const struct z_loaned_keyexpr_t *key_expr,
-                        struct z_owned_bytes_t *payload,
+                        struct z_moved_bytes_t payload,
                         struct z_query_reply_options_t *options);
 /**
  * Sends a delete reply to a query.
@@ -2648,7 +2648,7 @@ ZENOHC_API void z_query_reply_del_options_default(struct z_query_reply_del_optio
  */
 ZENOHC_API
 z_error_t z_query_reply_err(const struct z_loaned_query_t *this_,
-                            struct z_owned_bytes_t *payload,
+                            struct z_moved_bytes_t payload,
                             struct z_query_reply_err_options_t *options);
 /**
  * Constructs the default value for `z_query_reply_err_options_t`.

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -317,6 +317,12 @@ typedef struct z_owned_closure_hello_t {
   void (*drop)(void *context);
 } z_owned_closure_hello_t;
 /**
+ * Moved closure.
+ */
+typedef struct z_moved_closure_hello_t {
+  struct z_owned_closure_hello_t *ptr;
+} z_moved_closure_hello_t;
+/**
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:
  *
  * Members:
@@ -337,6 +343,12 @@ typedef struct z_owned_closure_owned_query_t {
   void (*call)(struct z_owned_query_t*, void *context);
   void (*drop)(void*);
 } z_owned_closure_owned_query_t;
+/**
+ * Moved closure.
+ */
+typedef struct z_moved_closure_owned_query_t {
+  struct z_owned_closure_owned_query_t *ptr;
+} z_moved_closure_owned_query_t;
 /**
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:
  *
@@ -362,6 +374,12 @@ typedef struct z_owned_closure_query_t {
   void (*drop)(void *context);
 } z_owned_closure_query_t;
 /**
+ * Moved closure.
+ */
+typedef struct z_moved_closure_query_t {
+  struct z_owned_closure_query_t *ptr;
+} z_moved_closure_query_t;
+/**
  * A structure that contains all the elements for stateful, memory-leak-free callbacks.
  *
  * Closures are not guaranteed not to be called concurrently.
@@ -385,6 +403,12 @@ typedef struct z_owned_closure_reply_t {
    */
   void (*drop)(void *context);
 } z_owned_closure_reply_t;
+/**
+ * Moved closure.
+ */
+typedef struct z_moved_closure_reply_t {
+  struct z_owned_closure_reply_t *ptr;
+} z_moved_closure_reply_t;
 /**
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
  *
@@ -410,6 +434,12 @@ typedef struct z_owned_closure_sample_t {
   void (*drop)(void *context);
 } z_owned_closure_sample_t;
 /**
+ * Moved closure.
+ */
+typedef struct z_moved_closure_sample_t {
+  struct z_owned_closure_sample_t *ptr;
+} z_moved_closure_sample_t;
+/**
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:
  *
  * Closures are not guaranteed not to be called concurrently.
@@ -433,6 +463,12 @@ typedef struct z_owned_closure_zid_t {
    */
   void (*drop)(void *context);
 } z_owned_closure_zid_t;
+/**
+ * Moved closure.
+ */
+typedef struct z_moved_closure_zid_t {
+  struct z_owned_closure_zid_t *ptr;
+} z_moved_closure_zid_t;
 typedef struct z_moved_condvar_t {
   struct z_owned_condvar_t *ptr;
 } z_moved_condvar_t;
@@ -933,6 +969,12 @@ typedef struct zcu_owned_closure_matching_status_t {
    */
   void (*drop)(void *context);
 } zcu_owned_closure_matching_status_t;
+/**
+ * Moved closure.
+ */
+typedef struct zcu_moved_closure_matching_status_t {
+  struct zcu_owned_closure_matching_status_t *ptr;
+} zcu_moved_closure_matching_status_t;
 /**
  * Options passed to the `ze_declare_publication_cache()` function.
  */
@@ -1573,7 +1615,7 @@ ZENOHC_API bool z_closure_hello_check(const struct z_owned_closure_hello_t *this
 /**
  * Drops the closure. Droping an uninitialized closure is a no-op.
  */
-ZENOHC_API void z_closure_hello_drop(struct z_owned_closure_hello_t *closure);
+ZENOHC_API void z_closure_hello_drop(struct z_moved_closure_hello_t _closure);
 /**
  * Borrows closure.
  */
@@ -1590,9 +1632,13 @@ ZENOHC_API
 void z_closure_owned_query_call(const struct z_loaned_closure_owned_query_t *closure,
                                 struct z_owned_query_t *query);
 /**
+ * Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
+ */
+ZENOHC_API bool z_closure_owned_query_check(const struct z_owned_closure_owned_query_t *this_);
+/**
  * Drops the closure. Droping an uninitialized closure is a no-op.
  */
-ZENOHC_API void z_closure_owned_query_drop(struct z_owned_closure_owned_query_t *closure);
+ZENOHC_API void z_closure_owned_query_drop(struct z_moved_closure_owned_query_t closure);
 /**
  * Borrows closure.
  */
@@ -1601,7 +1647,7 @@ const struct z_loaned_closure_owned_query_t *z_closure_owned_query_loan(const st
 /**
  * Constructs a null safe-to-drop value of 'z_owned_closure_query_t' type
  */
-ZENOHC_API struct z_owned_closure_owned_query_t z_closure_owned_query_null(void);
+ZENOHC_API void z_closure_owned_query_null(struct z_owned_closure_owned_query_t *this_);
 /**
  * Calls the closure. Calling an uninitialized closure is a no-op.
  */
@@ -1615,7 +1661,7 @@ ZENOHC_API bool z_closure_query_check(const struct z_owned_closure_query_t *this
 /**
  * Drops the closure, resetting it to its gravestone state.
  */
-ZENOHC_API void z_closure_query_drop(struct z_owned_closure_query_t *closure);
+ZENOHC_API void z_closure_query_drop(struct z_moved_closure_query_t closure);
 /**
  * Borrows closure.
  */
@@ -1639,7 +1685,7 @@ ZENOHC_API bool z_closure_reply_check(const struct z_owned_closure_reply_t *this
  * Drops the closure, resetting it to its gravestone state. Droping an uninitialized closure is a no-op.
  */
 ZENOHC_API
-void z_closure_reply_drop(struct z_owned_closure_reply_t *closure);
+void z_closure_reply_drop(struct z_moved_closure_reply_t closure);
 /**
  * Borrows closure.
  */
@@ -1662,7 +1708,7 @@ ZENOHC_API bool z_closure_sample_check(const struct z_owned_closure_sample_t *th
 /**
  * Drops the closure. Droping an uninitialized closure is a no-op.
  */
-ZENOHC_API void z_closure_sample_drop(struct z_owned_closure_sample_t *closure);
+ZENOHC_API void z_closure_sample_drop(struct z_moved_closure_sample_t closure);
 /**
  * Borrows closure.
  */
@@ -1686,7 +1732,7 @@ ZENOHC_API bool z_closure_zid_check(const struct z_owned_closure_zid_t *this_);
  * Drops the closure, resetting it to its gravestone state. Droping an uninitialized (null) closure is a no-op.
  */
 ZENOHC_API
-void z_closure_zid_drop(struct z_owned_closure_zid_t *closure);
+void z_closure_zid_drop(struct z_moved_closure_zid_t closure);
 /**
  * Vorrows closure.
  */
@@ -1825,7 +1871,7 @@ ZENOHC_API
 z_error_t z_declare_queryable(struct z_owned_queryable_t *this_,
                               const struct z_loaned_session_t *session,
                               const struct z_loaned_keyexpr_t *key_expr,
-                              struct z_owned_closure_query_t *callback,
+                              struct z_moved_closure_query_t callback,
                               struct z_queryable_options_t *options);
 /**
  * Constructs and declares a subscriber for a given key expression. Dropping subscriber
@@ -1842,7 +1888,7 @@ ZENOHC_API
 z_error_t z_declare_subscriber(struct z_owned_subscriber_t *this_,
                                const struct z_loaned_session_t *session,
                                const struct z_loaned_keyexpr_t *key_expr,
-                               struct z_owned_closure_sample_t *callback,
+                               struct z_moved_closure_sample_t callback,
                                struct z_subscriber_options_t *options);
 /**
  * Sends request to delete data on specified key expression (used when working with <a href="https://zenoh.io/docs/manual/abstractions/#storage"> Zenoh storages </a>).
@@ -2050,7 +2096,7 @@ ZENOHC_API
 z_error_t z_get(const struct z_loaned_session_t *session,
                 const struct z_loaned_keyexpr_t *key_expr,
                 const char *parameters,
-                struct z_owned_closure_reply_t *callback,
+                struct z_moved_closure_reply_t callback,
                 struct z_get_options_t *options);
 /**
  * Constructs default `z_get_options_t`
@@ -2098,7 +2144,7 @@ ZENOHC_API struct z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
  */
 ZENOHC_API
 z_error_t z_info_peers_zid(const struct z_loaned_session_t *session,
-                           struct z_owned_closure_zid_t *callback);
+                           struct z_moved_closure_zid_t callback);
 /**
  * Fetches the Zenoh IDs of all connected routers.
  *
@@ -2924,7 +2970,7 @@ ZENOHC_API const struct z_timestamp_t *z_sample_timestamp(const struct z_loaned_
  */
 ZENOHC_API
 z_error_t z_scout(struct z_owned_config_t *config,
-                  struct z_owned_closure_hello_t *callback,
+                  struct z_moved_closure_hello_t callback,
                   const struct z_scout_options_t *options);
 /**
  * Constructs the default values for the scouting operation.
@@ -3876,7 +3922,7 @@ ZENOHC_API
 z_error_t zc_liveliness_declare_subscriber(struct z_owned_subscriber_t *this_,
                                            const struct z_loaned_session_t *session,
                                            const struct z_loaned_keyexpr_t *key_expr,
-                                           struct z_owned_closure_sample_t *callback,
+                                           struct z_moved_closure_sample_t callback,
                                            struct zc_liveliness_subscriber_options_t *_options);
 /**
  * Constructs and declares a liveliness token on the network.
@@ -3905,7 +3951,7 @@ z_error_t zc_liveliness_declare_token(struct zc_owned_liveliness_token_t *this_,
 ZENOHC_API
 z_error_t zc_liveliness_get(const struct z_loaned_session_t *session,
                             const struct z_loaned_keyexpr_t *key_expr,
-                            struct z_owned_closure_reply_t *callback,
+                            struct z_moved_closure_reply_t callback,
                             struct zc_liveliness_get_options_t *options);
 /**
  * Constructs default value `zc_liveliness_get_options_t`.
@@ -4002,7 +4048,7 @@ bool zcu_closure_matching_status_check(const struct zcu_owned_closure_matching_s
  * Drops the closure, resetting it to its gravestone state. Droping an uninitialized closure is a no-op.
  */
 ZENOHC_API
-void zcu_closure_matching_status_drop(struct zcu_owned_closure_matching_status_t *closure);
+void zcu_closure_matching_status_drop(struct zcu_moved_closure_matching_status_t closure);
 /**
  * Borrows closure.
  */
@@ -4028,7 +4074,7 @@ ZENOHC_API enum zcu_locality_t zcu_locality_default(void);
 ZENOHC_API
 z_error_t zcu_publisher_matching_listener_callback(struct zcu_owned_matching_listener_t *this_,
                                                    const struct z_loaned_publisher_t *publisher,
-                                                   struct zcu_owned_closure_matching_status_t *callback);
+                                                   struct zcu_moved_closure_matching_status_t callback);
 /**
  * Undeclares the given matching listener, droping and invalidating it.
  *
@@ -4070,7 +4116,7 @@ ZENOHC_API
 z_error_t ze_declare_querying_subscriber(struct ze_owned_querying_subscriber_t *this_,
                                          const struct z_loaned_session_t *session,
                                          const struct z_loaned_keyexpr_t *key_expr,
-                                         struct z_owned_closure_sample_t *callback,
+                                         struct z_moved_closure_sample_t callback,
                                          struct ze_querying_subscriber_options_t *options);
 /**
  * Returns ``true`` if publication cache is valid, ``false`` otherwise.

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -206,6 +206,9 @@ typedef enum zcu_reply_keyexpr_t {
    */
   ZCU_REPLY_KEYEXPR_MATCHING_QUERY = 1,
 } zcu_reply_keyexpr_t;
+typedef struct z_moved_alloc_layout_t {
+  struct z_owned_alloc_layout_t *ptr;
+} z_moved_alloc_layout_t;
 typedef int8_t z_error_t;
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 typedef struct z_alloc_alignment_t {
@@ -238,6 +241,18 @@ typedef struct zc_threadsafe_context_t {
   void (*delete_fn)(void*);
 } zc_threadsafe_context_t;
 #endif
+typedef struct z_moved_buf_alloc_result_t {
+  struct z_owned_buf_alloc_result_t *ptr;
+} z_moved_buf_alloc_result_t;
+typedef struct z_moved_bytes_t {
+  struct z_owned_bytes_t *ptr;
+} z_moved_bytes_t;
+typedef struct z_moved_bytes_writer_t {
+  struct z_owned_bytes_writer_t *ptr;
+} z_moved_bytes_writer_t;
+typedef struct z_moved_chunk_alloc_result_t {
+  struct z_owned_chunk_alloc_result_t *ptr;
+} z_moved_chunk_alloc_result_t;
 /**
  * Unique segment identifier
  */
@@ -418,6 +433,9 @@ typedef struct z_owned_closure_zid_t {
    */
   void (*drop)(void *context);
 } z_owned_closure_zid_t;
+typedef struct z_moved_condvar_t {
+  struct z_owned_condvar_t *ptr;
+} z_moved_condvar_t;
 typedef struct z_moved_config_t {
   struct z_owned_config_t *ptr;
 } z_moved_config_t;
@@ -485,6 +503,18 @@ typedef struct z_delete_options_t {
    */
   enum zcu_locality_t allowed_destination;
 } z_delete_options_t;
+typedef struct z_moved_encoding_t {
+  struct z_owned_encoding_t *ptr;
+} z_moved_encoding_t;
+typedef struct z_moved_fifo_handler_query_t {
+  struct z_owned_fifo_handler_query_t *ptr;
+} z_moved_fifo_handler_query_t;
+typedef struct z_moved_fifo_handler_reply_t {
+  struct z_owned_fifo_handler_reply_t *ptr;
+} z_moved_fifo_handler_reply_t;
+typedef struct z_moved_fifo_handler_sample_t {
+  struct z_owned_fifo_handler_sample_t *ptr;
+} z_moved_fifo_handler_sample_t;
 /**
  * The replies consolidation strategy to apply on replies to a `z_get()`.
  */
@@ -540,6 +570,18 @@ typedef struct z_get_options_t {
    */
   uint64_t timeout_ms;
 } z_get_options_t;
+typedef struct z_moved_hello_t {
+  struct z_owned_hello_t *ptr;
+} z_moved_hello_t;
+typedef struct z_moved_keyexpr_t {
+  struct z_owned_keyexpr_t *ptr;
+} z_moved_keyexpr_t;
+typedef struct z_moved_memory_layout_t {
+  struct z_owned_memory_layout_t *ptr;
+} z_moved_memory_layout_t;
+typedef struct z_moved_mutex_t {
+  struct z_owned_mutex_t *ptr;
+} z_moved_mutex_t;
 /**
  * Represents the set of options that can be applied to the delete operation by a previously declared publisher,
  * whenever issued via `z_publisher_delete()`.
@@ -550,6 +592,9 @@ typedef struct z_publisher_delete_options_t {
    */
   struct z_timestamp_t *timestamp;
 } z_publisher_delete_options_t;
+typedef struct z_moved_publisher_t {
+  struct z_owned_publisher_t *ptr;
+} z_moved_publisher_t;
 /**
  * Options passed to the `z_publisher_put()` function.
  */
@@ -608,6 +653,9 @@ typedef struct z_put_options_t {
    */
   struct z_owned_bytes_t *attachment;
 } z_put_options_t;
+typedef struct z_moved_query_t {
+  struct z_owned_query_t *ptr;
+} z_moved_query_t;
 /**
  * Represents the set of options that can be applied to a query reply,
  * sent via `z_query_reply()`.
@@ -682,6 +730,27 @@ typedef struct z_query_reply_err_options_t {
    */
   struct z_owned_encoding_t *encoding;
 } z_query_reply_err_options_t;
+typedef struct z_moved_queryable_t {
+  struct z_owned_queryable_t *ptr;
+} z_moved_queryable_t;
+typedef struct z_moved_reply_t {
+  struct z_owned_reply_t *ptr;
+} z_moved_reply_t;
+typedef struct z_moved_reply_err_t {
+  struct z_owned_reply_err_t *ptr;
+} z_moved_reply_err_t;
+typedef struct z_moved_ring_handler_query_t {
+  struct z_owned_ring_handler_query_t *ptr;
+} z_moved_ring_handler_query_t;
+typedef struct z_moved_ring_handler_reply_t {
+  struct z_owned_ring_handler_reply_t *ptr;
+} z_moved_ring_handler_reply_t;
+typedef struct z_moved_ring_handler_sample_t {
+  struct z_owned_ring_handler_sample_t *ptr;
+} z_moved_ring_handler_sample_t;
+typedef struct z_moved_sample_t {
+  struct z_owned_sample_t *ptr;
+} z_moved_sample_t;
 /**
  * Options to pass to `z_scout()`.
  */
@@ -695,6 +764,12 @@ typedef struct z_scout_options_t {
    */
   enum z_whatami_t zc_what;
 } z_scout_options_t;
+typedef struct z_moved_session_t {
+  struct z_owned_session_t *ptr;
+} z_moved_session_t;
+typedef struct z_moved_shm_client_t {
+  struct z_owned_shm_client_t *ptr;
+} z_moved_shm_client_t;
 /**
  * A callbacks for ShmSegment
  */
@@ -720,6 +795,18 @@ typedef struct zc_shm_client_callbacks_t {
   bool (*attach_fn)(struct z_shm_segment_t *out_segment, z_segment_id_t segment_id, void *context);
 } zc_shm_client_callbacks_t;
 #endif
+typedef struct z_moved_shm_client_storage_t {
+  struct z_owned_shm_client_storage_t *ptr;
+} z_moved_shm_client_storage_t;
+typedef struct z_moved_shm_t {
+  struct z_owned_shm_t *ptr;
+} z_moved_shm_t;
+typedef struct z_moved_shm_mut_t {
+  struct z_owned_shm_mut_t *ptr;
+} z_moved_shm_mut_t;
+typedef struct z_moved_shm_provider_t {
+  struct z_owned_shm_provider_t *ptr;
+} z_moved_shm_provider_t;
 /**
  * Unique protocol identifier.
  * Here is a contract: it is up to user to make sure that incompatible ShmClient
@@ -768,6 +855,24 @@ typedef struct zc_shm_provider_backend_callbacks_t {
   void (*layout_for_fn)(struct z_owned_memory_layout_t *layout, void *context);
 } zc_shm_provider_backend_callbacks_t;
 #endif
+typedef struct z_moved_slice_t {
+  struct z_owned_slice_t *ptr;
+} z_moved_slice_t;
+typedef struct z_moved_slice_map_t {
+  struct z_owned_slice_map_t *ptr;
+} z_moved_slice_map_t;
+typedef struct z_moved_source_info_t {
+  struct z_owned_source_info_t *ptr;
+} z_moved_source_info_t;
+typedef struct z_moved_string_array_t {
+  struct z_owned_string_array_t *ptr;
+} z_moved_string_array_t;
+typedef struct z_moved_string_t {
+  struct z_owned_string_t *ptr;
+} z_moved_string_t;
+typedef struct z_moved_subscriber_t {
+  struct z_owned_subscriber_t *ptr;
+} z_moved_subscriber_t;
 typedef struct z_task_attr_t {
   size_t _0;
 } z_task_attr_t;
@@ -942,7 +1047,7 @@ ZENOHC_API bool z_alloc_layout_check(const struct z_owned_alloc_layout_t *this_)
  * Deletes Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_drop(struct z_owned_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_drop(struct z_moved_alloc_layout_t this_);
 #endif
 /**
  * Borrows Alloc Layout
@@ -985,7 +1090,7 @@ ZENOHC_API bool z_buf_alloc_result_check(const struct z_owned_buf_alloc_result_t
  * Deletes Buf Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_buf_alloc_result_drop(struct z_owned_buf_alloc_result_t *this_);
+ZENOHC_API void z_buf_alloc_result_drop(struct z_moved_buf_alloc_result_t this_);
 #endif
 /**
  * Borrows Buf Alloc Result
@@ -1156,7 +1261,7 @@ z_error_t z_bytes_deserialize_into_uint8(const struct z_loaned_bytes_t *this_,
  * Drops `this_`, resetting it to gravestone value. If there are any shallow copies
  * created by `z_bytes_clone()`, they would still stay valid.
  */
-ZENOHC_API void z_bytes_drop(struct z_owned_bytes_t *this_);
+ZENOHC_API void z_bytes_drop(struct z_moved_bytes_t this_);
 /**
  * Constructs an empty instance of `z_owned_bytes_t`.
  */
@@ -1366,7 +1471,7 @@ ZENOHC_API bool z_bytes_writer_check(const struct z_owned_bytes_writer_t *this_)
 /**
  * Drops `this_`, resetting it to gravestone value.
  */
-ZENOHC_API void z_bytes_writer_drop(struct z_owned_bytes_writer_t *this_);
+ZENOHC_API void z_bytes_writer_drop(struct z_moved_bytes_writer_t this_);
 /**
  * Borrows writer.
  */
@@ -1400,7 +1505,7 @@ ZENOHC_API bool z_chunk_alloc_result_check(const struct z_owned_chunk_alloc_resu
  * Deletes Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_drop(struct z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API void z_chunk_alloc_result_drop(struct z_moved_chunk_alloc_result_t this_);
 #endif
 /**
  * Borrows Chunk Alloc Result
@@ -1598,7 +1703,7 @@ ZENOHC_API bool z_condvar_check(const struct z_owned_condvar_t *this_);
 /**
  * Drops conditional variable.
  */
-ZENOHC_API void z_condvar_drop(struct z_owned_condvar_t *this_);
+ZENOHC_API void z_condvar_drop(struct z_moved_condvar_t this_);
 /**
  * Constructs conditional variable.
  */
@@ -1763,7 +1868,7 @@ ZENOHC_API bool z_encoding_check(const struct z_owned_encoding_t *this_);
 /**
  * Frees the memory and resets the encoding it to its default value.
  */
-ZENOHC_API void z_encoding_drop(struct z_owned_encoding_t *this_);
+ZENOHC_API void z_encoding_drop(struct z_moved_encoding_t this_);
 /**
  * Constructs a `z_owned_encoding_t` from a specified string.
  */
@@ -1840,7 +1945,7 @@ ZENOHC_API bool z_fifo_handler_query_check(const struct z_owned_fifo_handler_que
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_fifo_handler_query_drop(struct z_owned_fifo_handler_query_t *this_);
+ZENOHC_API void z_fifo_handler_query_drop(struct z_moved_fifo_handler_query_t this_);
 /**
  * Borrows handler.
  */
@@ -1872,7 +1977,7 @@ ZENOHC_API bool z_fifo_handler_reply_check(const struct z_owned_fifo_handler_rep
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_fifo_handler_reply_drop(struct z_owned_fifo_handler_reply_t *this_);
+ZENOHC_API void z_fifo_handler_reply_drop(struct z_moved_fifo_handler_reply_t this_);
 /**
  * Borrows handler.
  */
@@ -1904,7 +2009,7 @@ ZENOHC_API bool z_fifo_handler_sample_check(const struct z_owned_fifo_handler_sa
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_fifo_handler_sample_drop(struct z_owned_fifo_handler_sample_t *this_);
+ZENOHC_API void z_fifo_handler_sample_drop(struct z_moved_fifo_handler_sample_t this_);
 /**
  * Borrows handler.
  */
@@ -1958,7 +2063,7 @@ ZENOHC_API bool z_hello_check(const struct z_owned_hello_t *this_);
 /**
  * Frees memory and resets hello message to its gravestone state.
  */
-ZENOHC_API void z_hello_drop(struct z_owned_hello_t *this_);
+ZENOHC_API void z_hello_drop(struct z_moved_hello_t this_);
 /**
  * Borrows hello message.
  */
@@ -2059,7 +2164,7 @@ z_error_t z_keyexpr_concat(struct z_owned_keyexpr_t *this_,
 /**
  * Frees key expression and resets it to its gravestone state.
  */
-ZENOHC_API void z_keyexpr_drop(struct z_owned_keyexpr_t *this_);
+ZENOHC_API void z_keyexpr_drop(struct z_moved_keyexpr_t this_);
 /**
  * Returns ``true`` if both ``left`` and ``right`` are equal, ``false`` otherwise.
  */
@@ -2159,7 +2264,7 @@ ZENOHC_API bool z_memory_layout_check(const struct z_owned_memory_layout_t *this
  * Deletes Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_drop(struct z_owned_memory_layout_t *this_);
+ZENOHC_API void z_memory_layout_drop(struct z_moved_memory_layout_t this_);
 #endif
 /**
  * Deletes Memory Layout
@@ -2199,7 +2304,7 @@ ZENOHC_API bool z_mutex_check(const struct z_owned_mutex_t *this_);
 /**
  * Drops mutex and resets it to its gravestone state.
  */
-ZENOHC_API void z_mutex_drop(struct z_owned_mutex_t *this_);
+ZENOHC_API void z_mutex_drop(struct z_moved_mutex_t this_);
 /**
  * Constructs a mutex.
  * @return 0 in case of success, negative error code otherwise.
@@ -2236,7 +2341,7 @@ z_error_t z_mutex_unlock(struct z_loaned_mutex_t *this_);
  */
 ZENOHC_API
 z_error_t z_open(struct z_owned_session_t *this_,
-                 struct z_owned_config_t *config);
+                 struct z_moved_config_t config);
 /**
  * Constructs and opens a new Zenoh session with specified client storage.
  *
@@ -2245,7 +2350,7 @@ z_error_t z_open(struct z_owned_session_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_error_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
-                                         struct z_owned_config_t *config,
+                                         struct z_moved_config_t config,
                                          const struct z_loaned_shm_client_storage_t *shm_clients);
 #endif
 /**
@@ -2285,7 +2390,7 @@ ZENOHC_API void z_publisher_delete_options_default(struct z_publisher_delete_opt
 /**
  * Frees memory and resets publisher to its gravestone state. Also attempts undeclare publisher.
  */
-ZENOHC_API void z_publisher_drop(struct z_owned_publisher_t *this_);
+ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t this_);
 /**
  * Returns the ID of the publisher.
  */
@@ -2406,7 +2511,7 @@ ZENOHC_API struct z_query_consolidation_t z_query_consolidation_none(void);
 /**
  * Destroys the query resetting it to its gravestone value.
  */
-ZENOHC_API void z_query_drop(struct z_owned_query_t *this_);
+ZENOHC_API void z_query_drop(struct z_moved_query_t this_);
 /**
  * Gets query <a href="https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Query%20Payload.md">payload encoding</a>.
  *
@@ -2518,7 +2623,7 @@ ZENOHC_API bool z_queryable_check(const struct z_owned_queryable_t *this_);
 /**
  * Frees memory and resets it to its gravesztone state. Will also attempt to undeclare queryable.
  */
-ZENOHC_API void z_queryable_drop(struct z_owned_queryable_t *this_);
+ZENOHC_API void z_queryable_drop(struct z_moved_queryable_t this_);
 ZENOHC_API
 const struct z_loaned_queryable_t *z_queryable_loan(const struct z_owned_queryable_t *this_);
 /**
@@ -2563,7 +2668,7 @@ ZENOHC_API void z_reply_clone(const struct z_loaned_reply_t *this_, struct z_own
 /**
  * Frees reply, resetting it to its gravestone state.
  */
-ZENOHC_API void z_reply_drop(struct z_owned_reply_t *this_);
+ZENOHC_API void z_reply_drop(struct z_moved_reply_t this_);
 /**
  * Yields the contents of the reply by asserting it indicates a failure.
  *
@@ -2577,7 +2682,7 @@ ZENOHC_API bool z_reply_err_check(const struct z_owned_reply_err_t *this_);
 /**
  * Frees the memory and resets the reply error it to its default value.
  */
-ZENOHC_API void z_reply_err_drop(struct z_owned_reply_err_t *this_);
+ZENOHC_API void z_reply_err_drop(struct z_moved_reply_err_t this_);
 /**
  * Returns reply error encoding.
  */
@@ -2649,7 +2754,7 @@ ZENOHC_API bool z_ring_handler_query_check(const struct z_owned_ring_handler_que
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_ring_handler_query_drop(struct z_owned_ring_handler_query_t *this_);
+ZENOHC_API void z_ring_handler_query_drop(struct z_moved_ring_handler_query_t this_);
 /**
  * Borrows handler.
  */
@@ -2681,7 +2786,7 @@ ZENOHC_API bool z_ring_handler_reply_check(const struct z_owned_ring_handler_rep
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_ring_handler_reply_drop(struct z_owned_ring_handler_reply_t *this_);
+ZENOHC_API void z_ring_handler_reply_drop(struct z_moved_ring_handler_reply_t this_);
 /**
  * Borrows handler.
  */
@@ -2713,7 +2818,7 @@ ZENOHC_API bool z_ring_handler_sample_check(const struct z_owned_ring_handler_sa
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_ring_handler_sample_drop(struct z_owned_ring_handler_sample_t *this_);
+ZENOHC_API void z_ring_handler_sample_drop(struct z_moved_ring_handler_sample_t this_);
 /**
  * Borrows handler.
  */
@@ -2763,7 +2868,7 @@ enum z_congestion_control_t z_sample_congestion_control(const struct z_loaned_sa
 /**
  * Frees the memory and invalidates the sample, resetting it to a gravestone state.
  */
-ZENOHC_API void z_sample_drop(struct z_owned_sample_t *this_);
+ZENOHC_API void z_sample_drop(struct z_moved_sample_t this_);
 /**
  * Returns the encoding associated with the sample data.
  */
@@ -2834,7 +2939,7 @@ ZENOHC_API bool z_session_check(const struct z_owned_session_t *this_);
  *
  * This will also close the session if it does not have any clones left.
  */
-ZENOHC_API void z_session_drop(struct z_owned_session_t *this_);
+ZENOHC_API void z_session_drop(struct z_moved_session_t this_);
 /**
  * Borrows session.
  */
@@ -2859,7 +2964,7 @@ ZENOHC_API bool z_shm_client_check(const struct z_owned_shm_client_t *this_);
  * Deletes SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_drop(struct z_owned_shm_client_t *this_);
+ZENOHC_API void z_shm_client_drop(struct z_moved_shm_client_t this_);
 #endif
 /**
  * Creates a new SHM Client
@@ -2886,7 +2991,7 @@ ZENOHC_API bool z_shm_client_storage_check(const struct z_owned_shm_client_stora
  * Derefs SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_drop(struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_drop(struct z_moved_shm_client_storage_t this_);
 #endif
 /**
  * Borrows SHM Client Storage
@@ -2926,7 +3031,7 @@ ZENOHC_API const unsigned char *z_shm_data(const struct z_loaned_shm_t *this_);
  * Deletes ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_drop(struct z_owned_shm_t *this_);
+ZENOHC_API void z_shm_drop(struct z_moved_shm_t this_);
 #endif
 /**
  * Constructs ZShm slice from ZShmMut slice
@@ -2968,7 +3073,7 @@ ZENOHC_API unsigned char *z_shm_mut_data_mut(struct z_loaned_shm_mut_t *this_);
  * Deletes ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_drop(struct z_owned_shm_mut_t *this_);
+ZENOHC_API void z_shm_mut_drop(struct z_moved_shm_mut_t this_);
 #endif
 /**
  * @return the length of the ZShmMut slice
@@ -3064,7 +3169,7 @@ ZENOHC_API void z_shm_provider_defragment(const struct z_loaned_shm_provider_t *
  * Deletes SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_drop(struct z_owned_shm_provider_t *this_);
+ZENOHC_API void z_shm_provider_drop(struct z_moved_shm_provider_t this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API void z_shm_provider_garbage_collect(const struct z_loaned_shm_provider_t *provider);
@@ -3148,7 +3253,7 @@ ZENOHC_API const uint8_t *z_slice_data(const struct z_loaned_slice_t *this_);
 /**
  * Frees the memory and invalidates the slice.
  */
-ZENOHC_API void z_slice_drop(struct z_owned_slice_t *this_);
+ZENOHC_API void z_slice_drop(struct z_moved_slice_t this_);
 /**
  * Constructs an empty `z_owned_slice_t`.
  */
@@ -3180,7 +3285,7 @@ ZENOHC_API bool z_slice_map_check(const struct z_owned_slice_map_t *map);
 /**
  * Destroys the map, resetting it to its gravestone value.
  */
-ZENOHC_API void z_slice_map_drop(struct z_owned_slice_map_t *this_);
+ZENOHC_API void z_slice_map_drop(struct z_moved_slice_map_t this_);
 /**
  * @return the value associated with `key` (`NULL` if the key is not present in the map.).
  */
@@ -3262,7 +3367,7 @@ ZENOHC_API bool z_source_info_check(const struct z_owned_source_info_t *this_);
 /**
  * Frees the memory and invalidates the source info, resetting it to a gravestone state.
  */
-ZENOHC_API void z_source_info_drop(struct z_owned_source_info_t *this_);
+ZENOHC_API void z_source_info_drop(struct z_moved_source_info_t this_);
 /**
  * Returns the source_id of the source info.
  */
@@ -3294,7 +3399,7 @@ ZENOHC_API bool z_string_array_check(const struct z_owned_string_array_t *this_)
 /**
  * Destroys the string array, resetting it to its gravestone value.
  */
-ZENOHC_API void z_string_array_drop(struct z_owned_string_array_t *this_);
+ZENOHC_API void z_string_array_drop(struct z_moved_string_array_t this_);
 /**
  * @return the value at the position of index in the string array.
  *
@@ -3361,7 +3466,7 @@ ZENOHC_API const char *z_string_data(const struct z_loaned_string_t *this_);
 /**
  * Frees memory and invalidates `z_owned_string_t`, putting it in gravestone state.
  */
-ZENOHC_API void z_string_drop(struct z_owned_string_t *this_);
+ZENOHC_API void z_string_drop(struct z_moved_string_t this_);
 /**
  * Constructs an empty owned string.
  */
@@ -3406,7 +3511,7 @@ ZENOHC_API bool z_subscriber_check(const struct z_owned_subscriber_t *this_);
 /**
  * Drops subscriber and resets it to its gravestone state. Also attempts to undeclare it.
  */
-ZENOHC_API void z_subscriber_drop(struct z_owned_subscriber_t *this_);
+ZENOHC_API void z_subscriber_drop(struct z_moved_subscriber_t this_);
 /**
  * Returns the key expression of the subscriber.
  */
@@ -3508,13 +3613,13 @@ z_error_t z_undeclare_keyexpr(struct z_owned_keyexpr_t *this_,
  *
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_error_t z_undeclare_publisher(struct z_owned_publisher_t *this_);
+ZENOHC_API z_error_t z_undeclare_publisher(struct z_moved_publisher_t this_);
 /**
  * Undeclares a `z_owned_queryable_t` and drops it.
  *
  * Returns 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_error_t z_undeclare_queryable(struct z_owned_queryable_t *this_);
+ZENOHC_API z_error_t z_undeclare_queryable(struct z_moved_queryable_t this_);
 /**
  * Undeclares subscriber and drops subscriber.
  *

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -6,8 +6,11 @@
 
 #define z_loan(x) \
     _Generic((x), \
+        z_owned_alloc_layout_t : z_alloc_layout_loan, \
+        z_owned_buf_alloc_result_t : z_buf_alloc_result_loan, \
         z_owned_bytes_t : z_bytes_loan, \
         z_owned_bytes_writer_t : z_bytes_writer_loan, \
+        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_loan, \
         z_owned_closure_hello_t : z_closure_hello_loan, \
         z_owned_closure_owned_query_t : z_closure_owned_query_loan, \
         z_owned_closure_query_t : z_closure_query_loan, \
@@ -22,6 +25,7 @@
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_loan, \
         z_owned_hello_t : z_hello_loan, \
         z_owned_keyexpr_t : z_keyexpr_loan, \
+        z_owned_memory_layout_t : z_memory_layout_loan, \
         z_owned_publisher_t : z_publisher_loan, \
         z_owned_query_t : z_query_loan, \
         z_owned_queryable_t : z_queryable_loan, \
@@ -32,6 +36,9 @@
         z_owned_ring_handler_sample_t : z_ring_handler_sample_loan, \
         z_owned_sample_t : z_sample_loan, \
         z_owned_session_t : z_session_loan, \
+        z_owned_shm_client_storage_t : z_shm_client_storage_loan, \
+        z_owned_shm_t : z_shm_loan, \
+        z_owned_shm_provider_t : z_shm_provider_loan, \
         z_owned_slice_t : z_slice_loan, \
         z_owned_slice_map_t : z_slice_map_loan, \
         z_owned_source_info_t : z_source_info_loan, \
@@ -42,6 +49,7 @@
         z_view_slice_t : z_view_slice_loan, \
         z_view_string_t : z_view_string_loan, \
         zc_owned_liveliness_token_t : zc_liveliness_token_loan, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_loan, \
         zcu_owned_closure_matching_status_t : zcu_closure_matching_status_loan, \
         ze_owned_querying_subscriber_t : ze_querying_subscriber_loan \
     )(&x)
@@ -54,14 +62,20 @@
         z_owned_config_t : z_config_loan_mut, \
         z_owned_mutex_t : z_mutex_loan_mut, \
         z_owned_publisher_t : z_publisher_loan_mut, \
+        z_owned_shm_t : z_shm_loan_mut, \
+        z_owned_shm_mut_t : z_shm_mut_loan_mut, \
         z_owned_slice_map_t : z_slice_map_loan_mut, \
-        z_owned_string_array_t : z_string_array_loan_mut \
+        z_owned_string_array_t : z_string_array_loan_mut, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_loan_mut \
     )(&x)
 
 #define z_drop(x) \
     _Generic((x), \
+        z_owned_alloc_layout_t* : z_alloc_layout_drop, \
+        z_owned_buf_alloc_result_t* : z_buf_alloc_result_drop, \
         z_owned_bytes_t* : z_bytes_drop, \
         z_owned_bytes_writer_t* : z_bytes_writer_drop, \
+        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_drop, \
         z_owned_closure_hello_t* : z_closure_hello_drop, \
         z_owned_closure_owned_query_t* : z_closure_owned_query_drop, \
         z_owned_closure_query_t* : z_closure_query_drop, \
@@ -69,13 +83,13 @@
         z_owned_closure_sample_t* : z_closure_sample_drop, \
         z_owned_closure_zid_t* : z_closure_zid_drop, \
         z_owned_condvar_t* : z_condvar_drop, \
-        z_owned_config_t* : z_config_drop, \
         z_owned_encoding_t* : z_encoding_drop, \
         z_owned_fifo_handler_query_t* : z_fifo_handler_query_drop, \
         z_owned_fifo_handler_reply_t* : z_fifo_handler_reply_drop, \
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_drop, \
         z_owned_hello_t* : z_hello_drop, \
         z_owned_keyexpr_t* : z_keyexpr_drop, \
+        z_owned_memory_layout_t* : z_memory_layout_drop, \
         z_owned_mutex_t* : z_mutex_drop, \
         z_owned_publisher_t* : z_publisher_drop, \
         z_owned_query_t* : z_query_drop, \
@@ -87,6 +101,11 @@
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_drop, \
         z_owned_sample_t* : z_sample_drop, \
         z_owned_session_t* : z_session_drop, \
+        z_owned_shm_client_t* : z_shm_client_drop, \
+        z_owned_shm_client_storage_t* : z_shm_client_storage_drop, \
+        z_owned_shm_t* : z_shm_drop, \
+        z_owned_shm_mut_t* : z_shm_mut_drop, \
+        z_owned_shm_provider_t* : z_shm_provider_drop, \
         z_owned_slice_t* : z_slice_drop, \
         z_owned_slice_map_t* : z_slice_map_drop, \
         z_owned_source_info_t* : z_source_info_drop, \
@@ -94,46 +113,17 @@
         z_owned_string_t* : z_string_drop, \
         z_owned_subscriber_t* : z_subscriber_drop, \
         zc_owned_liveliness_token_t* : zc_liveliness_token_drop, \
+        zc_owned_shm_client_list_t* : zc_shm_client_list_drop, \
         zcu_owned_closure_matching_status_t* : zcu_closure_matching_status_drop, \
         ze_owned_publication_cache_t* : ze_publication_cache_drop, \
         ze_owned_querying_subscriber_t* : ze_querying_subscriber_drop \
     )(x)
 
-typedef struct z_moved_bytes_t { struct z_owned_bytes_t* ptr; } z_moved_bytes_t;
-typedef struct z_moved_bytes_writer_t { struct z_owned_bytes_writer_t* ptr; } z_moved_bytes_writer_t;
-typedef struct z_moved_closure_hello_t { struct z_owned_closure_hello_t* ptr; } z_moved_closure_hello_t;
-typedef struct z_moved_closure_owned_query_t { struct z_owned_closure_owned_query_t* ptr; } z_moved_closure_owned_query_t;
-typedef struct z_moved_closure_query_t { struct z_owned_closure_query_t* ptr; } z_moved_closure_query_t;
-typedef struct z_moved_closure_reply_t { struct z_owned_closure_reply_t* ptr; } z_moved_closure_reply_t;
-typedef struct z_moved_closure_sample_t { struct z_owned_closure_sample_t* ptr; } z_moved_closure_sample_t;
-typedef struct z_moved_closure_zid_t { struct z_owned_closure_zid_t* ptr; } z_moved_closure_zid_t;
-typedef struct z_moved_condvar_t { struct z_owned_condvar_t* ptr; } z_moved_condvar_t;
-typedef struct z_moved_config_t { struct z_owned_config_t* ptr; } z_moved_config_t;
-typedef struct z_moved_encoding_t { struct z_owned_encoding_t* ptr; } z_moved_encoding_t;
-typedef struct z_moved_fifo_handler_query_t { struct z_owned_fifo_handler_query_t* ptr; } z_moved_fifo_handler_query_t;
-typedef struct z_moved_fifo_handler_reply_t { struct z_owned_fifo_handler_reply_t* ptr; } z_moved_fifo_handler_reply_t;
-typedef struct z_moved_fifo_handler_sample_t { struct z_owned_fifo_handler_sample_t* ptr; } z_moved_fifo_handler_sample_t;
-typedef struct z_moved_hello_t { struct z_owned_hello_t* ptr; } z_moved_hello_t;
-typedef struct z_moved_keyexpr_t { struct z_owned_keyexpr_t* ptr; } z_moved_keyexpr_t;
-typedef struct z_moved_mutex_t { struct z_owned_mutex_t* ptr; } z_moved_mutex_t;
-typedef struct z_moved_publisher_t { struct z_owned_publisher_t* ptr; } z_moved_publisher_t;
-typedef struct z_moved_query_t { struct z_owned_query_t* ptr; } z_moved_query_t;
-typedef struct z_moved_queryable_t { struct z_owned_queryable_t* ptr; } z_moved_queryable_t;
-typedef struct z_moved_reply_t { struct z_owned_reply_t* ptr; } z_moved_reply_t;
-typedef struct z_moved_reply_err_t { struct z_owned_reply_err_t* ptr; } z_moved_reply_err_t;
-typedef struct z_moved_ring_handler_query_t { struct z_owned_ring_handler_query_t* ptr; } z_moved_ring_handler_query_t;
-typedef struct z_moved_ring_handler_reply_t { struct z_owned_ring_handler_reply_t* ptr; } z_moved_ring_handler_reply_t;
-typedef struct z_moved_ring_handler_sample_t { struct z_owned_ring_handler_sample_t* ptr; } z_moved_ring_handler_sample_t;
-typedef struct z_moved_sample_t { struct z_owned_sample_t* ptr; } z_moved_sample_t;
-typedef struct z_moved_session_t { struct z_owned_session_t* ptr; } z_moved_session_t;
-typedef struct z_moved_slice_t { struct z_owned_slice_t* ptr; } z_moved_slice_t;
-typedef struct z_moved_slice_map_t { struct z_owned_slice_map_t* ptr; } z_moved_slice_map_t;
-typedef struct z_moved_source_info_t { struct z_owned_source_info_t* ptr; } z_moved_source_info_t;
-typedef struct z_moved_string_array_t { struct z_owned_string_array_t* ptr; } z_moved_string_array_t;
-typedef struct z_moved_string_t { struct z_owned_string_t* ptr; } z_moved_string_t;
-typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_moved_subscriber_t;
+#define z_alloc_layout_move(x) (z_moved_alloc_layout_t){&x}
+#define z_buf_alloc_result_move(x) (z_moved_buf_alloc_result_t){&x}
 #define z_bytes_move(x) (z_moved_bytes_t){&x}
 #define z_bytes_writer_move(x) (z_moved_bytes_writer_t){&x}
+#define z_chunk_alloc_result_move(x) (z_moved_chunk_alloc_result_t){&x}
 #define z_closure_hello_move(x) (z_moved_closure_hello_t){&x}
 #define z_closure_owned_query_move(x) (z_moved_closure_owned_query_t){&x}
 #define z_closure_query_move(x) (z_moved_closure_query_t){&x}
@@ -141,13 +131,13 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
 #define z_closure_sample_move(x) (z_moved_closure_sample_t){&x}
 #define z_closure_zid_move(x) (z_moved_closure_zid_t){&x}
 #define z_condvar_move(x) (z_moved_condvar_t){&x}
-#define z_config_move(x) (z_moved_config_t){&x}
 #define z_encoding_move(x) (z_moved_encoding_t){&x}
 #define z_fifo_handler_query_move(x) (z_moved_fifo_handler_query_t){&x}
 #define z_fifo_handler_reply_move(x) (z_moved_fifo_handler_reply_t){&x}
 #define z_fifo_handler_sample_move(x) (z_moved_fifo_handler_sample_t){&x}
 #define z_hello_move(x) (z_moved_hello_t){&x}
 #define z_keyexpr_move(x) (z_moved_keyexpr_t){&x}
+#define z_memory_layout_move(x) (z_moved_memory_layout_t){&x}
 #define z_mutex_move(x) (z_moved_mutex_t){&x}
 #define z_publisher_move(x) (z_moved_publisher_t){&x}
 #define z_query_move(x) (z_moved_query_t){&x}
@@ -159,6 +149,11 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
 #define z_ring_handler_sample_move(x) (z_moved_ring_handler_sample_t){&x}
 #define z_sample_move(x) (z_moved_sample_t){&x}
 #define z_session_move(x) (z_moved_session_t){&x}
+#define z_shm_client_move(x) (z_moved_shm_client_t){&x}
+#define z_shm_client_storage_move(x) (z_moved_shm_client_storage_t){&x}
+#define z_shm_move(x) (z_moved_shm_t){&x}
+#define z_shm_mut_move(x) (z_moved_shm_mut_t){&x}
+#define z_shm_provider_move(x) (z_moved_shm_provider_t){&x}
 #define z_slice_move(x) (z_moved_slice_t){&x}
 #define z_slice_map_move(x) (z_moved_slice_map_t){&x}
 #define z_source_info_move(x) (z_moved_source_info_t){&x}
@@ -167,8 +162,11 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
 #define z_subscriber_move(x) (z_moved_subscriber_t){&x}
 #define z_move_(x) \
     _Generic((x), \
+        z_owned_alloc_layout_t : (z_moved_alloc_layout_t){(z_owned_alloc_layout_t*)&x}, \
+        z_owned_buf_alloc_result_t : (z_moved_buf_alloc_result_t){(z_owned_buf_alloc_result_t*)&x}, \
         z_owned_bytes_t : (z_moved_bytes_t){(z_owned_bytes_t*)&x}, \
         z_owned_bytes_writer_t : (z_moved_bytes_writer_t){(z_owned_bytes_writer_t*)&x}, \
+        z_owned_chunk_alloc_result_t : (z_moved_chunk_alloc_result_t){(z_owned_chunk_alloc_result_t*)&x}, \
         z_owned_closure_hello_t : (z_moved_closure_hello_t){(z_owned_closure_hello_t*)&x}, \
         z_owned_closure_owned_query_t : (z_moved_closure_owned_query_t){(z_owned_closure_owned_query_t*)&x}, \
         z_owned_closure_query_t : (z_moved_closure_query_t){(z_owned_closure_query_t*)&x}, \
@@ -176,13 +174,13 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
         z_owned_closure_sample_t : (z_moved_closure_sample_t){(z_owned_closure_sample_t*)&x}, \
         z_owned_closure_zid_t : (z_moved_closure_zid_t){(z_owned_closure_zid_t*)&x}, \
         z_owned_condvar_t : (z_moved_condvar_t){(z_owned_condvar_t*)&x}, \
-        z_owned_config_t : (z_moved_config_t){(z_owned_config_t*)&x}, \
         z_owned_encoding_t : (z_moved_encoding_t){(z_owned_encoding_t*)&x}, \
         z_owned_fifo_handler_query_t : (z_moved_fifo_handler_query_t){(z_owned_fifo_handler_query_t*)&x}, \
         z_owned_fifo_handler_reply_t : (z_moved_fifo_handler_reply_t){(z_owned_fifo_handler_reply_t*)&x}, \
         z_owned_fifo_handler_sample_t : (z_moved_fifo_handler_sample_t){(z_owned_fifo_handler_sample_t*)&x}, \
         z_owned_hello_t : (z_moved_hello_t){(z_owned_hello_t*)&x}, \
         z_owned_keyexpr_t : (z_moved_keyexpr_t){(z_owned_keyexpr_t*)&x}, \
+        z_owned_memory_layout_t : (z_moved_memory_layout_t){(z_owned_memory_layout_t*)&x}, \
         z_owned_mutex_t : (z_moved_mutex_t){(z_owned_mutex_t*)&x}, \
         z_owned_publisher_t : (z_moved_publisher_t){(z_owned_publisher_t*)&x}, \
         z_owned_query_t : (z_moved_query_t){(z_owned_query_t*)&x}, \
@@ -194,6 +192,11 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
         z_owned_ring_handler_sample_t : (z_moved_ring_handler_sample_t){(z_owned_ring_handler_sample_t*)&x}, \
         z_owned_sample_t : (z_moved_sample_t){(z_owned_sample_t*)&x}, \
         z_owned_session_t : (z_moved_session_t){(z_owned_session_t*)&x}, \
+        z_owned_shm_client_t : (z_moved_shm_client_t){(z_owned_shm_client_t*)&x}, \
+        z_owned_shm_client_storage_t : (z_moved_shm_client_storage_t){(z_owned_shm_client_storage_t*)&x}, \
+        z_owned_shm_t : (z_moved_shm_t){(z_owned_shm_t*)&x}, \
+        z_owned_shm_mut_t : (z_moved_shm_mut_t){(z_owned_shm_mut_t*)&x}, \
+        z_owned_shm_provider_t : (z_moved_shm_provider_t){(z_owned_shm_provider_t*)&x}, \
         z_owned_slice_t : (z_moved_slice_t){(z_owned_slice_t*)&x}, \
         z_owned_slice_map_t : (z_moved_slice_map_t){(z_owned_slice_map_t*)&x}, \
         z_owned_source_info_t : (z_moved_source_info_t){(z_owned_source_info_t*)&x}, \
@@ -205,8 +208,11 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
 
 #define z_null(x) \
     _Generic((x), \
+        z_owned_alloc_layout_t* : z_alloc_layout_null, \
+        z_owned_buf_alloc_result_t* : z_buf_alloc_result_null, \
         z_owned_bytes_t* : z_bytes_null, \
         z_owned_bytes_writer_t* : z_bytes_writer_null, \
+        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_null, \
         z_owned_closure_hello_t* : z_closure_hello_null, \
         z_owned_closure_query_t* : z_closure_query_null, \
         z_owned_closure_reply_t* : z_closure_reply_null, \
@@ -220,6 +226,7 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_null, \
         z_owned_hello_t* : z_hello_null, \
         z_owned_keyexpr_t* : z_keyexpr_null, \
+        z_owned_memory_layout_t* : z_memory_layout_null, \
         z_owned_mutex_t* : z_mutex_null, \
         z_owned_publisher_t* : z_publisher_null, \
         z_owned_query_t* : z_query_null, \
@@ -231,6 +238,11 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_null, \
         z_owned_sample_t* : z_sample_null, \
         z_owned_session_t* : z_session_null, \
+        z_owned_shm_client_t* : z_shm_client_null, \
+        z_owned_shm_client_storage_t* : z_shm_client_storage_null, \
+        z_owned_shm_mut_t* : z_shm_mut_null, \
+        z_owned_shm_t* : z_shm_null, \
+        z_owned_shm_provider_t* : z_shm_provider_null, \
         z_owned_slice_map_t* : z_slice_map_null, \
         z_owned_slice_t* : z_slice_null, \
         z_owned_source_info_t* : z_source_info_null, \
@@ -242,6 +254,7 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
         z_view_slice_t* : z_view_slice_null, \
         z_view_string_t* : z_view_string_null, \
         zc_owned_liveliness_token_t* : zc_liveliness_token_null, \
+        zc_owned_shm_client_list_t* : zc_shm_client_list_null, \
         zcu_owned_closure_matching_status_t* : zcu_closure_matching_status_null, \
         ze_owned_publication_cache_t* : ze_publication_cache_null, \
         ze_owned_querying_subscriber_t* : ze_querying_subscriber_null \
@@ -249,8 +262,11 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
 
 #define z_check(x) \
     _Generic((x), \
+        z_owned_alloc_layout_t : z_alloc_layout_check, \
+        z_owned_buf_alloc_result_t : z_buf_alloc_result_check, \
         z_owned_bytes_t : z_bytes_check, \
         z_owned_bytes_writer_t : z_bytes_writer_check, \
+        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_check, \
         z_owned_closure_hello_t : z_closure_hello_check, \
         z_owned_closure_query_t : z_closure_query_check, \
         z_owned_closure_reply_t : z_closure_reply_check, \
@@ -264,6 +280,7 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_check, \
         z_owned_hello_t : z_hello_check, \
         z_owned_keyexpr_t : z_keyexpr_check, \
+        z_owned_memory_layout_t : z_memory_layout_check, \
         z_owned_mutex_t : z_mutex_check, \
         z_owned_publisher_t : z_publisher_check, \
         z_owned_query_t : z_query_check, \
@@ -275,6 +292,11 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
         z_owned_ring_handler_sample_t : z_ring_handler_sample_check, \
         z_owned_sample_t : z_sample_check, \
         z_owned_session_t : z_session_check, \
+        z_owned_shm_t : z_shm_check, \
+        z_owned_shm_client_t : z_shm_client_check, \
+        z_owned_shm_client_storage_t : z_shm_client_storage_check, \
+        z_owned_shm_mut_t : z_shm_mut_check, \
+        z_owned_shm_provider_t : z_shm_provider_check, \
         z_owned_slice_t : z_slice_check, \
         z_owned_slice_map_t : z_slice_map_check, \
         z_owned_source_info_t : z_source_info_check, \
@@ -286,6 +308,7 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
         z_view_slice_t : z_view_slice_check, \
         z_view_string_t : z_view_string_check, \
         zc_owned_liveliness_token_t : zc_liveliness_token_check, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_check, \
         zcu_owned_closure_matching_status_t : zcu_closure_matching_status_check, \
         ze_owned_publication_cache_t : ze_publication_cache_check, \
         ze_owned_querying_subscriber_t : ze_querying_subscriber_check \
@@ -328,8 +351,11 @@ typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_move
 
 
 
+inline const z_loaned_alloc_layout_t* z_loan(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_loan(&this_); };
+inline const z_loaned_buf_alloc_result_t* z_loan(const z_owned_buf_alloc_result_t& this_) { return z_buf_alloc_result_loan(&this_); };
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& this_) { return z_bytes_loan(&this_); };
 inline const z_loaned_bytes_writer_t* z_loan(const z_owned_bytes_writer_t& this_) { return z_bytes_writer_loan(&this_); };
+inline const z_loaned_chunk_alloc_result_t* z_loan(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_loan(&this_); };
 inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t& closure) { return z_closure_hello_loan(&closure); };
 inline const z_loaned_closure_owned_query_t* z_loan(const z_owned_closure_owned_query_t& closure) { return z_closure_owned_query_loan(&closure); };
 inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t& closure) { return z_closure_query_loan(&closure); };
@@ -344,6 +370,7 @@ inline const z_loaned_fifo_handler_reply_t* z_loan(const z_owned_fifo_handler_re
 inline const z_loaned_fifo_handler_sample_t* z_loan(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_loan(&this_); };
 inline const z_loaned_hello_t* z_loan(const z_owned_hello_t& this_) { return z_hello_loan(&this_); };
 inline const z_loaned_keyexpr_t* z_loan(const z_owned_keyexpr_t& this_) { return z_keyexpr_loan(&this_); };
+inline const z_loaned_memory_layout_t* z_loan(const z_owned_memory_layout_t& this_) { return z_memory_layout_loan(&this_); };
 inline const z_loaned_publisher_t* z_loan(const z_owned_publisher_t& this_) { return z_publisher_loan(&this_); };
 inline const z_loaned_query_t* z_loan(const z_owned_query_t& this_) { return z_query_loan(&this_); };
 inline const z_loaned_queryable_t* z_loan(const z_owned_queryable_t& this_) { return z_queryable_loan(&this_); };
@@ -354,6 +381,9 @@ inline const z_loaned_ring_handler_reply_t* z_loan(const z_owned_ring_handler_re
 inline const z_loaned_ring_handler_sample_t* z_loan(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_loan(&this_); };
 inline const z_loaned_sample_t* z_loan(const z_owned_sample_t& this_) { return z_sample_loan(&this_); };
 inline const z_loaned_session_t* z_loan(const z_owned_session_t& this_) { return z_session_loan(&this_); };
+inline const z_loaned_shm_client_storage_t* z_loan(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_loan(&this_); };
+inline const z_loaned_shm_t* z_loan(const z_owned_shm_t& this_) { return z_shm_loan(&this_); };
+inline const z_loaned_shm_provider_t* z_loan(const z_owned_shm_provider_t& this_) { return z_shm_provider_loan(&this_); };
 inline const z_loaned_slice_t* z_loan(const z_owned_slice_t& this_) { return z_slice_loan(&this_); };
 inline const z_loaned_slice_map_t* z_loan(const z_owned_slice_map_t& this_) { return z_slice_map_loan(&this_); };
 inline const z_loaned_source_info_t* z_loan(const z_owned_source_info_t& this_) { return z_source_info_loan(&this_); };
@@ -364,6 +394,7 @@ inline const z_loaned_keyexpr_t* z_loan(const z_view_keyexpr_t& this_) { return 
 inline const z_loaned_slice_t* z_loan(const z_view_slice_t& this_) { return z_view_slice_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_view_string_t& this_) { return z_view_string_loan(&this_); };
 inline const zc_loaned_liveliness_token_t* z_loan(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_loan(&this_); };
+inline const zc_loaned_shm_client_list_t* z_loan(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan(&this_); };
 inline const zcu_loaned_closure_matching_status_t* z_loan(const zcu_owned_closure_matching_status_t& closure) { return zcu_closure_matching_status_loan(&closure); };
 inline const ze_loaned_querying_subscriber_t* z_loan(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_loan(&this_); };
 
@@ -374,12 +405,18 @@ inline z_loaned_condvar_t* z_loan_mut(z_owned_condvar_t& this_) { return z_condv
 inline z_loaned_config_t* z_loan_mut(z_owned_config_t& this_) { return z_config_loan_mut(&this_); };
 inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t& this_) { return z_mutex_loan_mut(&this_); };
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& this_) { return z_publisher_loan_mut(&this_); };
+inline z_loaned_shm_t* z_loan_mut(z_owned_shm_t& this_) { return z_shm_loan_mut(&this_); };
+inline z_loaned_shm_mut_t* z_loan_mut(z_owned_shm_mut_t& this_) { return z_shm_mut_loan_mut(&this_); };
 inline z_loaned_slice_map_t* z_loan_mut(z_owned_slice_map_t& this_) { return z_slice_map_loan_mut(&this_); };
 inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { return z_string_array_loan_mut(&this_); };
+inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan_mut(&this_); };
 
 
+inline void z_drop(z_owned_alloc_layout_t* this_) { return z_alloc_layout_drop(this_); };
+inline void z_drop(z_owned_buf_alloc_result_t* this_) { return z_buf_alloc_result_drop(this_); };
 inline void z_drop(z_owned_bytes_t* this_) { return z_bytes_drop(this_); };
 inline void z_drop(z_owned_bytes_writer_t* this_) { return z_bytes_writer_drop(this_); };
+inline void z_drop(z_owned_chunk_alloc_result_t* this_) { return z_chunk_alloc_result_drop(this_); };
 inline void z_drop(z_owned_closure_hello_t* closure) { return z_closure_hello_drop(closure); };
 inline void z_drop(z_owned_closure_owned_query_t* closure) { return z_closure_owned_query_drop(closure); };
 inline void z_drop(z_owned_closure_query_t* closure) { return z_closure_query_drop(closure); };
@@ -387,13 +424,13 @@ inline void z_drop(z_owned_closure_reply_t* closure) { return z_closure_reply_dr
 inline void z_drop(z_owned_closure_sample_t* closure) { return z_closure_sample_drop(closure); };
 inline void z_drop(z_owned_closure_zid_t* closure) { return z_closure_zid_drop(closure); };
 inline void z_drop(z_owned_condvar_t* this_) { return z_condvar_drop(this_); };
-inline void z_drop(z_owned_config_t* this_) { return z_config_drop(this_); };
 inline void z_drop(z_owned_encoding_t* this_) { return z_encoding_drop(this_); };
 inline void z_drop(z_owned_fifo_handler_query_t* this_) { return z_fifo_handler_query_drop(this_); };
 inline void z_drop(z_owned_fifo_handler_reply_t* this_) { return z_fifo_handler_reply_drop(this_); };
 inline void z_drop(z_owned_fifo_handler_sample_t* this_) { return z_fifo_handler_sample_drop(this_); };
 inline void z_drop(z_owned_hello_t* this_) { return z_hello_drop(this_); };
 inline void z_drop(z_owned_keyexpr_t* this_) { return z_keyexpr_drop(this_); };
+inline void z_drop(z_owned_memory_layout_t* this_) { return z_memory_layout_drop(this_); };
 inline void z_drop(z_owned_mutex_t* this_) { return z_mutex_drop(this_); };
 inline void z_drop(z_owned_publisher_t* this_) { return z_publisher_drop(this_); };
 inline void z_drop(z_owned_query_t* this_) { return z_query_drop(this_); };
@@ -405,6 +442,11 @@ inline void z_drop(z_owned_ring_handler_reply_t* this_) { return z_ring_handler_
 inline void z_drop(z_owned_ring_handler_sample_t* this_) { return z_ring_handler_sample_drop(this_); };
 inline void z_drop(z_owned_sample_t* this_) { return z_sample_drop(this_); };
 inline void z_drop(z_owned_session_t* this_) { return z_session_drop(this_); };
+inline void z_drop(z_owned_shm_client_t* this_) { return z_shm_client_drop(this_); };
+inline void z_drop(z_owned_shm_client_storage_t* this_) { return z_shm_client_storage_drop(this_); };
+inline void z_drop(z_owned_shm_t* this_) { return z_shm_drop(this_); };
+inline void z_drop(z_owned_shm_mut_t* this_) { return z_shm_mut_drop(this_); };
+inline void z_drop(z_owned_shm_provider_t* this_) { return z_shm_provider_drop(this_); };
 inline void z_drop(z_owned_slice_t* this_) { return z_slice_drop(this_); };
 inline void z_drop(z_owned_slice_map_t* this_) { return z_slice_map_drop(this_); };
 inline void z_drop(z_owned_source_info_t* this_) { return z_source_info_drop(this_); };
@@ -412,13 +454,17 @@ inline void z_drop(z_owned_string_array_t* this_) { return z_string_array_drop(t
 inline void z_drop(z_owned_string_t* this_) { return z_string_drop(this_); };
 inline void z_drop(z_owned_subscriber_t* this_) { return z_subscriber_drop(this_); };
 inline void z_drop(zc_owned_liveliness_token_t* this_) { return zc_liveliness_token_drop(this_); };
+inline void z_drop(zc_owned_shm_client_list_t* this_) { return zc_shm_client_list_drop(this_); };
 inline void z_drop(zcu_owned_closure_matching_status_t* closure) { return zcu_closure_matching_status_drop(closure); };
 inline void z_drop(ze_owned_publication_cache_t* this_) { return ze_publication_cache_drop(this_); };
 inline void z_drop(ze_owned_querying_subscriber_t* this_) { return ze_querying_subscriber_drop(this_); };
 
 
+inline z_owned_alloc_layout_t* z_move(z_owned_alloc_layout_t& this_) { return (&this_); };
+inline z_owned_buf_alloc_result_t* z_move(z_owned_buf_alloc_result_t& this_) { return (&this_); };
 inline z_owned_bytes_t* z_move(z_owned_bytes_t& this_) { return (&this_); };
 inline z_owned_bytes_writer_t* z_move(z_owned_bytes_writer_t& this_) { return (&this_); };
+inline z_owned_chunk_alloc_result_t* z_move(z_owned_chunk_alloc_result_t& this_) { return (&this_); };
 inline z_owned_closure_hello_t* z_move(z_owned_closure_hello_t& closure) { return (&closure); };
 inline z_owned_closure_owned_query_t* z_move(z_owned_closure_owned_query_t& closure) { return (&closure); };
 inline z_owned_closure_query_t* z_move(z_owned_closure_query_t& closure) { return (&closure); };
@@ -426,13 +472,13 @@ inline z_owned_closure_reply_t* z_move(z_owned_closure_reply_t& closure) { retur
 inline z_owned_closure_sample_t* z_move(z_owned_closure_sample_t& closure) { return (&closure); };
 inline z_owned_closure_zid_t* z_move(z_owned_closure_zid_t& closure) { return (&closure); };
 inline z_owned_condvar_t* z_move(z_owned_condvar_t& this_) { return (&this_); };
-inline z_owned_config_t* z_move(z_owned_config_t& this_) { return (&this_); };
 inline z_owned_encoding_t* z_move(z_owned_encoding_t& this_) { return (&this_); };
 inline z_owned_fifo_handler_query_t* z_move(z_owned_fifo_handler_query_t& this_) { return (&this_); };
 inline z_owned_fifo_handler_reply_t* z_move(z_owned_fifo_handler_reply_t& this_) { return (&this_); };
 inline z_owned_fifo_handler_sample_t* z_move(z_owned_fifo_handler_sample_t& this_) { return (&this_); };
 inline z_owned_hello_t* z_move(z_owned_hello_t& this_) { return (&this_); };
 inline z_owned_keyexpr_t* z_move(z_owned_keyexpr_t& this_) { return (&this_); };
+inline z_owned_memory_layout_t* z_move(z_owned_memory_layout_t& this_) { return (&this_); };
 inline z_owned_mutex_t* z_move(z_owned_mutex_t& this_) { return (&this_); };
 inline z_owned_publisher_t* z_move(z_owned_publisher_t& this_) { return (&this_); };
 inline z_owned_query_t* z_move(z_owned_query_t& this_) { return (&this_); };
@@ -444,6 +490,11 @@ inline z_owned_ring_handler_reply_t* z_move(z_owned_ring_handler_reply_t& this_)
 inline z_owned_ring_handler_sample_t* z_move(z_owned_ring_handler_sample_t& this_) { return (&this_); };
 inline z_owned_sample_t* z_move(z_owned_sample_t& this_) { return (&this_); };
 inline z_owned_session_t* z_move(z_owned_session_t& this_) { return (&this_); };
+inline z_owned_shm_client_t* z_move(z_owned_shm_client_t& this_) { return (&this_); };
+inline z_owned_shm_client_storage_t* z_move(z_owned_shm_client_storage_t& this_) { return (&this_); };
+inline z_owned_shm_t* z_move(z_owned_shm_t& this_) { return (&this_); };
+inline z_owned_shm_mut_t* z_move(z_owned_shm_mut_t& this_) { return (&this_); };
+inline z_owned_shm_provider_t* z_move(z_owned_shm_provider_t& this_) { return (&this_); };
 inline z_owned_slice_t* z_move(z_owned_slice_t& this_) { return (&this_); };
 inline z_owned_slice_map_t* z_move(z_owned_slice_map_t& this_) { return (&this_); };
 inline z_owned_source_info_t* z_move(z_owned_source_info_t& this_) { return (&this_); };
@@ -451,13 +502,17 @@ inline z_owned_string_array_t* z_move(z_owned_string_array_t& this_) { return (&
 inline z_owned_string_t* z_move(z_owned_string_t& this_) { return (&this_); };
 inline z_owned_subscriber_t* z_move(z_owned_subscriber_t& this_) { return (&this_); };
 inline zc_owned_liveliness_token_t* z_move(zc_owned_liveliness_token_t& this_) { return (&this_); };
+inline zc_owned_shm_client_list_t* z_move(zc_owned_shm_client_list_t& this_) { return (&this_); };
 inline zcu_owned_closure_matching_status_t* z_move(zcu_owned_closure_matching_status_t& closure) { return (&closure); };
 inline ze_owned_publication_cache_t* z_move(ze_owned_publication_cache_t& this_) { return (&this_); };
 inline ze_owned_querying_subscriber_t* z_move(ze_owned_querying_subscriber_t& this_) { return (&this_); };
 
 
+inline void z_null(z_owned_alloc_layout_t* this_) { return z_alloc_layout_null(this_); };
+inline void z_null(z_owned_buf_alloc_result_t* this_) { return z_buf_alloc_result_null(this_); };
 inline void z_null(z_owned_bytes_t* this_) { return z_bytes_null(this_); };
 inline void z_null(z_owned_bytes_writer_t* this_) { return z_bytes_writer_null(this_); };
+inline void z_null(z_owned_chunk_alloc_result_t* this_) { return z_chunk_alloc_result_null(this_); };
 inline void z_null(z_owned_closure_hello_t* this_) { return z_closure_hello_null(this_); };
 inline void z_null(z_owned_closure_query_t* this_) { return z_closure_query_null(this_); };
 inline void z_null(z_owned_closure_reply_t* this_) { return z_closure_reply_null(this_); };
@@ -471,6 +526,7 @@ inline void z_null(z_owned_fifo_handler_reply_t* this_) { return z_fifo_handler_
 inline void z_null(z_owned_fifo_handler_sample_t* this_) { return z_fifo_handler_sample_null(this_); };
 inline void z_null(z_owned_hello_t* this_) { return z_hello_null(this_); };
 inline void z_null(z_owned_keyexpr_t* this_) { return z_keyexpr_null(this_); };
+inline void z_null(z_owned_memory_layout_t* this_) { return z_memory_layout_null(this_); };
 inline void z_null(z_owned_mutex_t* this_) { return z_mutex_null(this_); };
 inline void z_null(z_owned_publisher_t* this_) { return z_publisher_null(this_); };
 inline void z_null(z_owned_query_t* this_) { return z_query_null(this_); };
@@ -482,6 +538,11 @@ inline void z_null(z_owned_ring_handler_reply_t* this_) { return z_ring_handler_
 inline void z_null(z_owned_ring_handler_sample_t* this_) { return z_ring_handler_sample_null(this_); };
 inline void z_null(z_owned_sample_t* this_) { return z_sample_null(this_); };
 inline void z_null(z_owned_session_t* this_) { return z_session_null(this_); };
+inline void z_null(z_owned_shm_client_t* this_) { return z_shm_client_null(this_); };
+inline void z_null(z_owned_shm_client_storage_t* this_) { return z_shm_client_storage_null(this_); };
+inline void z_null(z_owned_shm_mut_t* this_) { return z_shm_mut_null(this_); };
+inline void z_null(z_owned_shm_t* this_) { return z_shm_null(this_); };
+inline void z_null(z_owned_shm_provider_t* this_) { return z_shm_provider_null(this_); };
 inline void z_null(z_owned_slice_map_t* this_) { return z_slice_map_null(this_); };
 inline void z_null(z_owned_slice_t* this_) { return z_slice_null(this_); };
 inline void z_null(z_owned_source_info_t* this_) { return z_source_info_null(this_); };
@@ -493,13 +554,17 @@ inline void z_null(z_view_keyexpr_t* this_) { return z_view_keyexpr_null(this_);
 inline void z_null(z_view_slice_t* this_) { return z_view_slice_null(this_); };
 inline void z_null(z_view_string_t* this_) { return z_view_string_null(this_); };
 inline void z_null(zc_owned_liveliness_token_t* this_) { return zc_liveliness_token_null(this_); };
+inline void z_null(zc_owned_shm_client_list_t* this_) { return zc_shm_client_list_null(this_); };
 inline void z_null(zcu_owned_closure_matching_status_t* this_) { return zcu_closure_matching_status_null(this_); };
 inline void z_null(ze_owned_publication_cache_t* this_) { return ze_publication_cache_null(this_); };
 inline void z_null(ze_owned_querying_subscriber_t* this_) { return ze_querying_subscriber_null(this_); };
 
 
+inline bool z_check(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_check(&this_); };
+inline bool z_check(const z_owned_buf_alloc_result_t& this_) { return z_buf_alloc_result_check(&this_); };
 inline bool z_check(const z_owned_bytes_t& this_) { return z_bytes_check(&this_); };
 inline bool z_check(const z_owned_bytes_writer_t& this_) { return z_bytes_writer_check(&this_); };
+inline bool z_check(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_check(&this_); };
 inline bool z_check(const z_owned_closure_hello_t& this_) { return z_closure_hello_check(&this_); };
 inline bool z_check(const z_owned_closure_query_t& this_) { return z_closure_query_check(&this_); };
 inline bool z_check(const z_owned_closure_reply_t& this_) { return z_closure_reply_check(&this_); };
@@ -513,6 +578,7 @@ inline bool z_check(const z_owned_fifo_handler_reply_t& this_) { return z_fifo_h
 inline bool z_check(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_hello_t& this_) { return z_hello_check(&this_); };
 inline bool z_check(const z_owned_keyexpr_t& this_) { return z_keyexpr_check(&this_); };
+inline bool z_check(const z_owned_memory_layout_t& this_) { return z_memory_layout_check(&this_); };
 inline bool z_check(const z_owned_mutex_t& this_) { return z_mutex_check(&this_); };
 inline bool z_check(const z_owned_publisher_t& this_) { return z_publisher_check(&this_); };
 inline bool z_check(const z_owned_query_t& query) { return z_query_check(&query); };
@@ -524,6 +590,11 @@ inline bool z_check(const z_owned_ring_handler_reply_t& this_) { return z_ring_h
 inline bool z_check(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_sample_t& this_) { return z_sample_check(&this_); };
 inline bool z_check(const z_owned_session_t& this_) { return z_session_check(&this_); };
+inline bool z_check(const z_owned_shm_t& this_) { return z_shm_check(&this_); };
+inline bool z_check(const z_owned_shm_client_t& this_) { return z_shm_client_check(&this_); };
+inline bool z_check(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_check(&this_); };
+inline bool z_check(const z_owned_shm_mut_t& this_) { return z_shm_mut_check(&this_); };
+inline bool z_check(const z_owned_shm_provider_t& this_) { return z_shm_provider_check(&this_); };
 inline bool z_check(const z_owned_slice_t& this_) { return z_slice_check(&this_); };
 inline bool z_check(const z_owned_slice_map_t& map) { return z_slice_map_check(&map); };
 inline bool z_check(const z_owned_source_info_t& this_) { return z_source_info_check(&this_); };
@@ -535,6 +606,7 @@ inline bool z_check(const z_view_keyexpr_t& this_) { return z_view_keyexpr_check
 inline bool z_check(const z_view_slice_t& this_) { return z_view_slice_check(&this_); };
 inline bool z_check(const z_view_string_t& this_) { return z_view_string_check(&this_); };
 inline bool z_check(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_check(&this_); };
+inline bool z_check(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_check(&this_); };
 inline bool z_check(const zcu_owned_closure_matching_status_t& this_) { return zcu_closure_matching_status_check(&this_); };
 inline bool z_check(const ze_owned_publication_cache_t& this_) { return ze_publication_cache_check(&this_); };
 inline bool z_check(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_check(&this_); };
@@ -669,10 +741,16 @@ inline bool z_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sample_t
 
 template<class T> struct z_loaned_to_owned_type_t {};
 template<class T> struct z_owned_to_loaned_type_t {};
+template<> struct z_loaned_to_owned_type_t<z_loaned_alloc_layout_t> { typedef z_owned_alloc_layout_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_alloc_layout_t> { typedef z_loaned_alloc_layout_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_buf_alloc_result_t> { typedef z_owned_buf_alloc_result_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_buf_alloc_result_t> { typedef z_loaned_buf_alloc_result_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_t> { typedef z_owned_bytes_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_t> { typedef z_loaned_bytes_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_writer_t> { typedef z_owned_bytes_writer_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_writer_t> { typedef z_loaned_bytes_writer_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_chunk_alloc_result_t> { typedef z_owned_chunk_alloc_result_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_chunk_alloc_result_t> { typedef z_loaned_chunk_alloc_result_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_hello_t> { typedef z_owned_closure_hello_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_hello_t> { typedef z_loaned_closure_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_owned_query_t> { typedef z_owned_closure_owned_query_t type; };
@@ -701,6 +779,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_hello_t> { typedef z_owned_h
 template<> struct z_owned_to_loaned_type_t<z_owned_hello_t> { typedef z_loaned_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_keyexpr_t> { typedef z_owned_keyexpr_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_keyexpr_t> { typedef z_loaned_keyexpr_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_memory_layout_t> { typedef z_owned_memory_layout_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_memory_layout_t> { typedef z_loaned_memory_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_publisher_t> { typedef z_owned_publisher_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_publisher_t> { typedef z_loaned_publisher_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_query_t> { typedef z_owned_query_t type; };
@@ -721,6 +801,12 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_sample_t> { typedef z_owned_
 template<> struct z_owned_to_loaned_type_t<z_owned_sample_t> { typedef z_loaned_sample_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_session_t> { typedef z_owned_session_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_session_t> { typedef z_loaned_session_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_client_storage_t> { typedef z_owned_shm_client_storage_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_client_storage_t> { typedef z_loaned_shm_client_storage_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_t> { typedef z_owned_shm_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_t> { typedef z_loaned_shm_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_provider_t> { typedef z_owned_shm_provider_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_provider_t> { typedef z_loaned_shm_provider_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_slice_t> { typedef z_owned_slice_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_slice_t> { typedef z_loaned_slice_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_slice_map_t> { typedef z_owned_slice_map_t type; };
@@ -735,10 +821,14 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_subscriber_t> { typedef z_ow
 template<> struct z_owned_to_loaned_type_t<z_owned_subscriber_t> { typedef z_loaned_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<zc_loaned_liveliness_token_t> { typedef zc_owned_liveliness_token_t type; };
 template<> struct z_owned_to_loaned_type_t<zc_owned_liveliness_token_t> { typedef zc_loaned_liveliness_token_t type; };
+template<> struct z_loaned_to_owned_type_t<zc_loaned_shm_client_list_t> { typedef zc_owned_shm_client_list_t type; };
+template<> struct z_owned_to_loaned_type_t<zc_owned_shm_client_list_t> { typedef zc_loaned_shm_client_list_t type; };
 template<> struct z_loaned_to_owned_type_t<zcu_loaned_closure_matching_status_t> { typedef zcu_owned_closure_matching_status_t type; };
 template<> struct z_owned_to_loaned_type_t<zcu_owned_closure_matching_status_t> { typedef zcu_loaned_closure_matching_status_t type; };
 template<> struct z_loaned_to_owned_type_t<ze_loaned_querying_subscriber_t> { typedef ze_owned_querying_subscriber_t type; };
 template<> struct z_owned_to_loaned_type_t<ze_owned_querying_subscriber_t> { typedef ze_loaned_querying_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_mutex_t> { typedef z_owned_mutex_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_mutex_t> { typedef z_loaned_mutex_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_mut_t> { typedef z_owned_shm_mut_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_mut_t> { typedef z_loaned_shm_mut_t type; };
 #endif  // #ifndef __cplusplus

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -113,6 +113,7 @@
         z_moved_string_array_t : z_string_array_drop, \
         z_moved_string_t : z_string_drop, \
         z_moved_subscriber_t : z_subscriber_drop, \
+        zc_moved_liveliness_token_t : zc_liveliness_token_drop, \
         zcu_moved_closure_matching_status_t : zcu_closure_matching_status_drop \
     )(x)
 
@@ -158,6 +159,7 @@
 #define z_string_array_move(x) (z_moved_string_array_t){&x}
 #define z_string_move(x) (z_moved_string_t){&x}
 #define z_subscriber_move(x) (z_moved_subscriber_t){&x}
+#define zc_liveliness_token_move(x) (zc_moved_liveliness_token_t){&x}
 #define zcu_closure_matching_status_move(x) (zcu_moved_closure_matching_status_t){&x}
 #define z_move(x) \
     _Generic((x), \
@@ -203,6 +205,7 @@
         z_owned_string_array_t : (z_moved_string_array_t){(z_owned_string_array_t*)&x}, \
         z_owned_string_t : (z_moved_string_t){(z_owned_string_t*)&x}, \
         z_owned_subscriber_t : (z_moved_subscriber_t){(z_owned_subscriber_t*)&x}, \
+        zc_owned_liveliness_token_t : (zc_moved_liveliness_token_t){(zc_owned_liveliness_token_t*)&x}, \
         zcu_owned_closure_matching_status_t : (zcu_moved_closure_matching_status_t){(zcu_owned_closure_matching_status_t*)&x} \
     )
 
@@ -456,6 +459,7 @@ inline void z_drop(z_moved_source_info_t this_) { return z_source_info_drop(this
 inline void z_drop(z_moved_string_array_t this_) { return z_string_array_drop(this_); };
 inline void z_drop(z_moved_string_t this_) { return z_string_drop(this_); };
 inline void z_drop(z_moved_subscriber_t this_) { return z_subscriber_drop(this_); };
+inline void z_drop(zc_moved_liveliness_token_t this_) { return zc_liveliness_token_drop(this_); };
 inline void z_drop(zcu_moved_closure_matching_status_t closure) { return zcu_closure_matching_status_drop(closure); };
 
 
@@ -501,6 +505,7 @@ inline z_moved_source_info_t z_move(z_moved_source_info_t this_) { return (&this
 inline z_moved_string_array_t z_move(z_moved_string_array_t this_) { return (&this_); };
 inline z_moved_string_t z_move(z_moved_string_t this_) { return (&this_); };
 inline z_moved_subscriber_t z_move(z_moved_subscriber_t this_) { return (&this_); };
+inline zc_moved_liveliness_token_t z_move(zc_moved_liveliness_token_t this_) { return (&this_); };
 inline zcu_moved_closure_matching_status_t z_move(zcu_moved_closure_matching_status_t closure) { return (&closure); };
 
 

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -71,33 +71,53 @@
 
 #define z_drop(x) \
     _Generic((x), \
-        z_owned_closure_hello_t* : z_closure_hello_drop, \
-        z_owned_closure_owned_query_t* : z_closure_owned_query_drop, \
-        z_owned_closure_query_t* : z_closure_query_drop, \
-        z_owned_closure_reply_t* : z_closure_reply_drop, \
-        z_owned_closure_sample_t* : z_closure_sample_drop, \
-        z_owned_closure_zid_t* : z_closure_zid_drop, \
-        zc_owned_liveliness_token_t* : zc_liveliness_token_drop, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_drop, \
-        zcu_owned_closure_matching_status_t* : zcu_closure_matching_status_drop, \
-        ze_owned_publication_cache_t* : ze_publication_cache_drop, \
-        ze_owned_querying_subscriber_t* : ze_querying_subscriber_drop \
+        z_moved_alloc_layout_t : z_alloc_layout_drop, \
+        z_moved_buf_alloc_result_t : z_buf_alloc_result_drop, \
+        z_moved_bytes_t : z_bytes_drop, \
+        z_moved_bytes_writer_t : z_bytes_writer_drop, \
+        z_moved_chunk_alloc_result_t : z_chunk_alloc_result_drop, \
+        z_moved_closure_hello_t : z_closure_hello_drop, \
+        z_moved_closure_owned_query_t : z_closure_owned_query_drop, \
+        z_moved_closure_query_t : z_closure_query_drop, \
+        z_moved_closure_reply_t : z_closure_reply_drop, \
+        z_moved_closure_sample_t : z_closure_sample_drop, \
+        z_moved_closure_zid_t : z_closure_zid_drop, \
+        z_moved_condvar_t : z_condvar_drop, \
+        z_moved_config_t : z_config_drop, \
+        z_moved_encoding_t : z_encoding_drop, \
+        z_moved_fifo_handler_query_t : z_fifo_handler_query_drop, \
+        z_moved_fifo_handler_reply_t : z_fifo_handler_reply_drop, \
+        z_moved_fifo_handler_sample_t : z_fifo_handler_sample_drop, \
+        z_moved_hello_t : z_hello_drop, \
+        z_moved_keyexpr_t : z_keyexpr_drop, \
+        z_moved_memory_layout_t : z_memory_layout_drop, \
+        z_moved_mutex_t : z_mutex_drop, \
+        z_moved_publisher_t : z_publisher_drop, \
+        z_moved_query_t : z_query_drop, \
+        z_moved_queryable_t : z_queryable_drop, \
+        z_moved_reply_t : z_reply_drop, \
+        z_moved_reply_err_t : z_reply_err_drop, \
+        z_moved_ring_handler_query_t : z_ring_handler_query_drop, \
+        z_moved_ring_handler_reply_t : z_ring_handler_reply_drop, \
+        z_moved_ring_handler_sample_t : z_ring_handler_sample_drop, \
+        z_moved_sample_t : z_sample_drop, \
+        z_moved_session_t : z_session_drop, \
+        z_moved_shm_client_t : z_shm_client_drop, \
+        z_moved_shm_client_storage_t : z_shm_client_storage_drop, \
+        z_moved_shm_t : z_shm_drop, \
+        z_moved_shm_mut_t : z_shm_mut_drop, \
+        z_moved_shm_provider_t : z_shm_provider_drop, \
+        z_moved_slice_t : z_slice_drop, \
+        z_moved_slice_map_t : z_slice_map_drop, \
+        z_moved_source_info_t : z_source_info_drop, \
+        z_moved_string_array_t : z_string_array_drop, \
+        z_moved_string_t : z_string_drop, \
+        z_moved_subscriber_t : z_subscriber_drop, \
+        zcu_moved_closure_matching_status_t : zcu_closure_matching_status_drop \
     )(x)
 
-#define z_closure_hello_move(x) (z_moved_closure_hello_t){&x}
-#define z_closure_owned_query_move(x) (z_moved_closure_owned_query_t){&x}
-#define z_closure_query_move(x) (z_moved_closure_query_t){&x}
-#define z_closure_reply_move(x) (z_moved_closure_reply_t){&x}
-#define z_closure_sample_move(x) (z_moved_closure_sample_t){&x}
-#define z_closure_zid_move(x) (z_moved_closure_zid_t){&x}
 #define z_move_(x) \
-    _Generic((x), \
-        z_owned_closure_hello_t : (z_moved_closure_hello_t){(z_owned_closure_hello_t*)&x}, \
-        z_owned_closure_owned_query_t : (z_moved_closure_owned_query_t){(z_owned_closure_owned_query_t*)&x}, \
-        z_owned_closure_query_t : (z_moved_closure_query_t){(z_owned_closure_query_t*)&x}, \
-        z_owned_closure_reply_t : (z_moved_closure_reply_t){(z_owned_closure_reply_t*)&x}, \
-        z_owned_closure_sample_t : (z_moved_closure_sample_t){(z_owned_closure_sample_t*)&x}, \
-        z_owned_closure_zid_t : (z_moved_closure_zid_t){(z_owned_closure_zid_t*)&x} \
+    _Generic((x) \
     )
 #define z_move(x) (&x)
 
@@ -109,6 +129,7 @@
         z_owned_bytes_writer_t* : z_bytes_writer_null, \
         z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_null, \
         z_owned_closure_hello_t* : z_closure_hello_null, \
+        z_owned_closure_owned_query_t* : z_closure_owned_query_null, \
         z_owned_closure_query_t* : z_closure_query_null, \
         z_owned_closure_reply_t* : z_closure_reply_null, \
         z_owned_closure_sample_t* : z_closure_sample_null, \
@@ -163,6 +184,7 @@
         z_owned_bytes_writer_t : z_bytes_writer_check, \
         z_owned_chunk_alloc_result_t : z_chunk_alloc_result_check, \
         z_owned_closure_hello_t : z_closure_hello_check, \
+        z_owned_closure_owned_query_t : z_closure_owned_query_check, \
         z_owned_closure_query_t : z_closure_query_check, \
         z_owned_closure_reply_t : z_closure_reply_check, \
         z_owned_closure_sample_t : z_closure_sample_check, \
@@ -307,30 +329,94 @@ inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { retu
 inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan_mut(&this_); };
 
 
-inline void z_drop(z_owned_closure_hello_t* closure) { return z_closure_hello_drop(closure); };
-inline void z_drop(z_owned_closure_owned_query_t* closure) { return z_closure_owned_query_drop(closure); };
-inline void z_drop(z_owned_closure_query_t* closure) { return z_closure_query_drop(closure); };
-inline void z_drop(z_owned_closure_reply_t* closure) { return z_closure_reply_drop(closure); };
-inline void z_drop(z_owned_closure_sample_t* closure) { return z_closure_sample_drop(closure); };
-inline void z_drop(z_owned_closure_zid_t* closure) { return z_closure_zid_drop(closure); };
-inline void z_drop(zc_owned_liveliness_token_t* this_) { return zc_liveliness_token_drop(this_); };
-inline void z_drop(zc_owned_shm_client_list_t* this_) { return zc_shm_client_list_drop(this_); };
-inline void z_drop(zcu_owned_closure_matching_status_t* closure) { return zcu_closure_matching_status_drop(closure); };
-inline void z_drop(ze_owned_publication_cache_t* this_) { return ze_publication_cache_drop(this_); };
-inline void z_drop(ze_owned_querying_subscriber_t* this_) { return ze_querying_subscriber_drop(this_); };
+inline void z_drop(z_moved_alloc_layout_t this_) { return z_alloc_layout_drop(this_); };
+inline void z_drop(z_moved_buf_alloc_result_t this_) { return z_buf_alloc_result_drop(this_); };
+inline void z_drop(z_moved_bytes_t this_) { return z_bytes_drop(this_); };
+inline void z_drop(z_moved_bytes_writer_t this_) { return z_bytes_writer_drop(this_); };
+inline void z_drop(z_moved_chunk_alloc_result_t this_) { return z_chunk_alloc_result_drop(this_); };
+inline void z_drop(z_moved_closure_hello_t _closure) { return z_closure_hello_drop(_closure); };
+inline void z_drop(z_moved_closure_owned_query_t closure) { return z_closure_owned_query_drop(closure); };
+inline void z_drop(z_moved_closure_query_t closure) { return z_closure_query_drop(closure); };
+inline void z_drop(z_moved_closure_reply_t closure) { return z_closure_reply_drop(closure); };
+inline void z_drop(z_moved_closure_sample_t closure) { return z_closure_sample_drop(closure); };
+inline void z_drop(z_moved_closure_zid_t closure) { return z_closure_zid_drop(closure); };
+inline void z_drop(z_moved_condvar_t this_) { return z_condvar_drop(this_); };
+inline void z_drop(z_moved_config_t this_) { return z_config_drop(this_); };
+inline void z_drop(z_moved_encoding_t this_) { return z_encoding_drop(this_); };
+inline void z_drop(z_moved_fifo_handler_query_t this_) { return z_fifo_handler_query_drop(this_); };
+inline void z_drop(z_moved_fifo_handler_reply_t this_) { return z_fifo_handler_reply_drop(this_); };
+inline void z_drop(z_moved_fifo_handler_sample_t this_) { return z_fifo_handler_sample_drop(this_); };
+inline void z_drop(z_moved_hello_t this_) { return z_hello_drop(this_); };
+inline void z_drop(z_moved_keyexpr_t this_) { return z_keyexpr_drop(this_); };
+inline void z_drop(z_moved_memory_layout_t this_) { return z_memory_layout_drop(this_); };
+inline void z_drop(z_moved_mutex_t this_) { return z_mutex_drop(this_); };
+inline void z_drop(z_moved_publisher_t this_) { return z_publisher_drop(this_); };
+inline void z_drop(z_moved_query_t this_) { return z_query_drop(this_); };
+inline void z_drop(z_moved_queryable_t this_) { return z_queryable_drop(this_); };
+inline void z_drop(z_moved_reply_t this_) { return z_reply_drop(this_); };
+inline void z_drop(z_moved_reply_err_t this_) { return z_reply_err_drop(this_); };
+inline void z_drop(z_moved_ring_handler_query_t this_) { return z_ring_handler_query_drop(this_); };
+inline void z_drop(z_moved_ring_handler_reply_t this_) { return z_ring_handler_reply_drop(this_); };
+inline void z_drop(z_moved_ring_handler_sample_t this_) { return z_ring_handler_sample_drop(this_); };
+inline void z_drop(z_moved_sample_t this_) { return z_sample_drop(this_); };
+inline void z_drop(z_moved_session_t this_) { return z_session_drop(this_); };
+inline void z_drop(z_moved_shm_client_t this_) { return z_shm_client_drop(this_); };
+inline void z_drop(z_moved_shm_client_storage_t this_) { return z_shm_client_storage_drop(this_); };
+inline void z_drop(z_moved_shm_t this_) { return z_shm_drop(this_); };
+inline void z_drop(z_moved_shm_mut_t this_) { return z_shm_mut_drop(this_); };
+inline void z_drop(z_moved_shm_provider_t this_) { return z_shm_provider_drop(this_); };
+inline void z_drop(z_moved_slice_t this_) { return z_slice_drop(this_); };
+inline void z_drop(z_moved_slice_map_t this_) { return z_slice_map_drop(this_); };
+inline void z_drop(z_moved_source_info_t this_) { return z_source_info_drop(this_); };
+inline void z_drop(z_moved_string_array_t this_) { return z_string_array_drop(this_); };
+inline void z_drop(z_moved_string_t this_) { return z_string_drop(this_); };
+inline void z_drop(z_moved_subscriber_t this_) { return z_subscriber_drop(this_); };
+inline void z_drop(zcu_moved_closure_matching_status_t closure) { return zcu_closure_matching_status_drop(closure); };
 
 
-inline z_owned_closure_hello_t* z_move(z_owned_closure_hello_t& closure) { return (&closure); };
-inline z_owned_closure_owned_query_t* z_move(z_owned_closure_owned_query_t& closure) { return (&closure); };
-inline z_owned_closure_query_t* z_move(z_owned_closure_query_t& closure) { return (&closure); };
-inline z_owned_closure_reply_t* z_move(z_owned_closure_reply_t& closure) { return (&closure); };
-inline z_owned_closure_sample_t* z_move(z_owned_closure_sample_t& closure) { return (&closure); };
-inline z_owned_closure_zid_t* z_move(z_owned_closure_zid_t& closure) { return (&closure); };
-inline zc_owned_liveliness_token_t* z_move(zc_owned_liveliness_token_t& this_) { return (&this_); };
-inline zc_owned_shm_client_list_t* z_move(zc_owned_shm_client_list_t& this_) { return (&this_); };
-inline zcu_owned_closure_matching_status_t* z_move(zcu_owned_closure_matching_status_t& closure) { return (&closure); };
-inline ze_owned_publication_cache_t* z_move(ze_owned_publication_cache_t& this_) { return (&this_); };
-inline ze_owned_querying_subscriber_t* z_move(ze_owned_querying_subscriber_t& this_) { return (&this_); };
+inline z_moved_alloc_layout_t z_move(z_moved_alloc_layout_t this_) { return (&this_); };
+inline z_moved_buf_alloc_result_t z_move(z_moved_buf_alloc_result_t this_) { return (&this_); };
+inline z_moved_bytes_t z_move(z_moved_bytes_t this_) { return (&this_); };
+inline z_moved_bytes_writer_t z_move(z_moved_bytes_writer_t this_) { return (&this_); };
+inline z_moved_chunk_alloc_result_t z_move(z_moved_chunk_alloc_result_t this_) { return (&this_); };
+inline z_moved_closure_hello_t z_move(z_moved_closure_hello_t _closure) { return (&_closure); };
+inline z_moved_closure_owned_query_t z_move(z_moved_closure_owned_query_t closure) { return (&closure); };
+inline z_moved_closure_query_t z_move(z_moved_closure_query_t closure) { return (&closure); };
+inline z_moved_closure_reply_t z_move(z_moved_closure_reply_t closure) { return (&closure); };
+inline z_moved_closure_sample_t z_move(z_moved_closure_sample_t closure) { return (&closure); };
+inline z_moved_closure_zid_t z_move(z_moved_closure_zid_t closure) { return (&closure); };
+inline z_moved_condvar_t z_move(z_moved_condvar_t this_) { return (&this_); };
+inline z_moved_config_t z_move(z_moved_config_t this_) { return (&this_); };
+inline z_moved_encoding_t z_move(z_moved_encoding_t this_) { return (&this_); };
+inline z_moved_fifo_handler_query_t z_move(z_moved_fifo_handler_query_t this_) { return (&this_); };
+inline z_moved_fifo_handler_reply_t z_move(z_moved_fifo_handler_reply_t this_) { return (&this_); };
+inline z_moved_fifo_handler_sample_t z_move(z_moved_fifo_handler_sample_t this_) { return (&this_); };
+inline z_moved_hello_t z_move(z_moved_hello_t this_) { return (&this_); };
+inline z_moved_keyexpr_t z_move(z_moved_keyexpr_t this_) { return (&this_); };
+inline z_moved_memory_layout_t z_move(z_moved_memory_layout_t this_) { return (&this_); };
+inline z_moved_mutex_t z_move(z_moved_mutex_t this_) { return (&this_); };
+inline z_moved_publisher_t z_move(z_moved_publisher_t this_) { return (&this_); };
+inline z_moved_query_t z_move(z_moved_query_t this_) { return (&this_); };
+inline z_moved_queryable_t z_move(z_moved_queryable_t this_) { return (&this_); };
+inline z_moved_reply_t z_move(z_moved_reply_t this_) { return (&this_); };
+inline z_moved_reply_err_t z_move(z_moved_reply_err_t this_) { return (&this_); };
+inline z_moved_ring_handler_query_t z_move(z_moved_ring_handler_query_t this_) { return (&this_); };
+inline z_moved_ring_handler_reply_t z_move(z_moved_ring_handler_reply_t this_) { return (&this_); };
+inline z_moved_ring_handler_sample_t z_move(z_moved_ring_handler_sample_t this_) { return (&this_); };
+inline z_moved_sample_t z_move(z_moved_sample_t this_) { return (&this_); };
+inline z_moved_session_t z_move(z_moved_session_t this_) { return (&this_); };
+inline z_moved_shm_client_t z_move(z_moved_shm_client_t this_) { return (&this_); };
+inline z_moved_shm_client_storage_t z_move(z_moved_shm_client_storage_t this_) { return (&this_); };
+inline z_moved_shm_t z_move(z_moved_shm_t this_) { return (&this_); };
+inline z_moved_shm_mut_t z_move(z_moved_shm_mut_t this_) { return (&this_); };
+inline z_moved_shm_provider_t z_move(z_moved_shm_provider_t this_) { return (&this_); };
+inline z_moved_slice_t z_move(z_moved_slice_t this_) { return (&this_); };
+inline z_moved_slice_map_t z_move(z_moved_slice_map_t this_) { return (&this_); };
+inline z_moved_source_info_t z_move(z_moved_source_info_t this_) { return (&this_); };
+inline z_moved_string_array_t z_move(z_moved_string_array_t this_) { return (&this_); };
+inline z_moved_string_t z_move(z_moved_string_t this_) { return (&this_); };
+inline z_moved_subscriber_t z_move(z_moved_subscriber_t this_) { return (&this_); };
+inline zcu_moved_closure_matching_status_t z_move(zcu_moved_closure_matching_status_t closure) { return (&closure); };
 
 
 inline void z_null(z_owned_alloc_layout_t* this_) { return z_alloc_layout_null(this_); };
@@ -339,6 +425,7 @@ inline void z_null(z_owned_bytes_t* this_) { return z_bytes_null(this_); };
 inline void z_null(z_owned_bytes_writer_t* this_) { return z_bytes_writer_null(this_); };
 inline void z_null(z_owned_chunk_alloc_result_t* this_) { return z_chunk_alloc_result_null(this_); };
 inline void z_null(z_owned_closure_hello_t* this_) { return z_closure_hello_null(this_); };
+inline void z_null(z_owned_closure_owned_query_t* this_) { return z_closure_owned_query_null(this_); };
 inline void z_null(z_owned_closure_query_t* this_) { return z_closure_query_null(this_); };
 inline void z_null(z_owned_closure_reply_t* this_) { return z_closure_reply_null(this_); };
 inline void z_null(z_owned_closure_sample_t* this_) { return z_closure_sample_null(this_); };
@@ -391,6 +478,7 @@ inline bool z_check(const z_owned_bytes_t& this_) { return z_bytes_check(&this_)
 inline bool z_check(const z_owned_bytes_writer_t& this_) { return z_bytes_writer_check(&this_); };
 inline bool z_check(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_check(&this_); };
 inline bool z_check(const z_owned_closure_hello_t& this_) { return z_closure_hello_check(&this_); };
+inline bool z_check(const z_owned_closure_owned_query_t& this_) { return z_closure_owned_query_check(&this_); };
 inline bool z_check(const z_owned_closure_query_t& this_) { return z_closure_query_check(&this_); };
 inline bool z_check(const z_owned_closure_reply_t& this_) { return z_closure_reply_check(&this_); };
 inline bool z_check(const z_owned_closure_sample_t& this_) { return z_closure_sample_check(&this_); };

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -99,6 +99,108 @@
         ze_owned_querying_subscriber_t* : ze_querying_subscriber_drop \
     )(x)
 
+typedef struct z_moved_bytes_t { struct z_owned_bytes_t* ptr; } z_moved_bytes_t;
+typedef struct z_moved_bytes_writer_t { struct z_owned_bytes_writer_t* ptr; } z_moved_bytes_writer_t;
+typedef struct z_moved_closure_hello_t { struct z_owned_closure_hello_t* ptr; } z_moved_closure_hello_t;
+typedef struct z_moved_closure_owned_query_t { struct z_owned_closure_owned_query_t* ptr; } z_moved_closure_owned_query_t;
+typedef struct z_moved_closure_query_t { struct z_owned_closure_query_t* ptr; } z_moved_closure_query_t;
+typedef struct z_moved_closure_reply_t { struct z_owned_closure_reply_t* ptr; } z_moved_closure_reply_t;
+typedef struct z_moved_closure_sample_t { struct z_owned_closure_sample_t* ptr; } z_moved_closure_sample_t;
+typedef struct z_moved_closure_zid_t { struct z_owned_closure_zid_t* ptr; } z_moved_closure_zid_t;
+typedef struct z_moved_condvar_t { struct z_owned_condvar_t* ptr; } z_moved_condvar_t;
+typedef struct z_moved_config_t { struct z_owned_config_t* ptr; } z_moved_config_t;
+typedef struct z_moved_encoding_t { struct z_owned_encoding_t* ptr; } z_moved_encoding_t;
+typedef struct z_moved_fifo_handler_query_t { struct z_owned_fifo_handler_query_t* ptr; } z_moved_fifo_handler_query_t;
+typedef struct z_moved_fifo_handler_reply_t { struct z_owned_fifo_handler_reply_t* ptr; } z_moved_fifo_handler_reply_t;
+typedef struct z_moved_fifo_handler_sample_t { struct z_owned_fifo_handler_sample_t* ptr; } z_moved_fifo_handler_sample_t;
+typedef struct z_moved_hello_t { struct z_owned_hello_t* ptr; } z_moved_hello_t;
+typedef struct z_moved_keyexpr_t { struct z_owned_keyexpr_t* ptr; } z_moved_keyexpr_t;
+typedef struct z_moved_mutex_t { struct z_owned_mutex_t* ptr; } z_moved_mutex_t;
+typedef struct z_moved_publisher_t { struct z_owned_publisher_t* ptr; } z_moved_publisher_t;
+typedef struct z_moved_query_t { struct z_owned_query_t* ptr; } z_moved_query_t;
+typedef struct z_moved_queryable_t { struct z_owned_queryable_t* ptr; } z_moved_queryable_t;
+typedef struct z_moved_reply_t { struct z_owned_reply_t* ptr; } z_moved_reply_t;
+typedef struct z_moved_reply_err_t { struct z_owned_reply_err_t* ptr; } z_moved_reply_err_t;
+typedef struct z_moved_ring_handler_query_t { struct z_owned_ring_handler_query_t* ptr; } z_moved_ring_handler_query_t;
+typedef struct z_moved_ring_handler_reply_t { struct z_owned_ring_handler_reply_t* ptr; } z_moved_ring_handler_reply_t;
+typedef struct z_moved_ring_handler_sample_t { struct z_owned_ring_handler_sample_t* ptr; } z_moved_ring_handler_sample_t;
+typedef struct z_moved_sample_t { struct z_owned_sample_t* ptr; } z_moved_sample_t;
+typedef struct z_moved_session_t { struct z_owned_session_t* ptr; } z_moved_session_t;
+typedef struct z_moved_slice_t { struct z_owned_slice_t* ptr; } z_moved_slice_t;
+typedef struct z_moved_slice_map_t { struct z_owned_slice_map_t* ptr; } z_moved_slice_map_t;
+typedef struct z_moved_source_info_t { struct z_owned_source_info_t* ptr; } z_moved_source_info_t;
+typedef struct z_moved_string_array_t { struct z_owned_string_array_t* ptr; } z_moved_string_array_t;
+typedef struct z_moved_string_t { struct z_owned_string_t* ptr; } z_moved_string_t;
+typedef struct z_moved_subscriber_t { struct z_owned_subscriber_t* ptr; } z_moved_subscriber_t;
+#define z_bytes_move(x) (z_moved_bytes_t){&x}
+#define z_bytes_writer_move(x) (z_moved_bytes_writer_t){&x}
+#define z_closure_hello_move(x) (z_moved_closure_hello_t){&x}
+#define z_closure_owned_query_move(x) (z_moved_closure_owned_query_t){&x}
+#define z_closure_query_move(x) (z_moved_closure_query_t){&x}
+#define z_closure_reply_move(x) (z_moved_closure_reply_t){&x}
+#define z_closure_sample_move(x) (z_moved_closure_sample_t){&x}
+#define z_closure_zid_move(x) (z_moved_closure_zid_t){&x}
+#define z_condvar_move(x) (z_moved_condvar_t){&x}
+#define z_config_move(x) (z_moved_config_t){&x}
+#define z_encoding_move(x) (z_moved_encoding_t){&x}
+#define z_fifo_handler_query_move(x) (z_moved_fifo_handler_query_t){&x}
+#define z_fifo_handler_reply_move(x) (z_moved_fifo_handler_reply_t){&x}
+#define z_fifo_handler_sample_move(x) (z_moved_fifo_handler_sample_t){&x}
+#define z_hello_move(x) (z_moved_hello_t){&x}
+#define z_keyexpr_move(x) (z_moved_keyexpr_t){&x}
+#define z_mutex_move(x) (z_moved_mutex_t){&x}
+#define z_publisher_move(x) (z_moved_publisher_t){&x}
+#define z_query_move(x) (z_moved_query_t){&x}
+#define z_queryable_move(x) (z_moved_queryable_t){&x}
+#define z_reply_move(x) (z_moved_reply_t){&x}
+#define z_reply_err_move(x) (z_moved_reply_err_t){&x}
+#define z_ring_handler_query_move(x) (z_moved_ring_handler_query_t){&x}
+#define z_ring_handler_reply_move(x) (z_moved_ring_handler_reply_t){&x}
+#define z_ring_handler_sample_move(x) (z_moved_ring_handler_sample_t){&x}
+#define z_sample_move(x) (z_moved_sample_t){&x}
+#define z_session_move(x) (z_moved_session_t){&x}
+#define z_slice_move(x) (z_moved_slice_t){&x}
+#define z_slice_map_move(x) (z_moved_slice_map_t){&x}
+#define z_source_info_move(x) (z_moved_source_info_t){&x}
+#define z_string_array_move(x) (z_moved_string_array_t){&x}
+#define z_string_move(x) (z_moved_string_t){&x}
+#define z_subscriber_move(x) (z_moved_subscriber_t){&x}
+#define z_move_(x) \
+    _Generic((x), \
+        z_owned_bytes_t : (z_moved_bytes_t){(z_owned_bytes_t*)&x}, \
+        z_owned_bytes_writer_t : (z_moved_bytes_writer_t){(z_owned_bytes_writer_t*)&x}, \
+        z_owned_closure_hello_t : (z_moved_closure_hello_t){(z_owned_closure_hello_t*)&x}, \
+        z_owned_closure_owned_query_t : (z_moved_closure_owned_query_t){(z_owned_closure_owned_query_t*)&x}, \
+        z_owned_closure_query_t : (z_moved_closure_query_t){(z_owned_closure_query_t*)&x}, \
+        z_owned_closure_reply_t : (z_moved_closure_reply_t){(z_owned_closure_reply_t*)&x}, \
+        z_owned_closure_sample_t : (z_moved_closure_sample_t){(z_owned_closure_sample_t*)&x}, \
+        z_owned_closure_zid_t : (z_moved_closure_zid_t){(z_owned_closure_zid_t*)&x}, \
+        z_owned_condvar_t : (z_moved_condvar_t){(z_owned_condvar_t*)&x}, \
+        z_owned_config_t : (z_moved_config_t){(z_owned_config_t*)&x}, \
+        z_owned_encoding_t : (z_moved_encoding_t){(z_owned_encoding_t*)&x}, \
+        z_owned_fifo_handler_query_t : (z_moved_fifo_handler_query_t){(z_owned_fifo_handler_query_t*)&x}, \
+        z_owned_fifo_handler_reply_t : (z_moved_fifo_handler_reply_t){(z_owned_fifo_handler_reply_t*)&x}, \
+        z_owned_fifo_handler_sample_t : (z_moved_fifo_handler_sample_t){(z_owned_fifo_handler_sample_t*)&x}, \
+        z_owned_hello_t : (z_moved_hello_t){(z_owned_hello_t*)&x}, \
+        z_owned_keyexpr_t : (z_moved_keyexpr_t){(z_owned_keyexpr_t*)&x}, \
+        z_owned_mutex_t : (z_moved_mutex_t){(z_owned_mutex_t*)&x}, \
+        z_owned_publisher_t : (z_moved_publisher_t){(z_owned_publisher_t*)&x}, \
+        z_owned_query_t : (z_moved_query_t){(z_owned_query_t*)&x}, \
+        z_owned_queryable_t : (z_moved_queryable_t){(z_owned_queryable_t*)&x}, \
+        z_owned_reply_t : (z_moved_reply_t){(z_owned_reply_t*)&x}, \
+        z_owned_reply_err_t : (z_moved_reply_err_t){(z_owned_reply_err_t*)&x}, \
+        z_owned_ring_handler_query_t : (z_moved_ring_handler_query_t){(z_owned_ring_handler_query_t*)&x}, \
+        z_owned_ring_handler_reply_t : (z_moved_ring_handler_reply_t){(z_owned_ring_handler_reply_t*)&x}, \
+        z_owned_ring_handler_sample_t : (z_moved_ring_handler_sample_t){(z_owned_ring_handler_sample_t*)&x}, \
+        z_owned_sample_t : (z_moved_sample_t){(z_owned_sample_t*)&x}, \
+        z_owned_session_t : (z_moved_session_t){(z_owned_session_t*)&x}, \
+        z_owned_slice_t : (z_moved_slice_t){(z_owned_slice_t*)&x}, \
+        z_owned_slice_map_t : (z_moved_slice_map_t){(z_owned_slice_map_t*)&x}, \
+        z_owned_source_info_t : (z_moved_source_info_t){(z_owned_source_info_t*)&x}, \
+        z_owned_string_array_t : (z_moved_string_array_t){(z_owned_string_array_t*)&x}, \
+        z_owned_string_t : (z_moved_string_t){(z_owned_string_t*)&x}, \
+        z_owned_subscriber_t : (z_moved_subscriber_t){(z_owned_subscriber_t*)&x} \
+    )
 #define z_move(x) (&x)
 
 #define z_null(x) \

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -159,7 +159,7 @@
 #define z_string_move(x) (z_moved_string_t){&x}
 #define z_subscriber_move(x) (z_moved_subscriber_t){&x}
 #define zcu_closure_matching_status_move(x) (zcu_moved_closure_matching_status_t){&x}
-#define z_move_(x) \
+#define z_move(x) \
     _Generic((x), \
         z_owned_alloc_layout_t : (z_moved_alloc_layout_t){(z_owned_alloc_layout_t*)&x}, \
         z_owned_buf_alloc_result_t : (z_moved_buf_alloc_result_t){(z_owned_buf_alloc_result_t*)&x}, \

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -71,47 +71,12 @@
 
 #define z_drop(x) \
     _Generic((x), \
-        z_owned_alloc_layout_t* : z_alloc_layout_drop, \
-        z_owned_buf_alloc_result_t* : z_buf_alloc_result_drop, \
-        z_owned_bytes_t* : z_bytes_drop, \
-        z_owned_bytes_writer_t* : z_bytes_writer_drop, \
-        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_drop, \
         z_owned_closure_hello_t* : z_closure_hello_drop, \
         z_owned_closure_owned_query_t* : z_closure_owned_query_drop, \
         z_owned_closure_query_t* : z_closure_query_drop, \
         z_owned_closure_reply_t* : z_closure_reply_drop, \
         z_owned_closure_sample_t* : z_closure_sample_drop, \
         z_owned_closure_zid_t* : z_closure_zid_drop, \
-        z_owned_condvar_t* : z_condvar_drop, \
-        z_owned_encoding_t* : z_encoding_drop, \
-        z_owned_fifo_handler_query_t* : z_fifo_handler_query_drop, \
-        z_owned_fifo_handler_reply_t* : z_fifo_handler_reply_drop, \
-        z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_drop, \
-        z_owned_hello_t* : z_hello_drop, \
-        z_owned_keyexpr_t* : z_keyexpr_drop, \
-        z_owned_memory_layout_t* : z_memory_layout_drop, \
-        z_owned_mutex_t* : z_mutex_drop, \
-        z_owned_publisher_t* : z_publisher_drop, \
-        z_owned_query_t* : z_query_drop, \
-        z_owned_queryable_t* : z_queryable_drop, \
-        z_owned_reply_t* : z_reply_drop, \
-        z_owned_reply_err_t* : z_reply_err_drop, \
-        z_owned_ring_handler_query_t* : z_ring_handler_query_drop, \
-        z_owned_ring_handler_reply_t* : z_ring_handler_reply_drop, \
-        z_owned_ring_handler_sample_t* : z_ring_handler_sample_drop, \
-        z_owned_sample_t* : z_sample_drop, \
-        z_owned_session_t* : z_session_drop, \
-        z_owned_shm_client_t* : z_shm_client_drop, \
-        z_owned_shm_client_storage_t* : z_shm_client_storage_drop, \
-        z_owned_shm_t* : z_shm_drop, \
-        z_owned_shm_mut_t* : z_shm_mut_drop, \
-        z_owned_shm_provider_t* : z_shm_provider_drop, \
-        z_owned_slice_t* : z_slice_drop, \
-        z_owned_slice_map_t* : z_slice_map_drop, \
-        z_owned_source_info_t* : z_source_info_drop, \
-        z_owned_string_array_t* : z_string_array_drop, \
-        z_owned_string_t* : z_string_drop, \
-        z_owned_subscriber_t* : z_subscriber_drop, \
         zc_owned_liveliness_token_t* : zc_liveliness_token_drop, \
         zc_owned_shm_client_list_t* : zc_shm_client_list_drop, \
         zcu_owned_closure_matching_status_t* : zcu_closure_matching_status_drop, \
@@ -119,90 +84,20 @@
         ze_owned_querying_subscriber_t* : ze_querying_subscriber_drop \
     )(x)
 
-#define z_alloc_layout_move(x) (z_moved_alloc_layout_t){&x}
-#define z_buf_alloc_result_move(x) (z_moved_buf_alloc_result_t){&x}
-#define z_bytes_move(x) (z_moved_bytes_t){&x}
-#define z_bytes_writer_move(x) (z_moved_bytes_writer_t){&x}
-#define z_chunk_alloc_result_move(x) (z_moved_chunk_alloc_result_t){&x}
 #define z_closure_hello_move(x) (z_moved_closure_hello_t){&x}
 #define z_closure_owned_query_move(x) (z_moved_closure_owned_query_t){&x}
 #define z_closure_query_move(x) (z_moved_closure_query_t){&x}
 #define z_closure_reply_move(x) (z_moved_closure_reply_t){&x}
 #define z_closure_sample_move(x) (z_moved_closure_sample_t){&x}
 #define z_closure_zid_move(x) (z_moved_closure_zid_t){&x}
-#define z_condvar_move(x) (z_moved_condvar_t){&x}
-#define z_encoding_move(x) (z_moved_encoding_t){&x}
-#define z_fifo_handler_query_move(x) (z_moved_fifo_handler_query_t){&x}
-#define z_fifo_handler_reply_move(x) (z_moved_fifo_handler_reply_t){&x}
-#define z_fifo_handler_sample_move(x) (z_moved_fifo_handler_sample_t){&x}
-#define z_hello_move(x) (z_moved_hello_t){&x}
-#define z_keyexpr_move(x) (z_moved_keyexpr_t){&x}
-#define z_memory_layout_move(x) (z_moved_memory_layout_t){&x}
-#define z_mutex_move(x) (z_moved_mutex_t){&x}
-#define z_publisher_move(x) (z_moved_publisher_t){&x}
-#define z_query_move(x) (z_moved_query_t){&x}
-#define z_queryable_move(x) (z_moved_queryable_t){&x}
-#define z_reply_move(x) (z_moved_reply_t){&x}
-#define z_reply_err_move(x) (z_moved_reply_err_t){&x}
-#define z_ring_handler_query_move(x) (z_moved_ring_handler_query_t){&x}
-#define z_ring_handler_reply_move(x) (z_moved_ring_handler_reply_t){&x}
-#define z_ring_handler_sample_move(x) (z_moved_ring_handler_sample_t){&x}
-#define z_sample_move(x) (z_moved_sample_t){&x}
-#define z_session_move(x) (z_moved_session_t){&x}
-#define z_shm_client_move(x) (z_moved_shm_client_t){&x}
-#define z_shm_client_storage_move(x) (z_moved_shm_client_storage_t){&x}
-#define z_shm_move(x) (z_moved_shm_t){&x}
-#define z_shm_mut_move(x) (z_moved_shm_mut_t){&x}
-#define z_shm_provider_move(x) (z_moved_shm_provider_t){&x}
-#define z_slice_move(x) (z_moved_slice_t){&x}
-#define z_slice_map_move(x) (z_moved_slice_map_t){&x}
-#define z_source_info_move(x) (z_moved_source_info_t){&x}
-#define z_string_array_move(x) (z_moved_string_array_t){&x}
-#define z_string_move(x) (z_moved_string_t){&x}
-#define z_subscriber_move(x) (z_moved_subscriber_t){&x}
 #define z_move_(x) \
     _Generic((x), \
-        z_owned_alloc_layout_t : (z_moved_alloc_layout_t){(z_owned_alloc_layout_t*)&x}, \
-        z_owned_buf_alloc_result_t : (z_moved_buf_alloc_result_t){(z_owned_buf_alloc_result_t*)&x}, \
-        z_owned_bytes_t : (z_moved_bytes_t){(z_owned_bytes_t*)&x}, \
-        z_owned_bytes_writer_t : (z_moved_bytes_writer_t){(z_owned_bytes_writer_t*)&x}, \
-        z_owned_chunk_alloc_result_t : (z_moved_chunk_alloc_result_t){(z_owned_chunk_alloc_result_t*)&x}, \
         z_owned_closure_hello_t : (z_moved_closure_hello_t){(z_owned_closure_hello_t*)&x}, \
         z_owned_closure_owned_query_t : (z_moved_closure_owned_query_t){(z_owned_closure_owned_query_t*)&x}, \
         z_owned_closure_query_t : (z_moved_closure_query_t){(z_owned_closure_query_t*)&x}, \
         z_owned_closure_reply_t : (z_moved_closure_reply_t){(z_owned_closure_reply_t*)&x}, \
         z_owned_closure_sample_t : (z_moved_closure_sample_t){(z_owned_closure_sample_t*)&x}, \
-        z_owned_closure_zid_t : (z_moved_closure_zid_t){(z_owned_closure_zid_t*)&x}, \
-        z_owned_condvar_t : (z_moved_condvar_t){(z_owned_condvar_t*)&x}, \
-        z_owned_encoding_t : (z_moved_encoding_t){(z_owned_encoding_t*)&x}, \
-        z_owned_fifo_handler_query_t : (z_moved_fifo_handler_query_t){(z_owned_fifo_handler_query_t*)&x}, \
-        z_owned_fifo_handler_reply_t : (z_moved_fifo_handler_reply_t){(z_owned_fifo_handler_reply_t*)&x}, \
-        z_owned_fifo_handler_sample_t : (z_moved_fifo_handler_sample_t){(z_owned_fifo_handler_sample_t*)&x}, \
-        z_owned_hello_t : (z_moved_hello_t){(z_owned_hello_t*)&x}, \
-        z_owned_keyexpr_t : (z_moved_keyexpr_t){(z_owned_keyexpr_t*)&x}, \
-        z_owned_memory_layout_t : (z_moved_memory_layout_t){(z_owned_memory_layout_t*)&x}, \
-        z_owned_mutex_t : (z_moved_mutex_t){(z_owned_mutex_t*)&x}, \
-        z_owned_publisher_t : (z_moved_publisher_t){(z_owned_publisher_t*)&x}, \
-        z_owned_query_t : (z_moved_query_t){(z_owned_query_t*)&x}, \
-        z_owned_queryable_t : (z_moved_queryable_t){(z_owned_queryable_t*)&x}, \
-        z_owned_reply_t : (z_moved_reply_t){(z_owned_reply_t*)&x}, \
-        z_owned_reply_err_t : (z_moved_reply_err_t){(z_owned_reply_err_t*)&x}, \
-        z_owned_ring_handler_query_t : (z_moved_ring_handler_query_t){(z_owned_ring_handler_query_t*)&x}, \
-        z_owned_ring_handler_reply_t : (z_moved_ring_handler_reply_t){(z_owned_ring_handler_reply_t*)&x}, \
-        z_owned_ring_handler_sample_t : (z_moved_ring_handler_sample_t){(z_owned_ring_handler_sample_t*)&x}, \
-        z_owned_sample_t : (z_moved_sample_t){(z_owned_sample_t*)&x}, \
-        z_owned_session_t : (z_moved_session_t){(z_owned_session_t*)&x}, \
-        z_owned_shm_client_t : (z_moved_shm_client_t){(z_owned_shm_client_t*)&x}, \
-        z_owned_shm_client_storage_t : (z_moved_shm_client_storage_t){(z_owned_shm_client_storage_t*)&x}, \
-        z_owned_shm_t : (z_moved_shm_t){(z_owned_shm_t*)&x}, \
-        z_owned_shm_mut_t : (z_moved_shm_mut_t){(z_owned_shm_mut_t*)&x}, \
-        z_owned_shm_provider_t : (z_moved_shm_provider_t){(z_owned_shm_provider_t*)&x}, \
-        z_owned_slice_t : (z_moved_slice_t){(z_owned_slice_t*)&x}, \
-        z_owned_slice_map_t : (z_moved_slice_map_t){(z_owned_slice_map_t*)&x}, \
-        z_owned_source_info_t : (z_moved_source_info_t){(z_owned_source_info_t*)&x}, \
-        z_owned_string_array_t : (z_moved_string_array_t){(z_owned_string_array_t*)&x}, \
-        z_owned_string_t : (z_moved_string_t){(z_owned_string_t*)&x}, \
-        z_owned_subscriber_t : (z_moved_subscriber_t){(z_owned_subscriber_t*)&x} \
+        z_owned_closure_zid_t : (z_moved_closure_zid_t){(z_owned_closure_zid_t*)&x} \
     )
 #define z_move(x) (&x)
 
@@ -412,47 +307,12 @@ inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { retu
 inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan_mut(&this_); };
 
 
-inline void z_drop(z_owned_alloc_layout_t* this_) { return z_alloc_layout_drop(this_); };
-inline void z_drop(z_owned_buf_alloc_result_t* this_) { return z_buf_alloc_result_drop(this_); };
-inline void z_drop(z_owned_bytes_t* this_) { return z_bytes_drop(this_); };
-inline void z_drop(z_owned_bytes_writer_t* this_) { return z_bytes_writer_drop(this_); };
-inline void z_drop(z_owned_chunk_alloc_result_t* this_) { return z_chunk_alloc_result_drop(this_); };
 inline void z_drop(z_owned_closure_hello_t* closure) { return z_closure_hello_drop(closure); };
 inline void z_drop(z_owned_closure_owned_query_t* closure) { return z_closure_owned_query_drop(closure); };
 inline void z_drop(z_owned_closure_query_t* closure) { return z_closure_query_drop(closure); };
 inline void z_drop(z_owned_closure_reply_t* closure) { return z_closure_reply_drop(closure); };
 inline void z_drop(z_owned_closure_sample_t* closure) { return z_closure_sample_drop(closure); };
 inline void z_drop(z_owned_closure_zid_t* closure) { return z_closure_zid_drop(closure); };
-inline void z_drop(z_owned_condvar_t* this_) { return z_condvar_drop(this_); };
-inline void z_drop(z_owned_encoding_t* this_) { return z_encoding_drop(this_); };
-inline void z_drop(z_owned_fifo_handler_query_t* this_) { return z_fifo_handler_query_drop(this_); };
-inline void z_drop(z_owned_fifo_handler_reply_t* this_) { return z_fifo_handler_reply_drop(this_); };
-inline void z_drop(z_owned_fifo_handler_sample_t* this_) { return z_fifo_handler_sample_drop(this_); };
-inline void z_drop(z_owned_hello_t* this_) { return z_hello_drop(this_); };
-inline void z_drop(z_owned_keyexpr_t* this_) { return z_keyexpr_drop(this_); };
-inline void z_drop(z_owned_memory_layout_t* this_) { return z_memory_layout_drop(this_); };
-inline void z_drop(z_owned_mutex_t* this_) { return z_mutex_drop(this_); };
-inline void z_drop(z_owned_publisher_t* this_) { return z_publisher_drop(this_); };
-inline void z_drop(z_owned_query_t* this_) { return z_query_drop(this_); };
-inline void z_drop(z_owned_queryable_t* this_) { return z_queryable_drop(this_); };
-inline void z_drop(z_owned_reply_t* this_) { return z_reply_drop(this_); };
-inline void z_drop(z_owned_reply_err_t* this_) { return z_reply_err_drop(this_); };
-inline void z_drop(z_owned_ring_handler_query_t* this_) { return z_ring_handler_query_drop(this_); };
-inline void z_drop(z_owned_ring_handler_reply_t* this_) { return z_ring_handler_reply_drop(this_); };
-inline void z_drop(z_owned_ring_handler_sample_t* this_) { return z_ring_handler_sample_drop(this_); };
-inline void z_drop(z_owned_sample_t* this_) { return z_sample_drop(this_); };
-inline void z_drop(z_owned_session_t* this_) { return z_session_drop(this_); };
-inline void z_drop(z_owned_shm_client_t* this_) { return z_shm_client_drop(this_); };
-inline void z_drop(z_owned_shm_client_storage_t* this_) { return z_shm_client_storage_drop(this_); };
-inline void z_drop(z_owned_shm_t* this_) { return z_shm_drop(this_); };
-inline void z_drop(z_owned_shm_mut_t* this_) { return z_shm_mut_drop(this_); };
-inline void z_drop(z_owned_shm_provider_t* this_) { return z_shm_provider_drop(this_); };
-inline void z_drop(z_owned_slice_t* this_) { return z_slice_drop(this_); };
-inline void z_drop(z_owned_slice_map_t* this_) { return z_slice_map_drop(this_); };
-inline void z_drop(z_owned_source_info_t* this_) { return z_source_info_drop(this_); };
-inline void z_drop(z_owned_string_array_t* this_) { return z_string_array_drop(this_); };
-inline void z_drop(z_owned_string_t* this_) { return z_string_drop(this_); };
-inline void z_drop(z_owned_subscriber_t* this_) { return z_subscriber_drop(this_); };
 inline void z_drop(zc_owned_liveliness_token_t* this_) { return zc_liveliness_token_drop(this_); };
 inline void z_drop(zc_owned_shm_client_list_t* this_) { return zc_shm_client_list_drop(this_); };
 inline void z_drop(zcu_owned_closure_matching_status_t* closure) { return zcu_closure_matching_status_drop(closure); };
@@ -460,47 +320,12 @@ inline void z_drop(ze_owned_publication_cache_t* this_) { return ze_publication_
 inline void z_drop(ze_owned_querying_subscriber_t* this_) { return ze_querying_subscriber_drop(this_); };
 
 
-inline z_owned_alloc_layout_t* z_move(z_owned_alloc_layout_t& this_) { return (&this_); };
-inline z_owned_buf_alloc_result_t* z_move(z_owned_buf_alloc_result_t& this_) { return (&this_); };
-inline z_owned_bytes_t* z_move(z_owned_bytes_t& this_) { return (&this_); };
-inline z_owned_bytes_writer_t* z_move(z_owned_bytes_writer_t& this_) { return (&this_); };
-inline z_owned_chunk_alloc_result_t* z_move(z_owned_chunk_alloc_result_t& this_) { return (&this_); };
 inline z_owned_closure_hello_t* z_move(z_owned_closure_hello_t& closure) { return (&closure); };
 inline z_owned_closure_owned_query_t* z_move(z_owned_closure_owned_query_t& closure) { return (&closure); };
 inline z_owned_closure_query_t* z_move(z_owned_closure_query_t& closure) { return (&closure); };
 inline z_owned_closure_reply_t* z_move(z_owned_closure_reply_t& closure) { return (&closure); };
 inline z_owned_closure_sample_t* z_move(z_owned_closure_sample_t& closure) { return (&closure); };
 inline z_owned_closure_zid_t* z_move(z_owned_closure_zid_t& closure) { return (&closure); };
-inline z_owned_condvar_t* z_move(z_owned_condvar_t& this_) { return (&this_); };
-inline z_owned_encoding_t* z_move(z_owned_encoding_t& this_) { return (&this_); };
-inline z_owned_fifo_handler_query_t* z_move(z_owned_fifo_handler_query_t& this_) { return (&this_); };
-inline z_owned_fifo_handler_reply_t* z_move(z_owned_fifo_handler_reply_t& this_) { return (&this_); };
-inline z_owned_fifo_handler_sample_t* z_move(z_owned_fifo_handler_sample_t& this_) { return (&this_); };
-inline z_owned_hello_t* z_move(z_owned_hello_t& this_) { return (&this_); };
-inline z_owned_keyexpr_t* z_move(z_owned_keyexpr_t& this_) { return (&this_); };
-inline z_owned_memory_layout_t* z_move(z_owned_memory_layout_t& this_) { return (&this_); };
-inline z_owned_mutex_t* z_move(z_owned_mutex_t& this_) { return (&this_); };
-inline z_owned_publisher_t* z_move(z_owned_publisher_t& this_) { return (&this_); };
-inline z_owned_query_t* z_move(z_owned_query_t& this_) { return (&this_); };
-inline z_owned_queryable_t* z_move(z_owned_queryable_t& this_) { return (&this_); };
-inline z_owned_reply_t* z_move(z_owned_reply_t& this_) { return (&this_); };
-inline z_owned_reply_err_t* z_move(z_owned_reply_err_t& this_) { return (&this_); };
-inline z_owned_ring_handler_query_t* z_move(z_owned_ring_handler_query_t& this_) { return (&this_); };
-inline z_owned_ring_handler_reply_t* z_move(z_owned_ring_handler_reply_t& this_) { return (&this_); };
-inline z_owned_ring_handler_sample_t* z_move(z_owned_ring_handler_sample_t& this_) { return (&this_); };
-inline z_owned_sample_t* z_move(z_owned_sample_t& this_) { return (&this_); };
-inline z_owned_session_t* z_move(z_owned_session_t& this_) { return (&this_); };
-inline z_owned_shm_client_t* z_move(z_owned_shm_client_t& this_) { return (&this_); };
-inline z_owned_shm_client_storage_t* z_move(z_owned_shm_client_storage_t& this_) { return (&this_); };
-inline z_owned_shm_t* z_move(z_owned_shm_t& this_) { return (&this_); };
-inline z_owned_shm_mut_t* z_move(z_owned_shm_mut_t& this_) { return (&this_); };
-inline z_owned_shm_provider_t* z_move(z_owned_shm_provider_t& this_) { return (&this_); };
-inline z_owned_slice_t* z_move(z_owned_slice_t& this_) { return (&this_); };
-inline z_owned_slice_map_t* z_move(z_owned_slice_map_t& this_) { return (&this_); };
-inline z_owned_source_info_t* z_move(z_owned_source_info_t& this_) { return (&this_); };
-inline z_owned_string_array_t* z_move(z_owned_string_array_t& this_) { return (&this_); };
-inline z_owned_string_t* z_move(z_owned_string_t& this_) { return (&this_); };
-inline z_owned_subscriber_t* z_move(z_owned_subscriber_t& this_) { return (&this_); };
 inline zc_owned_liveliness_token_t* z_move(zc_owned_liveliness_token_t& this_) { return (&this_); };
 inline zc_owned_shm_client_list_t* z_move(zc_owned_shm_client_list_t& this_) { return (&this_); };
 inline zcu_owned_closure_matching_status_t* z_move(zcu_owned_closure_matching_status_t& closure) { return (&closure); };

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -116,10 +116,95 @@
         zcu_moved_closure_matching_status_t : zcu_closure_matching_status_drop \
     )(x)
 
+#define z_alloc_layout_move(x) (z_moved_alloc_layout_t){&x}
+#define z_buf_alloc_result_move(x) (z_moved_buf_alloc_result_t){&x}
+#define z_bytes_move(x) (z_moved_bytes_t){&x}
+#define z_bytes_writer_move(x) (z_moved_bytes_writer_t){&x}
+#define z_chunk_alloc_result_move(x) (z_moved_chunk_alloc_result_t){&x}
+#define z_closure_hello_move(x) (z_moved_closure_hello_t){&x}
+#define z_closure_owned_query_move(x) (z_moved_closure_owned_query_t){&x}
+#define z_closure_query_move(x) (z_moved_closure_query_t){&x}
+#define z_closure_reply_move(x) (z_moved_closure_reply_t){&x}
+#define z_closure_sample_move(x) (z_moved_closure_sample_t){&x}
+#define z_closure_zid_move(x) (z_moved_closure_zid_t){&x}
+#define z_condvar_move(x) (z_moved_condvar_t){&x}
+#define z_config_move(x) (z_moved_config_t){&x}
+#define z_encoding_move(x) (z_moved_encoding_t){&x}
+#define z_fifo_handler_query_move(x) (z_moved_fifo_handler_query_t){&x}
+#define z_fifo_handler_reply_move(x) (z_moved_fifo_handler_reply_t){&x}
+#define z_fifo_handler_sample_move(x) (z_moved_fifo_handler_sample_t){&x}
+#define z_hello_move(x) (z_moved_hello_t){&x}
+#define z_keyexpr_move(x) (z_moved_keyexpr_t){&x}
+#define z_memory_layout_move(x) (z_moved_memory_layout_t){&x}
+#define z_mutex_move(x) (z_moved_mutex_t){&x}
+#define z_publisher_move(x) (z_moved_publisher_t){&x}
+#define z_query_move(x) (z_moved_query_t){&x}
+#define z_queryable_move(x) (z_moved_queryable_t){&x}
+#define z_reply_move(x) (z_moved_reply_t){&x}
+#define z_reply_err_move(x) (z_moved_reply_err_t){&x}
+#define z_ring_handler_query_move(x) (z_moved_ring_handler_query_t){&x}
+#define z_ring_handler_reply_move(x) (z_moved_ring_handler_reply_t){&x}
+#define z_ring_handler_sample_move(x) (z_moved_ring_handler_sample_t){&x}
+#define z_sample_move(x) (z_moved_sample_t){&x}
+#define z_session_move(x) (z_moved_session_t){&x}
+#define z_shm_client_move(x) (z_moved_shm_client_t){&x}
+#define z_shm_client_storage_move(x) (z_moved_shm_client_storage_t){&x}
+#define z_shm_move(x) (z_moved_shm_t){&x}
+#define z_shm_mut_move(x) (z_moved_shm_mut_t){&x}
+#define z_shm_provider_move(x) (z_moved_shm_provider_t){&x}
+#define z_slice_move(x) (z_moved_slice_t){&x}
+#define z_slice_map_move(x) (z_moved_slice_map_t){&x}
+#define z_source_info_move(x) (z_moved_source_info_t){&x}
+#define z_string_array_move(x) (z_moved_string_array_t){&x}
+#define z_string_move(x) (z_moved_string_t){&x}
+#define z_subscriber_move(x) (z_moved_subscriber_t){&x}
+#define zcu_closure_matching_status_move(x) (zcu_moved_closure_matching_status_t){&x}
 #define z_move_(x) \
-    _Generic((x) \
+    _Generic((x), \
+        z_owned_alloc_layout_t : (z_moved_alloc_layout_t){(z_owned_alloc_layout_t*)&x}, \
+        z_owned_buf_alloc_result_t : (z_moved_buf_alloc_result_t){(z_owned_buf_alloc_result_t*)&x}, \
+        z_owned_bytes_t : (z_moved_bytes_t){(z_owned_bytes_t*)&x}, \
+        z_owned_bytes_writer_t : (z_moved_bytes_writer_t){(z_owned_bytes_writer_t*)&x}, \
+        z_owned_chunk_alloc_result_t : (z_moved_chunk_alloc_result_t){(z_owned_chunk_alloc_result_t*)&x}, \
+        z_owned_closure_hello_t : (z_moved_closure_hello_t){(z_owned_closure_hello_t*)&x}, \
+        z_owned_closure_owned_query_t : (z_moved_closure_owned_query_t){(z_owned_closure_owned_query_t*)&x}, \
+        z_owned_closure_query_t : (z_moved_closure_query_t){(z_owned_closure_query_t*)&x}, \
+        z_owned_closure_reply_t : (z_moved_closure_reply_t){(z_owned_closure_reply_t*)&x}, \
+        z_owned_closure_sample_t : (z_moved_closure_sample_t){(z_owned_closure_sample_t*)&x}, \
+        z_owned_closure_zid_t : (z_moved_closure_zid_t){(z_owned_closure_zid_t*)&x}, \
+        z_owned_condvar_t : (z_moved_condvar_t){(z_owned_condvar_t*)&x}, \
+        z_owned_config_t : (z_moved_config_t){(z_owned_config_t*)&x}, \
+        z_owned_encoding_t : (z_moved_encoding_t){(z_owned_encoding_t*)&x}, \
+        z_owned_fifo_handler_query_t : (z_moved_fifo_handler_query_t){(z_owned_fifo_handler_query_t*)&x}, \
+        z_owned_fifo_handler_reply_t : (z_moved_fifo_handler_reply_t){(z_owned_fifo_handler_reply_t*)&x}, \
+        z_owned_fifo_handler_sample_t : (z_moved_fifo_handler_sample_t){(z_owned_fifo_handler_sample_t*)&x}, \
+        z_owned_hello_t : (z_moved_hello_t){(z_owned_hello_t*)&x}, \
+        z_owned_keyexpr_t : (z_moved_keyexpr_t){(z_owned_keyexpr_t*)&x}, \
+        z_owned_memory_layout_t : (z_moved_memory_layout_t){(z_owned_memory_layout_t*)&x}, \
+        z_owned_mutex_t : (z_moved_mutex_t){(z_owned_mutex_t*)&x}, \
+        z_owned_publisher_t : (z_moved_publisher_t){(z_owned_publisher_t*)&x}, \
+        z_owned_query_t : (z_moved_query_t){(z_owned_query_t*)&x}, \
+        z_owned_queryable_t : (z_moved_queryable_t){(z_owned_queryable_t*)&x}, \
+        z_owned_reply_t : (z_moved_reply_t){(z_owned_reply_t*)&x}, \
+        z_owned_reply_err_t : (z_moved_reply_err_t){(z_owned_reply_err_t*)&x}, \
+        z_owned_ring_handler_query_t : (z_moved_ring_handler_query_t){(z_owned_ring_handler_query_t*)&x}, \
+        z_owned_ring_handler_reply_t : (z_moved_ring_handler_reply_t){(z_owned_ring_handler_reply_t*)&x}, \
+        z_owned_ring_handler_sample_t : (z_moved_ring_handler_sample_t){(z_owned_ring_handler_sample_t*)&x}, \
+        z_owned_sample_t : (z_moved_sample_t){(z_owned_sample_t*)&x}, \
+        z_owned_session_t : (z_moved_session_t){(z_owned_session_t*)&x}, \
+        z_owned_shm_client_t : (z_moved_shm_client_t){(z_owned_shm_client_t*)&x}, \
+        z_owned_shm_client_storage_t : (z_moved_shm_client_storage_t){(z_owned_shm_client_storage_t*)&x}, \
+        z_owned_shm_t : (z_moved_shm_t){(z_owned_shm_t*)&x}, \
+        z_owned_shm_mut_t : (z_moved_shm_mut_t){(z_owned_shm_mut_t*)&x}, \
+        z_owned_shm_provider_t : (z_moved_shm_provider_t){(z_owned_shm_provider_t*)&x}, \
+        z_owned_slice_t : (z_moved_slice_t){(z_owned_slice_t*)&x}, \
+        z_owned_slice_map_t : (z_moved_slice_map_t){(z_owned_slice_map_t*)&x}, \
+        z_owned_source_info_t : (z_moved_source_info_t){(z_owned_source_info_t*)&x}, \
+        z_owned_string_array_t : (z_moved_string_array_t){(z_owned_string_array_t*)&x}, \
+        z_owned_string_t : (z_moved_string_t){(z_owned_string_t*)&x}, \
+        z_owned_subscriber_t : (z_moved_subscriber_t){(z_owned_subscriber_t*)&x}, \
+        zcu_owned_closure_matching_status_t : (zcu_moved_closure_matching_status_t){(zcu_owned_closure_matching_status_t*)&x} \
     )
-#define z_move(x) (&x)
 
 #define z_null(x) \
     _Generic((x), \

--- a/src/closures/hello_closure.rs
+++ b/src/closures/hello_closure.rs
@@ -45,8 +45,8 @@ pub struct z_loaned_closure_hello_t {
 
 /// Moved closure.
 #[repr(C)]
-pub struct z_moved_closure_hello_t<'a> {
-    pub ptr: &'a z_owned_closure_hello_t,
+pub struct z_moved_closure_hello_t {
+    pub ptr: &'static mut z_owned_closure_hello_t,
 }
 
 decl_c_type!(
@@ -54,15 +54,16 @@ decl_c_type!(
     loaned(z_loaned_closure_hello_t)
 );
 
-impl z_owned_closure_hello_t {
-    pub fn empty() -> Self {
+impl Default for z_owned_closure_hello_t {
+    fn default() -> Self {
         z_owned_closure_hello_t {
             context: std::ptr::null_mut(),
             call: None,
             drop: None,
         }
     }
-
+}
+impl z_owned_closure_hello_t {
     pub fn is_empty(&self) -> bool {
         self.call.is_none() && self.drop.is_none() && self.context.is_null()
     }
@@ -80,7 +81,7 @@ impl Drop for z_owned_closure_hello_t {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_closure_hello_null(this: *mut MaybeUninit<z_owned_closure_hello_t>) {
-    (*this).write(z_owned_closure_hello_t::empty());
+    (*this).write(z_owned_closure_hello_t::default());
 }
 /// Calls the closure. Calling an uninitialized closure is a no-op.
 #[no_mangle]
@@ -98,10 +99,9 @@ pub extern "C" fn z_closure_hello_call(
 }
 /// Drops the closure. Droping an uninitialized closure is a no-op.
 #[no_mangle]
-pub extern "C" fn z_closure_hello_drop(closure: &mut z_owned_closure_hello_t) {
-    let mut empty_closure = z_owned_closure_hello_t::empty();
-    std::mem::swap(&mut empty_closure, closure);
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_closure_hello_drop(_closure: z_moved_closure_hello_t) {}
+
 impl<F: Fn(&z_loaned_hello_t)> From<F> for z_owned_closure_hello_t {
     fn from(f: F) -> Self {
         let this = Box::into_raw(Box::new(f)) as _;

--- a/src/closures/hello_closure.rs
+++ b/src/closures/hello_closure.rs
@@ -43,8 +43,14 @@ pub struct z_loaned_closure_hello_t {
     _0: [usize; 3],
 }
 
+/// Moved closure.
+#[repr(C)]
+pub struct z_moved_closure_hello_t<'a> {
+    pub ptr: &'a z_owned_closure_hello_t,
+}
+
 decl_c_type!(
-    owned(z_owned_closure_hello_t),
+    owned(z_owned_closure_hello_t, z_moved_closure_hello_t),
     loaned(z_loaned_closure_hello_t)
 );
 

--- a/src/closures/matching_status_closure.rs
+++ b/src/closures/matching_status_closure.rs
@@ -41,8 +41,16 @@ pub struct zcu_loaned_closure_matching_status_t {
     _0: [usize; 3],
 }
 
+/// Moved closure.
+pub struct zcu_moved_closure_matching_status_t<'a> {
+    pub ptr: &'a zcu_owned_closure_matching_status_t,
+}
+
 decl_c_type!(
-    owned(zcu_owned_closure_matching_status_t),
+    owned(
+        zcu_owned_closure_matching_status_t,
+        zcu_moved_closure_matching_status_t
+    ),
     loaned(zcu_loaned_closure_matching_status_t)
 );
 

--- a/src/closures/query_channel.rs
+++ b/src/closures/query_channel.rs
@@ -24,9 +24,14 @@ use zenoh::{
 };
 
 pub use crate::opaque_types::z_loaned_fifo_handler_query_t;
+pub use crate::opaque_types::z_moved_fifo_handler_query_t;
 pub use crate::opaque_types::z_owned_fifo_handler_query_t;
 decl_c_type!(
-    owned(z_owned_fifo_handler_query_t, Option<flume::Receiver<Query>>),
+    owned(
+        z_owned_fifo_handler_query_t,
+        z_moved_fifo_handler_query_t,
+        Option<flume::Receiver<Query>>,
+    ),
     loaned(z_loaned_fifo_handler_query_t, flume::Receiver<Query>)
 );
 
@@ -138,9 +143,14 @@ pub extern "C" fn z_fifo_handler_query_try_recv(
 }
 
 pub use crate::opaque_types::z_loaned_ring_handler_query_t;
+pub use crate::opaque_types::z_moved_ring_handler_query_t;
 pub use crate::opaque_types::z_owned_ring_handler_query_t;
 decl_c_type!(
-    owned(z_owned_ring_handler_query_t, Option<RingChannelHandler<Query>>),
+    owned(
+        z_owned_ring_handler_query_t,
+        z_moved_ring_handler_query_t,
+        Option<RingChannelHandler<Query>>,
+    ),
     loaned(z_loaned_ring_handler_query_t, RingChannelHandler<Query>)
 );
 

--- a/src/closures/query_channel.rs
+++ b/src/closures/query_channel.rs
@@ -37,8 +37,8 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_fifo_handler_query_drop(this: &mut z_owned_fifo_handler_query_t) {
-    *this.as_rust_type_mut() = None;
+#[allow(unused_variables)]
+pub extern "C" fn z_fifo_handler_query_drop(this: z_moved_fifo_handler_query_t) {
 }
 
 /// Constructs a handler in gravestone state.
@@ -156,8 +156,8 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_ring_handler_query_drop(this: &mut z_owned_ring_handler_query_t) {
-    *this.as_rust_type_mut() = None;
+#[allow(unused_variables)]
+pub extern "C" fn z_ring_handler_query_drop(this: z_moved_ring_handler_query_t) {
 }
 
 /// Constructs a handler in gravestone state.

--- a/src/closures/query_closure.rs
+++ b/src/closures/query_closure.rs
@@ -42,8 +42,14 @@ pub struct z_loaned_closure_query_t {
     _0: [usize; 3],
 }
 
+/// Moved closure.
+#[repr(C)]
+pub struct z_moved_closure_query_t<'a> {
+    pub ptr: &'a z_owned_closure_query_t,
+}
+
 decl_c_type!(
-    owned(z_owned_closure_query_t),
+    owned(z_owned_closure_query_t, z_moved_closure_query_t),
     loaned(z_loaned_closure_query_t)
 );
 
@@ -145,8 +151,14 @@ pub struct z_loaned_closure_owned_query_t {
     _0: [usize; 3],
 }
 
+/// Moved closure.
+#[repr(C)]
+pub struct z_moved_closure_owned_query_t<'a> {
+    pub ptr: &'a z_owned_closure_owned_query_t,
+}
+
 decl_c_type!(
-    owned(z_owned_closure_owned_query_t),
+    owned(z_owned_closure_owned_query_t, z_moved_closure_owned_query_t),
     loaned(z_loaned_closure_owned_query_t)
 );
 

--- a/src/closures/reply_closure.rs
+++ b/src/closures/reply_closure.rs
@@ -44,8 +44,8 @@ pub struct z_loaned_closure_reply_t {
 
 /// Moved closure.
 #[repr(C)]
-pub struct z_moved_closure_reply_t<'a> {
-    pub ptr: &'a z_owned_closure_reply_t,
+pub struct z_moved_closure_reply_t {
+    pub ptr: &'static mut z_owned_closure_reply_t,
 }
 
 decl_c_type!(
@@ -53,15 +53,17 @@ decl_c_type!(
     loaned(z_loaned_closure_reply_t)
 );
 
-impl z_owned_closure_reply_t {
-    pub(crate) fn empty() -> Self {
+impl Default for z_owned_closure_reply_t {
+    fn default() -> Self {
         z_owned_closure_reply_t {
             context: std::ptr::null_mut(),
             call: None,
             drop: None,
         }
     }
+}
 
+impl z_owned_closure_reply_t {
     pub(crate) fn is_empty(&self) -> bool {
         self.call.is_none() && self.drop.is_none() && self.context.is_null()
     }
@@ -79,7 +81,7 @@ impl Drop for z_owned_closure_reply_t {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_closure_reply_null(this: *mut MaybeUninit<z_owned_closure_reply_t>) {
-    (*this).write(z_owned_closure_reply_t::empty());
+    (*this).write(z_owned_closure_reply_t::default());
 }
 
 /// Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
@@ -104,10 +106,9 @@ pub extern "C" fn z_closure_reply_call(
 }
 /// Drops the closure, resetting it to its gravestone state. Droping an uninitialized closure is a no-op.
 #[no_mangle]
-pub extern "C" fn z_closure_reply_drop(closure: &mut z_owned_closure_reply_t) {
-    let mut empty_closure = z_owned_closure_reply_t::empty();
-    std::mem::swap(&mut empty_closure, closure);
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_closure_reply_drop(closure: z_moved_closure_reply_t) {}
+
 impl<F: Fn(&z_loaned_reply_t)> From<F> for z_owned_closure_reply_t {
     fn from(f: F) -> Self {
         let this = Box::into_raw(Box::new(f)) as _;

--- a/src/closures/reply_closure.rs
+++ b/src/closures/reply_closure.rs
@@ -42,8 +42,14 @@ pub struct z_loaned_closure_reply_t {
     _0: [usize; 3],
 }
 
+/// Moved closure.
+#[repr(C)]
+pub struct z_moved_closure_reply_t<'a> {
+    pub ptr: &'a z_owned_closure_reply_t,
+}
+
 decl_c_type!(
-    owned(z_owned_closure_reply_t),
+    owned(z_owned_closure_reply_t, z_moved_closure_reply_t),
     loaned(z_loaned_closure_reply_t)
 );
 

--- a/src/closures/response_channel.rs
+++ b/src/closures/response_channel.rs
@@ -24,9 +24,14 @@ use zenoh::{
 };
 
 pub use crate::opaque_types::z_loaned_fifo_handler_reply_t;
+pub use crate::opaque_types::z_moved_fifo_handler_reply_t;
 pub use crate::opaque_types::z_owned_fifo_handler_reply_t;
 decl_c_type!(
-    owned(z_owned_fifo_handler_reply_t, Option<flume::Receiver<Reply>>),
+    owned(
+        z_owned_fifo_handler_reply_t,
+        z_moved_fifo_handler_reply_t,
+        Option<flume::Receiver<Reply>>,
+    ),
     loaned(z_loaned_fifo_handler_reply_t, flume::Receiver<Reply>)
 );
 
@@ -138,9 +143,14 @@ pub extern "C" fn z_fifo_handler_reply_try_recv(
 }
 
 pub use crate::opaque_types::z_loaned_ring_handler_reply_t;
+pub use crate::opaque_types::z_moved_ring_handler_reply_t;
 pub use crate::opaque_types::z_owned_ring_handler_reply_t;
 decl_c_type!(
-    owned(z_owned_ring_handler_reply_t, Option<RingChannelHandler<Reply>>),
+    owned(
+        z_owned_ring_handler_reply_t,
+        z_moved_ring_handler_reply_t,
+        Option<RingChannelHandler<Reply>>,
+    ),
     loaned(z_loaned_ring_handler_reply_t, RingChannelHandler<Reply>)
 );
 

--- a/src/closures/response_channel.rs
+++ b/src/closures/response_channel.rs
@@ -37,8 +37,8 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_fifo_handler_reply_drop(this: &mut z_owned_fifo_handler_reply_t) {
-    *this.as_rust_type_mut() = None;
+#[allow(unused_variables)]
+pub extern "C" fn z_fifo_handler_reply_drop(this: z_moved_fifo_handler_reply_t) {
 }
 
 /// Constructs a handler in gravestone state.
@@ -156,8 +156,8 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_ring_handler_reply_drop(this: &mut z_owned_ring_handler_reply_t) {
-    *this.as_rust_type_mut() = None;
+#[allow(unused_variables)]
+pub extern "C" fn z_ring_handler_reply_drop(this: z_moved_ring_handler_reply_t) {
 }
 
 /// Constructs a handler in gravestone state.

--- a/src/closures/sample_channel.rs
+++ b/src/closures/sample_channel.rs
@@ -24,9 +24,14 @@ use zenoh::{
 };
 
 pub use crate::opaque_types::z_loaned_fifo_handler_sample_t;
+pub use crate::opaque_types::z_moved_fifo_handler_sample_t;
 pub use crate::opaque_types::z_owned_fifo_handler_sample_t;
 decl_c_type!(
-    owned(z_owned_fifo_handler_sample_t, Option<flume::Receiver<Sample>>),
+    owned(
+        z_owned_fifo_handler_sample_t,
+        z_moved_fifo_handler_sample_t,
+        Option<flume::Receiver<Sample>>,
+    ),
     loaned(z_loaned_fifo_handler_sample_t, flume::Receiver<Sample>)
 );
 
@@ -140,9 +145,14 @@ pub extern "C" fn z_fifo_handler_sample_try_recv(
 }
 
 pub use crate::opaque_types::z_loaned_ring_handler_sample_t;
+pub use crate::opaque_types::z_moved_ring_handler_sample_t;
 pub use crate::opaque_types::z_owned_ring_handler_sample_t;
 decl_c_type!(
-    owned(z_owned_ring_handler_sample_t, Option<RingChannelHandler<Sample>>),
+    owned(
+        z_owned_ring_handler_sample_t,
+        z_moved_ring_handler_sample_t,
+        Option<RingChannelHandler<Sample>>,
+    ),
     loaned(z_loaned_ring_handler_sample_t, RingChannelHandler<Sample>)
 );
 

--- a/src/closures/sample_channel.rs
+++ b/src/closures/sample_channel.rs
@@ -37,8 +37,8 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_fifo_handler_sample_drop(this: &mut z_owned_fifo_handler_sample_t) {
-    *this.as_rust_type_mut() = None;
+#[allow(unused_variables)]
+pub extern "C" fn z_fifo_handler_sample_drop(this: z_moved_fifo_handler_sample_t) {
 }
 
 /// Constructs a handler in gravestone state.
@@ -158,8 +158,8 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_ring_handler_sample_drop(this: &mut z_owned_ring_handler_sample_t) {
-    *this.as_rust_type_mut() = None;
+#[allow(unused_variables)]
+pub extern "C" fn z_ring_handler_sample_drop(this: z_moved_ring_handler_sample_t) {
 }
 
 /// Constructs a handler in gravestone state.

--- a/src/closures/sample_closure.rs
+++ b/src/closures/sample_closure.rs
@@ -42,8 +42,14 @@ pub struct z_loaned_closure_sample_t {
     _0: [usize; 3],
 }
 
+/// Moved closure.
+#[repr(C)]
+pub struct z_moved_closure_sample_t<'a> {
+    pub ptr: &'a z_owned_closure_sample_t,
+}
+
 decl_c_type!(
-    owned(z_owned_closure_sample_t),
+    owned(z_owned_closure_sample_t, z_moved_closure_sample_t),
     loaned(z_loaned_closure_sample_t)
 );
 

--- a/src/closures/zenohid_closure.rs
+++ b/src/closures/zenohid_closure.rs
@@ -44,8 +44,8 @@ pub struct z_loaned_closure_zid_t {
 
 /// Moved closure.
 #[repr(C)]
-pub struct z_moved_closure_zid_t<'a> {
-    pub ptr: &'a z_owned_closure_zid_t,
+pub struct z_moved_closure_zid_t {
+    pub ptr: &'static mut z_owned_closure_zid_t,
 }
 
 decl_c_type!(
@@ -53,15 +53,17 @@ decl_c_type!(
     loaned(z_loaned_closure_zid_t)
 );
 
-impl z_owned_closure_zid_t {
-    pub fn empty() -> Self {
+impl Default for z_owned_closure_zid_t {
+    fn default() -> Self {
         z_owned_closure_zid_t {
             context: std::ptr::null_mut(),
             call: None,
             drop: None,
         }
     }
+}
 
+impl z_owned_closure_zid_t {
     pub fn is_empty(&self) -> bool {
         self.call.is_none() && self.drop.is_none() && self.context.is_null()
     }
@@ -87,7 +89,7 @@ pub unsafe extern "C" fn z_closure_zid_check(this: &z_owned_closure_zid_t) -> bo
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_closure_zid_null(this: &mut MaybeUninit<z_owned_closure_zid_t>) {
-    this.write(z_owned_closure_zid_t::empty());
+    this.write(z_owned_closure_zid_t::default());
 }
 /// Calls the closure. Calling an uninitialized closure is a no-op.
 #[no_mangle]
@@ -102,10 +104,9 @@ pub extern "C" fn z_closure_zid_call(closure: &z_loaned_closure_zid_t, z_id: &z_
 }
 /// Drops the closure, resetting it to its gravestone state. Droping an uninitialized (null) closure is a no-op.
 #[no_mangle]
-pub extern "C" fn z_closure_zid_drop(closure: &mut z_owned_closure_zid_t) {
-    let mut empty_closure = z_owned_closure_zid_t::empty();
-    std::mem::swap(&mut empty_closure, closure);
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_closure_zid_drop(closure: z_moved_closure_zid_t) {}
+
 impl<F: Fn(&z_id_t)> From<F> for z_owned_closure_zid_t {
     fn from(f: F) -> Self {
         let this = Box::into_raw(Box::new(f)) as _;

--- a/src/closures/zenohid_closure.rs
+++ b/src/closures/zenohid_closure.rs
@@ -42,7 +42,16 @@ pub struct z_loaned_closure_zid_t {
     _0: [usize; 3],
 }
 
-decl_c_type!(owned(z_owned_closure_zid_t), loaned(z_loaned_closure_zid_t));
+/// Moved closure.
+#[repr(C)]
+pub struct z_moved_closure_zid_t<'a> {
+    pub ptr: &'a z_owned_closure_zid_t,
+}
+
+decl_c_type!(
+    owned(z_owned_closure_zid_t, z_moved_closure_zid_t),
+    loaned(z_loaned_closure_zid_t)
+);
 
 impl z_owned_closure_zid_t {
     pub fn empty() -> Self {

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -201,11 +201,12 @@ impl From<Vec<u8>> for CSlice {
 impl std::cmp::Eq for CSlice {}
 
 pub use crate::opaque_types::z_loaned_slice_t;
+pub use crate::opaque_types::z_moved_slice_t;
 pub use crate::opaque_types::z_owned_slice_t;
 pub use crate::opaque_types::z_view_slice_t;
 
 decl_c_type!(
-    owned(z_owned_slice_t, CSliceOwned),
+    owned(z_owned_slice_t, z_moved_slice_t, CSliceOwned),
     view(z_view_slice_t, CSliceView),
     loaned(z_loaned_slice_t, CSlice),
 );
@@ -373,6 +374,7 @@ pub extern "C" fn z_slice_is_empty(this: &z_loaned_slice_t) -> bool {
 }
 
 pub use crate::opaque_types::z_loaned_string_t;
+pub use crate::opaque_types::z_moved_string_t;
 pub use crate::opaque_types::z_owned_string_t;
 pub use crate::opaque_types::z_view_string_t;
 
@@ -453,7 +455,7 @@ impl From<String> for CStringOwned {
 }
 
 decl_c_type!(
-    owned(z_owned_string_t, CStringOwned),
+    owned(z_owned_string_t, z_moved_string_t, CStringOwned),
     view(z_view_string_t, CStringView),
     loaned(z_loaned_string_t, CString),
 );
@@ -633,10 +635,11 @@ pub extern "C" fn z_string_is_empty(this: &z_loaned_string_t) -> bool {
 }
 
 pub use crate::opaque_types::z_loaned_slice_map_t;
+pub use crate::opaque_types::z_moved_slice_map_t;
 pub use crate::opaque_types::z_owned_slice_map_t;
 pub type ZHashMap = HashMap<CSlice, CSlice>;
 decl_c_type!(
-    owned(z_owned_slice_map_t, Option<ZHashMap>),
+    owned(z_owned_slice_map_t, z_moved_slice_map_t, Option<ZHashMap>),
     loaned(z_loaned_slice_map_t, ZHashMap),
 );
 
@@ -775,10 +778,11 @@ pub extern "C" fn z_slice_map_insert_by_alias(
 }
 
 pub use crate::opaque_types::z_loaned_string_array_t;
+pub use crate::opaque_types::z_moved_string_array_t;
 pub use crate::opaque_types::z_owned_string_array_t;
 pub type ZVector = Vec<CString>;
 decl_c_type!(
-    owned(z_owned_string_array_t, Option<ZVector>),
+    owned(z_owned_string_array_t, z_moved_string_array_t, Option<ZVector>),
     loaned(z_loaned_string_array_t, ZVector),
 );
 

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -332,9 +332,8 @@ pub unsafe extern "C" fn z_slice_wrap(
 /// Frees the memory and invalidates the slice.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_slice_drop(this: &mut z_owned_slice_t) {
-    *this.as_rust_type_mut() = CSliceOwned::default();
-}
+#[allow(unused_variables)]
+pub unsafe extern "C" fn z_slice_drop(this: z_moved_slice_t) {}
 
 /// Borrows slice.
 #[no_mangle]
@@ -463,9 +462,8 @@ decl_c_type!(
 /// Frees memory and invalidates `z_owned_string_t`, putting it in gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_string_drop(this: &mut z_owned_string_t) {
-    *this.as_rust_type_mut() = CStringOwned::default();
-}
+#[allow(unused_variables)]
+pub unsafe extern "C" fn z_string_drop(this: z_moved_string_t) {}
 
 /// @return ``true`` if `this_` is a valid string, ``false`` if it is in gravestone state.
 #[no_mangle]
@@ -663,9 +661,8 @@ pub extern "C" fn z_slice_map_check(map: &z_owned_slice_map_t) -> bool {
 
 /// Destroys the map, resetting it to its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_slice_map_drop(this: &mut z_owned_slice_map_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_slice_map_drop(this: z_moved_slice_map_t) {}
 
 /// Borrows slice map.
 #[no_mangle]
@@ -806,9 +803,8 @@ pub extern "C" fn z_string_array_check(this: &z_owned_string_array_t) -> bool {
 
 /// Destroys the string array, resetting it to its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_string_array_drop(this: &mut z_owned_string_array_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_string_array_drop(this: z_moved_string_array_t) {}
 
 /// Borrows string array.
 #[no_mangle]

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -213,8 +213,8 @@ pub unsafe extern "C" fn z_sample_loan(this: &z_owned_sample_t) -> &z_loaned_sam
 
 /// Frees the memory and invalidates the sample, resetting it to a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_sample_drop(this: &mut z_owned_sample_t) {
-    *this.as_rust_type_mut() = None;
+#[allow(unused_variables)]
+pub extern "C" fn z_sample_drop(this: z_moved_sample_t) {
 }
 
 /// Constructs sample in its gravestone state.
@@ -299,8 +299,8 @@ pub extern "C" fn z_encoding_null(this: &mut MaybeUninit<z_owned_encoding_t>) {
 
 /// Frees the memory and resets the encoding it to its default value.
 #[no_mangle]
-pub extern "C" fn z_encoding_drop(this: &mut z_owned_encoding_t) {
-    *this.as_rust_type_mut() = Encoding::default();
+#[allow(unused_variables)]
+pub extern "C" fn z_encoding_drop(this: z_moved_encoding_t) {
 }
 
 /// Returns ``true`` if encoding is in non-default state, ``false`` otherwise.
@@ -639,8 +639,8 @@ pub extern "C" fn z_source_info_loan(this: &z_owned_source_info_t) -> &z_loaned_
 
 /// Frees the memory and invalidates the source info, resetting it to a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_source_info_drop(this: &mut z_owned_source_info_t) {
-    *this.as_rust_type_mut() = SourceInfo::default();
+#[allow(unused_variables)]
+pub extern "C" fn z_source_info_drop(this: z_moved_source_info_t) {
 }
 
 /// Constructs source info in its gravestone state.

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -110,9 +110,10 @@ pub extern "C" fn z_timestamp_id(this: &z_timestamp_t) -> z_id_t {
 }
 
 use crate::opaque_types::z_loaned_sample_t;
+pub use crate::opaque_types::z_moved_sample_t;
 pub use crate::opaque_types::z_owned_sample_t;
 decl_c_type!(
-    owned(z_owned_sample_t, Option<Sample>),
+    owned(z_owned_sample_t, z_moved_sample_t, Option<Sample>),
     loaned(z_loaned_sample_t, Sample),
 );
 
@@ -223,10 +224,11 @@ pub extern "C" fn z_sample_null(this: &mut MaybeUninit<z_owned_sample_t>) {
 }
 
 pub use crate::opaque_types::z_loaned_encoding_t;
+pub use crate::opaque_types::z_moved_encoding_t;
 pub use crate::opaque_types::z_owned_encoding_t;
 
 decl_c_type!(
-    owned(z_owned_encoding_t, Encoding),
+    owned(z_owned_encoding_t, z_moved_encoding_t, Encoding),
     loaned(z_loaned_encoding_t, Encoding),
 );
 
@@ -584,9 +586,10 @@ pub extern "C" fn z_entity_global_id_eid(this: &z_entity_global_id_t) -> u32 {
     this.as_rust_type_ref().eid()
 }
 pub use crate::opaque_types::z_loaned_source_info_t;
+pub use crate::opaque_types::z_moved_source_info_t;
 pub use crate::opaque_types::z_owned_source_info_t;
 decl_c_type!(
-    owned(z_owned_source_info_t, SourceInfo),
+    owned(z_owned_source_info_t, z_moved_source_info_t, SourceInfo),
     loaned(z_loaned_source_info_t, SourceInfo)
 );
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,9 +63,10 @@ pub static Z_CONFIG_ADD_TIMESTAMP_KEY: &c_char =
     unsafe { &*(b"timestamping/enabled\0".as_ptr() as *const c_char) };
 
 pub use crate::opaque_types::z_loaned_config_t;
+pub use crate::opaque_types::z_moved_config_t;
 pub use crate::opaque_types::z_owned_config_t;
 decl_c_type!(
-    owned(z_owned_config_t, Option<Config>),
+    owned(z_owned_config_t, z_moved_config_t, Option<Config>),
     loaned(z_loaned_config_t, Config)
 );
 
@@ -202,8 +203,8 @@ pub unsafe extern "C" fn zc_config_insert_json_from_substring(
 /// Frees `config`, and resets it to its gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_config_drop(this: &mut z_owned_config_t) {
-    *this.as_rust_type_mut() = None;
+pub extern "C" fn z_config_drop(this: z_moved_config_t) {
+    *this.ptr.as_rust_type_mut() = None;
 }
 /// Returns ``true`` if config is valid, ``false`` if it is in a gravestone state.
 #[no_mangle]

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,10 +202,8 @@ pub unsafe extern "C" fn zc_config_insert_json_from_substring(
 
 /// Frees `config`, and resets it to its gravestone state.
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_config_drop(this: z_moved_config_t) {
-    *this.ptr.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_config_drop(this: z_moved_config_t) {}
 /// Returns ``true`` if config is valid, ``false`` if it is in a gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]

--- a/src/get.rs
+++ b/src/get.rs
@@ -73,9 +73,10 @@ impl From<&ReplyError> for &ReplyErrorNewtype {
 }
 
 pub use crate::opaque_types::z_loaned_reply_err_t;
+pub use crate::opaque_types::z_moved_reply_err_t;
 pub use crate::opaque_types::z_owned_reply_err_t;
 decl_c_type!(
-    owned(z_owned_reply_err_t, ReplyErrorNewtype),
+    owned(z_owned_reply_err_t, z_moved_reply_err_t, ReplyErrorNewtype),
     loaned(z_loaned_reply_err_t, ReplyErrorNewtype)
 );
 
@@ -118,9 +119,10 @@ pub extern "C" fn z_reply_err_drop(this: &mut z_owned_reply_err_t) {
 }
 
 pub use crate::opaque_types::z_loaned_reply_t;
+pub use crate::opaque_types::z_moved_reply_t;
 pub use crate::opaque_types::z_owned_reply_t;
 decl_c_type!(
-    owned(z_owned_reply_t, Option<Reply>),
+    owned(z_owned_reply_t, z_owned_reply_t, Option<Reply>),
     loaned(z_loaned_reply_t, Reply)
 );
 

--- a/src/get.rs
+++ b/src/get.rs
@@ -122,7 +122,7 @@ pub use crate::opaque_types::z_loaned_reply_t;
 pub use crate::opaque_types::z_moved_reply_t;
 pub use crate::opaque_types::z_owned_reply_t;
 decl_c_type!(
-    owned(z_owned_reply_t, z_owned_reply_t, Option<Reply>),
+    owned(z_owned_reply_t, z_moved_reply_t, Option<Reply>),
     loaned(z_loaned_reply_t, Reply)
 );
 

--- a/src/get.rs
+++ b/src/get.rs
@@ -114,8 +114,8 @@ pub extern "C" fn z_reply_err_loan(this: &z_owned_reply_err_t) -> &z_loaned_repl
 
 /// Frees the memory and resets the reply error it to its default value.
 #[no_mangle]
-pub extern "C" fn z_reply_err_drop(this: &mut z_owned_reply_err_t) {
-    std::mem::take(this.as_rust_type_mut());
+#[allow(unused_variables)]
+pub extern "C" fn z_reply_err_drop(this: z_moved_reply_err_t) {
 }
 
 pub use crate::opaque_types::z_loaned_reply_t;
@@ -313,8 +313,8 @@ pub unsafe extern "C" fn z_get(
 
 /// Frees reply, resetting it to its gravestone state.
 #[no_mangle]
-pub extern "C" fn z_reply_drop(this: &mut z_owned_reply_t) {
-    *this.as_rust_type_mut() = None;
+#[allow(unused_variables)]
+pub extern "C" fn z_reply_drop(this: z_moved_reply_t) {
 }
 
 /// Returns ``true`` if `reply` is valid, ``false`` otherwise.

--- a/src/info.rs
+++ b/src/info.rs
@@ -14,7 +14,6 @@
 use crate::transmute::{CTypeRef, IntoCType, OwnedCTypeRef, RustTypeRef};
 use crate::{
     errors, z_closure_zid_call, z_closure_zid_loan, z_loaned_session_t, z_moved_closure_zid_t,
-    z_owned_closure_zid_t,
 };
 use zenoh::core::Wait;
 use zenoh::info::ZenohId;
@@ -73,13 +72,14 @@ pub unsafe extern "C" fn z_info_peers_zid(
 #[no_mangle]
 pub unsafe extern "C" fn z_info_routers_zid(
     session: &z_loaned_session_t,
-    callback: &mut z_owned_closure_zid_t,
+    callback: z_moved_closure_zid_t,
 ) -> errors::z_error_t {
-    let mut closure = z_owned_closure_zid_t::default();
-    std::mem::swap(&mut closure, callback);
     let session = session.as_rust_type_ref();
     for id in session.info().routers_zid().wait() {
-        z_closure_zid_call(z_closure_zid_loan(&closure), id.as_ctype_ref());
+        z_closure_zid_call(
+            z_closure_zid_loan(callback.as_owned_c_type_ref()),
+            id.as_ctype_ref(),
+        );
     }
     errors::Z_OK
 }

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -30,10 +30,11 @@ use zenoh::key_expr::SetIntersectionLevel;
 use zenoh_protocol::core::key_expr::canon::Canonizable;
 
 pub use crate::opaque_types::z_loaned_keyexpr_t;
+pub use crate::opaque_types::z_moved_keyexpr_t;
 pub use crate::opaque_types::z_owned_keyexpr_t;
 pub use crate::opaque_types::z_view_keyexpr_t;
 decl_c_type! {
-    owned(z_owned_keyexpr_t, Option<KeyExpr<'static>>),
+    owned(z_owned_keyexpr_t, z_moved_keyexpr_t, Option<KeyExpr<'static>>),
     view(z_view_keyexpr_t, Option<KeyExpr<'static>>),
     loaned(z_loaned_keyexpr_t, KeyExpr<'static>),
 }

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -14,6 +14,7 @@
 use crate::errors;
 use crate::errors::z_error_t;
 use crate::errors::Z_OK;
+use crate::transmute::IntoRustType;
 use crate::transmute::LoanedCTypeRef;
 use crate::transmute::RustTypeRef;
 use crate::transmute::RustTypeRefUninit;
@@ -149,8 +150,7 @@ pub unsafe extern "C" fn z_view_keyexpr_loan(this: &z_view_keyexpr_t) -> &z_loan
 /// Frees key expression and resets it to its gravestone state.
 #[no_mangle]
 #[allow(unused_variables)]
-pub extern "C" fn z_keyexpr_drop(this: z_moved_keyexpr_t) {
-}
+pub extern "C" fn z_keyexpr_drop(this: z_moved_keyexpr_t) {}
 
 /// Returns ``true`` if `keyexpr` is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
@@ -492,10 +492,10 @@ pub extern "C" fn z_declare_keyexpr(
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
 pub extern "C" fn z_undeclare_keyexpr(
-    this: &mut z_owned_keyexpr_t,
+    this: z_moved_keyexpr_t,
     session: &z_loaned_session_t,
 ) -> errors::z_error_t {
-    let Some(kexpr) = this.as_rust_type_mut().take() else {
+    let Some(kexpr) = this.into_rust_type().take() else {
         log::debug!("Attempted to undeclare dropped keyexpr");
         return errors::Z_EINVAL;
     };

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -148,8 +148,8 @@ pub unsafe extern "C" fn z_view_keyexpr_loan(this: &z_view_keyexpr_t) -> &z_loan
 
 /// Frees key expression and resets it to its gravestone state.
 #[no_mangle]
-pub extern "C" fn z_keyexpr_drop(this: &mut z_owned_keyexpr_t) {
-    *this.as_rust_type_mut() = None;
+#[allow(unused_variables)]
+pub extern "C" fn z_keyexpr_drop(this: z_moved_keyexpr_t) {
 }
 
 /// Returns ``true`` if `keyexpr` is valid, ``false`` if it is in gravestone state.

--- a/src/liveliness.rs
+++ b/src/liveliness.rs
@@ -29,9 +29,14 @@ use crate::{z_closure_reply_loan, z_closure_sample_loan};
 use zenoh::core::Wait;
 
 use crate::opaque_types::zc_loaned_liveliness_token_t;
+use crate::opaque_types::zc_moved_liveliness_token_t;
 use crate::opaque_types::zc_owned_liveliness_token_t;
 decl_c_type!(
-    owned(zc_owned_liveliness_token_t, Option<LivelinessToken<'static>>),
+    owned(
+        zc_owned_liveliness_token_t,
+        zc_moved_liveliness_token_t,
+        Option<LivelinessToken<'static>>,
+    ),
     loaned(zc_loaned_liveliness_token_t, LivelinessToken<'static>)
 );
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -36,9 +36,10 @@ use crate::errors::Z_ENULL;
 use crate::{z_loaned_shm_t, z_owned_shm_mut_t, z_owned_shm_t};
 
 pub use crate::opaque_types::z_loaned_bytes_t;
+pub use crate::opaque_types::z_moved_bytes_t;
 pub use crate::opaque_types::z_owned_bytes_t;
 decl_c_type! {
-    owned(z_owned_bytes_t, ZBytes),
+    owned(z_owned_bytes_t, z_moved_bytes_t, ZBytes),
     loaned(z_loaned_bytes_t, ZBytes),
 }
 
@@ -798,10 +799,12 @@ pub unsafe extern "C" fn z_bytes_reader_tell(this: &mut z_bytes_reader_t) -> i64
 }
 
 pub use crate::opaque_types::z_loaned_bytes_writer_t;
+pub use crate::opaque_types::z_moved_bytes_writer_t;
 pub use crate::opaque_types::z_owned_bytes_writer_t;
 
 decl_c_type! {
-    owned(z_owned_bytes_writer_t, Option<ZBytesWriter<'static>>),
+    owned(z_owned_bytes_writer_t, z_moved_bytes_writer_t,
+        Option<ZBytesWriter<'static>>),
     loaned(z_loaned_bytes_writer_t, ZBytesWriter<'static>),
 }
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -59,8 +59,7 @@ extern "C" fn z_bytes_empty(this: &mut MaybeUninit<z_owned_bytes_t>) {
 /// created by `z_bytes_clone()`, they would still stay valid.
 #[no_mangle]
 #[allow(unused_variables)]
-extern "C" fn z_bytes_drop(this: z_moved_bytes_t) {
-}
+extern "C" fn z_bytes_drop(this: z_moved_bytes_t) {}
 
 /// Returns ``true`` if `this_` is in a valid state, ``false`` if it is in a gravestone state.
 #[no_mangle]
@@ -548,11 +547,11 @@ pub unsafe extern "C" fn z_bytes_serialize_from_string_copy(
 #[no_mangle]
 pub extern "C" fn z_bytes_serialize_from_pair(
     this: &mut MaybeUninit<z_owned_bytes_t>,
-    first: &mut z_owned_bytes_t,
-    second: &mut z_owned_bytes_t,
+    first: z_moved_bytes_t,
+    second: z_moved_bytes_t,
 ) -> z_error_t {
-    let first = std::mem::take(first.as_rust_type_mut());
-    let second = std::mem::take(second.as_rust_type_mut());
+    let first = first.as_rust_type_ref();
+    let second = second.as_rust_type_ref();
     let b = ZBytes::serialize((first, second));
     this.as_rust_type_mut_uninit().write(b);
     Z_OK
@@ -817,8 +816,7 @@ extern "C" fn z_bytes_writer_null(this: &mut MaybeUninit<z_owned_bytes_writer_t>
 /// Drops `this_`, resetting it to gravestone value.
 #[no_mangle]
 #[allow(unused_variables)]
-extern "C" fn z_bytes_writer_drop(this: z_moved_bytes_writer_t) {
-}
+extern "C" fn z_bytes_writer_drop(this: z_moved_bytes_writer_t) {}
 
 /// Returns ``true`` if `this_` is in a valid state, ``false`` if it is in a gravestone state.
 #[no_mangle]

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -58,8 +58,8 @@ extern "C" fn z_bytes_empty(this: &mut MaybeUninit<z_owned_bytes_t>) {
 /// Drops `this_`, resetting it to gravestone value. If there are any shallow copies
 /// created by `z_bytes_clone()`, they would still stay valid.
 #[no_mangle]
-extern "C" fn z_bytes_drop(this: &mut z_owned_bytes_t) {
-    *this.as_rust_type_mut() = ZBytes::default();
+#[allow(unused_variables)]
+extern "C" fn z_bytes_drop(this: z_moved_bytes_t) {
 }
 
 /// Returns ``true`` if `this_` is in a valid state, ``false`` if it is in a gravestone state.
@@ -816,8 +816,8 @@ extern "C" fn z_bytes_writer_null(this: &mut MaybeUninit<z_owned_bytes_writer_t>
 
 /// Drops `this_`, resetting it to gravestone value.
 #[no_mangle]
-extern "C" fn z_bytes_writer_drop(this: &mut z_owned_bytes_writer_t) {
-    *this.as_rust_type_mut() = None;
+#[allow(unused_variables)]
+extern "C" fn z_bytes_writer_drop(this: z_moved_bytes_writer_t) {
 }
 
 /// Returns ``true`` if `this_` is in a valid state, ``false`` if it is in a gravestone state.

--- a/src/platform/synchronization.rs
+++ b/src/platform/synchronization.rs
@@ -6,15 +6,17 @@ use std::{
 
 use libc::c_void;
 
-pub use crate::opaque_types::z_loaned_mutex_t;
-pub use crate::opaque_types::z_owned_mutex_t;
 use crate::{
     errors,
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
 };
 
+pub use crate::opaque_types::z_loaned_mutex_t;
+pub use crate::opaque_types::z_moved_mutex_t;
+pub use crate::opaque_types::z_owned_mutex_t;
+
 decl_c_type!(
-    owned(z_owned_mutex_t, Option<(Mutex<()>, Option<MutexGuard<'static, ()>>)>),
+    owned(z_owned_mutex_t, z_moved_mutex_t, Option<(Mutex<()>, Option<MutexGuard<'static, ()>>)>),
     loaned(z_loaned_mutex_t, (Mutex<()>, Option<MutexGuard<'static, ()>>))
 );
 
@@ -109,10 +111,12 @@ pub unsafe extern "C" fn z_mutex_try_lock(
 }
 
 pub use crate::opaque_types::z_loaned_condvar_t;
+pub use crate::opaque_types::z_moved_condvar_t;
 pub use crate::opaque_types::z_owned_condvar_t;
 decl_c_type!(
     inequal
-    owned(z_owned_condvar_t, Option<Condvar>),
+    owned(z_owned_condvar_t, z_moved_condvar_t,
+         Option<Condvar>),
     loaned(z_loaned_condvar_t, Condvar)
 );
 
@@ -197,8 +201,9 @@ pub unsafe extern "C" fn z_condvar_wait(
     errors::Z_OK
 }
 
+pub use crate::opaque_types::z_moved_task_t;
 pub use crate::opaque_types::z_owned_task_t;
-decl_c_type!(owned(z_owned_task_t, Option<JoinHandle<()>>));
+decl_c_type!(owned(z_owned_task_t, z_moved_task_t, Option<JoinHandle<()>>));
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/src/platform/synchronization.rs
+++ b/src/platform/synchronization.rs
@@ -33,9 +33,8 @@ pub extern "C" fn z_mutex_init(this: &mut MaybeUninit<z_owned_mutex_t>) -> error
 
 /// Drops mutex and resets it to its gravestone state.
 #[no_mangle]
-pub extern "C" fn z_mutex_drop(this: &mut z_owned_mutex_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_mutex_drop(this: z_moved_mutex_t) {}
 
 /// Returns ``true`` if mutex is valid, ``false`` otherwise.
 #[no_mangle]
@@ -134,9 +133,8 @@ pub extern "C" fn z_condvar_null(this: &mut MaybeUninit<z_owned_condvar_t>) {
 
 /// Drops conditional variable.
 #[no_mangle]
-pub extern "C" fn z_condvar_drop(this: &mut z_owned_condvar_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_condvar_drop(this: z_moved_condvar_t) {}
 
 /// Returns ``true`` if conditional variable is valid, ``false`` otherwise.
 #[no_mangle]

--- a/src/publication_cache.rs
+++ b/src/publication_cache.rs
@@ -53,9 +53,14 @@ pub extern "C" fn ze_publication_cache_options_default(this: &mut ze_publication
 }
 
 pub use crate::opaque_types::ze_loaned_publication_cache_t;
+pub use crate::opaque_types::ze_moved_publication_cache_t;
 pub use crate::opaque_types::ze_owned_publication_cache_t;
 decl_c_type!(
-    owned(ze_owned_publication_cache_t, Option<zenoh_ext::PublicationCache<'static>>),
+    owned(
+        ze_owned_publication_cache_t,
+        ze_moved_publication_cache_t,
+        Option<zenoh_ext::PublicationCache<'static>>,
+    ),
     loaned(ze_loaned_publication_cache_t, zenoh_ext::PublicationCache<'static>)
 );
 

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -14,11 +14,13 @@
 
 use crate::errors;
 use crate::transmute::IntoCType;
+use crate::transmute::IntoRustType;
 use crate::transmute::LoanedCTypeRef;
 use crate::transmute::OwnedCTypeRef;
 use crate::transmute::RustTypeRef;
 use crate::transmute::RustTypeRefUninit;
 use crate::z_entity_global_id_t;
+use crate::z_moved_bytes_t;
 use crate::z_owned_encoding_t;
 use crate::z_owned_source_info_t;
 use crate::z_timestamp_t;
@@ -194,11 +196,11 @@ pub extern "C" fn z_publisher_put_options_default(this: &mut z_publisher_put_opt
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_publisher_put(
     this: &z_loaned_publisher_t,
-    payload: &mut z_owned_bytes_t,
+    payload: z_moved_bytes_t,
     options: Option<&mut z_publisher_put_options_t>,
 ) -> errors::z_error_t {
     let publisher = this.as_rust_type_ref();
-    let payload = std::mem::take(payload.as_rust_type_mut());
+    let payload = payload.into_rust_type();
 
     let mut put = publisher.put(payload);
     if let Some(options) = options {

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -370,8 +370,8 @@ pub extern "C" fn zcu_publisher_matching_listener_undeclare(
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_undeclare_publisher(mut this: z_moved_publisher_t) -> errors::z_error_t {
-    if let Some(p) = this.as_rust_type_mut().take() {
+pub extern "C" fn z_undeclare_publisher(this: z_moved_publisher_t) -> errors::z_error_t {
+    if let Some(p) = this.into_rust_type().take() {
         if let Err(e) = p.undeclare().wait() {
             log::error!("{}", e);
             return errors::Z_EGENERIC;

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -366,7 +366,7 @@ pub extern "C" fn zcu_publisher_matching_listener_undeclare(
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_undeclare_publisher(this: &mut z_owned_publisher_t) -> errors::z_error_t {
+pub extern "C" fn z_undeclare_publisher(mut this: z_moved_publisher_t) -> errors::z_error_t {
     if let Some(p) = this.as_rust_type_mut().take() {
         if let Err(e) = p.undeclare().wait() {
             log::error!("{}", e);
@@ -379,6 +379,6 @@ pub extern "C" fn z_undeclare_publisher(this: &mut z_owned_publisher_t) -> error
 /// Frees memory and resets publisher to its gravestone state. Also attempts undeclare publisher.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_publisher_drop(this: &mut z_owned_publisher_t) {
+pub extern "C" fn z_publisher_drop(this: z_moved_publisher_t) {
     z_undeclare_publisher(this);
 }

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -66,10 +66,11 @@ pub extern "C" fn z_publisher_options_default(this: &mut z_publisher_options_t) 
 }
 
 pub use crate::opaque_types::z_loaned_publisher_t;
+pub use crate::opaque_types::z_moved_publisher_t;
 pub use crate::opaque_types::z_owned_publisher_t;
 
 decl_c_type!(
-    owned(z_owned_publisher_t, Option<Publisher<'static>>),
+    owned(z_owned_publisher_t, z_moved_publisher_t, Option<Publisher<'static>>),
     loaned(z_loaned_publisher_t, Publisher<'static>)
 );
 
@@ -286,8 +287,15 @@ pub extern "C" fn z_publisher_keyexpr(publisher: &z_loaned_publisher_t) -> &z_lo
         .as_loaned_c_type_ref()
 }
 
+pub use crate::opaque_types::zcu_moved_matching_listener_t;
 pub use crate::opaque_types::zcu_owned_matching_listener_t;
-decl_c_type!(owned(zcu_owned_matching_listener_t, Option<MatchingListener<'static, ()>>));
+decl_c_type!(
+    owned(
+        zcu_owned_matching_listener_t,
+        zcu_moved_matching_listener_t,
+        Option<MatchingListener<'static, ()>>,
+    )
+);
 
 /// A struct that indicates if there exist Subscribers matching the Publisher's key expression.
 #[repr(C)]

--- a/src/put.rs
+++ b/src/put.rs
@@ -14,8 +14,10 @@
 use crate::commons::*;
 use crate::errors;
 use crate::keyexpr::*;
+use crate::transmute::IntoRustType;
 use crate::transmute::RustTypeRef;
 use crate::z_loaned_session_t;
+use crate::z_moved_bytes_t;
 use crate::z_owned_bytes_t;
 use crate::z_timestamp_t;
 use std::ptr::null_mut;
@@ -78,12 +80,12 @@ pub extern "C" fn z_put_options_default(this: &mut z_put_options_t) {
 pub extern "C" fn z_put(
     session: &z_loaned_session_t,
     key_expr: &z_loaned_keyexpr_t,
-    payload: &mut z_owned_bytes_t,
+    payload: z_moved_bytes_t,
     options: Option<&mut z_put_options_t>,
 ) -> errors::z_error_t {
     let session = session.as_rust_type_ref();
     let key_expr = key_expr.as_rust_type_ref();
-    let payload = std::mem::take(payload.as_rust_type_mut());
+    let payload = payload.into_rust_type();
 
     let mut put = session.put(key_expr, payload);
     if let Some(options) = options {

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -32,9 +32,10 @@ use zenoh::sample::{
 };
 
 pub use crate::opaque_types::z_loaned_queryable_t;
+pub use crate::opaque_types::z_moved_queryable_t;
 pub use crate::opaque_types::z_owned_queryable_t;
 decl_c_type!(
-    owned(z_owned_queryable_t, Option<Queryable<'static, ()>>),
+    owned(z_owned_queryable_t, z_moved_queryable_t, Option<Queryable<'static, ()>>),
     loaned(z_loaned_queryable_t, Queryable<'static, ()>)
 );
 
@@ -55,9 +56,10 @@ pub unsafe extern "C" fn z_queryable_loan(this: &z_owned_queryable_t) -> &z_loan
 }
 
 pub use crate::opaque_types::z_loaned_query_t;
+pub use crate::opaque_types::z_moved_query_t;
 pub use crate::opaque_types::z_owned_query_t;
 decl_c_type!(
-    owned(z_owned_query_t, Option<Query>),
+    owned(z_owned_query_t, z_moved_query_t, Option<Query>),
     loaned(z_loaned_query_t, Query)
 );
 

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -84,9 +84,8 @@ pub unsafe extern "C" fn z_query_loan(this: &'static z_owned_query_t) -> &z_loan
 }
 /// Destroys the query resetting it to its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_query_drop(this: &mut z_owned_query_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_query_drop(this: z_moved_query_t) {}
 /// Constructs a shallow copy of the query, allowing to keep it in an "open" state past the callback's return.
 ///
 /// This operation is infallible, but may return a gravestone value if `query` itself was a gravestone value (which cannot be the case in a callback).
@@ -247,7 +246,7 @@ pub extern "C" fn z_declare_queryable(
 /// Returns 0 in case of success, negative error code otherwise.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_undeclare_queryable(this: &mut z_owned_queryable_t) -> errors::z_error_t {
+pub extern "C" fn z_undeclare_queryable(mut this: z_moved_queryable_t) -> errors::z_error_t {
     if let Some(qable) = this.as_rust_type_mut().take() {
         if let Err(e) = qable.undeclare().wait() {
             log::error!("{}", e);
@@ -260,7 +259,7 @@ pub extern "C" fn z_undeclare_queryable(this: &mut z_owned_queryable_t) -> error
 /// Frees memory and resets it to its gravesztone state. Will also attempt to undeclare queryable.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_queryable_drop(this: &mut z_owned_queryable_t) {
+pub extern "C" fn z_queryable_drop(this: z_moved_queryable_t) {
     z_undeclare_queryable(this);
 }
 

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -249,8 +249,8 @@ pub extern "C" fn z_declare_queryable(
 /// Returns 0 in case of success, negative error code otherwise.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_undeclare_queryable(mut this: z_moved_queryable_t) -> errors::z_error_t {
-    if let Some(qable) = this.as_rust_type_mut().take() {
+pub extern "C" fn z_undeclare_queryable(this: z_moved_queryable_t) -> errors::z_error_t {
+    if let Some(qable) = this.into_rust_type().take() {
         if let Err(e) = qable.undeclare().wait() {
             log::error!("{}", e);
             return errors::Z_EGENERIC;

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -39,10 +39,12 @@ use zenoh::subscriber::Reliability;
 use zenoh_ext::*;
 
 use crate::opaque_types::ze_loaned_querying_subscriber_t;
+use crate::opaque_types::ze_moved_querying_subscriber_t;
 use crate::opaque_types::ze_owned_querying_subscriber_t;
 decl_c_type!(
     owned(
         ze_owned_querying_subscriber_t,
+        ze_moved_querying_subscriber_t,
         Option<(zenoh_ext::FetchingSubscriber<'static, ()>, &'static Session)>,
     ),
     loaned(

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -34,8 +34,8 @@ decl_c_type!(
 /// Frees memory and resets hello message to its gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_hello_drop(this: &mut z_owned_hello_t) {
-    *this.as_rust_type_mut() = None;
+#[allow(unused_variables)]
+pub unsafe extern "C" fn z_hello_drop(this: z_moved_hello_t) {
 }
 
 /// Borrows hello message.

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -13,8 +13,10 @@
 //
 use crate::{
     errors::{self, Z_OK},
-    transmute::{IntoCType, LoanedCTypeRef, OwnedCTypeRef, RustTypeRef, RustTypeRefUninit},
-    z_closure_hello_call, z_closure_hello_loan, z_id_t, z_moved_closure_hello_t, z_owned_config_t,
+    transmute::{
+        IntoCType, IntoRustType, LoanedCTypeRef, OwnedCTypeRef, RustTypeRef, RustTypeRefUninit,
+    },
+    z_closure_hello_call, z_closure_hello_loan, z_id_t, z_moved_closure_hello_t, z_moved_config_t,
     z_owned_string_array_t, z_view_string_t, zc_init_logger, CString, CStringView, ZVector,
 };
 use async_std::task;
@@ -142,7 +144,7 @@ pub extern "C" fn z_scout_options_default(this: &mut z_scout_options_t) {
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub extern "C" fn z_scout(
-    config: &mut z_owned_config_t,
+    config: z_moved_config_t,
     callback: z_moved_closure_hello_t,
     options: Option<&z_scout_options_t>,
 ) -> errors::z_error_t {
@@ -154,7 +156,7 @@ pub extern "C" fn z_scout(
         WhatAmIMatcher::try_from(options.zc_what as u8).unwrap_or(WhatAmI::Router | WhatAmI::Peer);
     #[allow(clippy::unnecessary_cast)] // Required for multi-target
     let timeout = options.zc_timeout_ms as u64;
-    let Some(config) = config.as_rust_type_mut().take() else {
+    let Some(config) = config.into_rust_type().take() else {
         log::error!("Config not provided");
         return errors::Z_EINVAL;
     };

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -24,9 +24,10 @@ use zenoh::scouting::Hello;
 use zenoh_protocol::core::{whatami::WhatAmIMatcher, WhatAmI};
 
 pub use crate::opaque_types::z_loaned_hello_t;
+pub use crate::opaque_types::z_moved_hello_t;
 pub use crate::opaque_types::z_owned_hello_t;
 decl_c_type!(
-    owned(z_owned_hello_t, Option<Hello>),
+    owned(z_owned_hello_t, z_moved_hello_t, Option<Hello>),
     loaned(z_loaned_hello_t, Hello)
 );
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -126,9 +126,8 @@ pub extern "C" fn z_session_check(this: &z_owned_session_t) -> bool {
 /// @return 0 in  case of success, a negative value if an error occured while closing the session,
 /// the remaining reference count (number of shallow copies) of the session otherwise, saturating at i8::MAX.
 #[no_mangle]
-pub extern "C" fn z_close(this: &mut z_owned_session_t) -> errors::z_error_t {
-    let session = this.as_rust_type_mut();
-    let Some(s) = session.take() else {
+pub extern "C" fn z_close(session: z_moved_session_t) -> errors::z_error_t {
+    let Some(s) = session.into_rust_type().take() else {
         return errors::Z_EINVAL;
     };
     let s = match Arc::try_unwrap(s) {

--- a/src/session.rs
+++ b/src/session.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit};
-use crate::{errors, z_owned_config_t, zc_init_logger};
+use crate::{errors, z_moved_config_t, zc_init_logger};
 use std::mem::MaybeUninit;
 use std::sync::Arc;
 use zenoh::core::Wait;
@@ -54,7 +54,7 @@ pub extern "C" fn z_session_null(this: &mut MaybeUninit<z_owned_session_t>) {
 #[no_mangle]
 pub extern "C" fn z_open(
     this: &mut MaybeUninit<z_owned_session_t>,
-    config: &mut z_owned_config_t,
+    mut config: z_moved_config_t,
 ) -> errors::z_error_t {
     let this = this.as_rust_type_mut_uninit();
     if cfg!(feature = "logger-autoinit") {
@@ -86,7 +86,7 @@ pub extern "C" fn z_open(
 #[no_mangle]
 pub extern "C" fn z_open_with_custom_shm_clients(
     this: &mut MaybeUninit<z_owned_session_t>,
-    config: &mut z_owned_config_t,
+    mut config: z_moved_config_t,
     shm_clients: &z_loaned_shm_client_storage_t,
 ) -> errors::z_error_t {
     let this = this.as_rust_type_mut_uninit();
@@ -150,9 +150,8 @@ pub extern "C" fn z_close(this: &mut z_owned_session_t) -> errors::z_error_t {
 ///
 /// This will also close the session if it does not have any clones left.
 #[no_mangle]
-pub extern "C" fn z_session_drop(this: &mut z_owned_session_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_session_drop(this: z_moved_session_t) {}
 
 /// Constructs an owned shallow copy of the session in provided uninitialized memory location.
 #[allow(clippy::missing_safety_doc)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh team, <zenoh@zettascale.tech>
 //
 
-use crate::transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit};
+use crate::transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit};
 use crate::{errors, z_moved_config_t, zc_init_logger};
 use std::mem::MaybeUninit;
 use std::sync::Arc;
@@ -54,13 +54,13 @@ pub extern "C" fn z_session_null(this: &mut MaybeUninit<z_owned_session_t>) {
 #[no_mangle]
 pub extern "C" fn z_open(
     this: &mut MaybeUninit<z_owned_session_t>,
-    mut config: z_moved_config_t,
+    config: z_moved_config_t,
 ) -> errors::z_error_t {
     let this = this.as_rust_type_mut_uninit();
     if cfg!(feature = "logger-autoinit") {
         zc_init_logger();
     }
-    let Some(config) = config.as_rust_type_mut().take() else {
+    let Some(config) = config.into_rust_type().take() else {
         log::error!("Config not provided");
         this.write(None);
         return errors::Z_EINVAL;
@@ -86,14 +86,14 @@ pub extern "C" fn z_open(
 #[no_mangle]
 pub extern "C" fn z_open_with_custom_shm_clients(
     this: &mut MaybeUninit<z_owned_session_t>,
-    mut config: z_moved_config_t,
+    config: z_moved_config_t,
     shm_clients: &z_loaned_shm_client_storage_t,
 ) -> errors::z_error_t {
     let this = this.as_rust_type_mut_uninit();
     if cfg!(feature = "logger-autoinit") {
         zc_init_logger();
     }
-    let Some(config) = config.as_rust_type_mut().take() else {
+    let Some(config) = config.into_rust_type().take() else {
         log::error!("Config not provided");
         this.write(None);
         return errors::Z_EINVAL;

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,9 +23,10 @@ use zenoh::session::Session;
 use crate::z_loaned_shm_client_storage_t;
 
 use crate::opaque_types::z_loaned_session_t;
+use crate::opaque_types::z_moved_session_t;
 use crate::opaque_types::z_owned_session_t;
 decl_c_type!(
-    owned(z_owned_session_t, Option<Arc<Session>>),
+    owned(z_owned_session_t, z_moved_session_t, Option<Arc<Session>>),
     loaned(z_loaned_session_t, Arc<Session>)
 );
 

--- a/src/shm/buffer/zshm.rs
+++ b/src/shm/buffer/zshm.rs
@@ -21,11 +21,11 @@ use zenoh::shm::{zshm, zshmmut, ZShm};
 
 use crate::{
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
-    z_loaned_shm_mut_t, z_loaned_shm_t, z_owned_shm_mut_t, z_owned_shm_t,
+    z_loaned_shm_mut_t, z_loaned_shm_t, z_moved_shm_t, z_owned_shm_mut_t, z_owned_shm_t,
 };
 
 decl_c_type!(
-    owned(z_owned_shm_t, Option<ZShm>),
+    owned(z_owned_shm_t, z_moved_shm_t, Option<ZShm>),
     loaned(z_loaned_shm_t, zshm),
 );
 

--- a/src/shm/buffer/zshm.rs
+++ b/src/shm/buffer/zshm.rs
@@ -97,9 +97,8 @@ pub unsafe extern "C" fn z_shm_try_mut(this: &mut z_owned_shm_t) -> *mut z_loane
 
 /// Deletes ZShm slice
 #[no_mangle]
-pub extern "C" fn z_shm_drop(this: &mut z_owned_shm_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_shm_drop(this: z_moved_shm_t) {}
 
 /// Tries to reborrow mutably-borrowed ZShm slice as borrowed ZShmMut slice
 #[no_mangle]

--- a/src/shm/buffer/zshm.rs
+++ b/src/shm/buffer/zshm.rs
@@ -20,8 +20,8 @@ use std::{
 use zenoh::shm::{zshm, zshmmut, ZShm};
 
 use crate::{
-    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
-    z_loaned_shm_mut_t, z_loaned_shm_t, z_moved_shm_t, z_owned_shm_mut_t, z_owned_shm_t,
+    transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    z_loaned_shm_mut_t, z_loaned_shm_t, z_moved_shm_mut_t, z_moved_shm_t, z_owned_shm_t,
 };
 
 decl_c_type!(
@@ -31,11 +31,8 @@ decl_c_type!(
 
 /// Constructs ZShm slice from ZShmMut slice
 #[no_mangle]
-pub extern "C" fn z_shm_from_mut(
-    this: &mut MaybeUninit<z_owned_shm_t>,
-    that: &mut z_owned_shm_mut_t,
-) {
-    let shm: Option<ZShm> = that.as_rust_type_mut().take().map(|val| val.into());
+pub extern "C" fn z_shm_from_mut(this: &mut MaybeUninit<z_owned_shm_t>, that: z_moved_shm_mut_t) {
+    let shm: Option<ZShm> = that.into_rust_type().take().map(|val| val.into());
     this.as_rust_type_mut_uninit().write(shm);
 }
 

--- a/src/shm/buffer/zshmmut.rs
+++ b/src/shm/buffer/zshmmut.rs
@@ -18,11 +18,11 @@ use zenoh::shm::{zshmmut, ZShmMut};
 
 use crate::{
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
-    z_loaned_shm_mut_t, z_owned_shm_mut_t, z_owned_shm_t,
+    z_loaned_shm_mut_t, z_moved_shm_t, z_owned_shm_mut_t, z_owned_shm_t,
 };
 
 decl_c_type!(
-    owned(z_owned_shm_mut_t, Option<ZShmMut>),
+    owned(z_owned_shm_mut_t, z_moved_shm_t, Option<ZShmMut>),
     loaned(z_loaned_shm_mut_t, zshmmut)
 );
 

--- a/src/shm/buffer/zshmmut.rs
+++ b/src/shm/buffer/zshmmut.rs
@@ -67,9 +67,8 @@ pub unsafe extern "C" fn z_shm_mut_loan_mut(
 
 /// Deletes ZShmMut slice
 #[no_mangle]
-pub extern "C" fn z_shm_mut_drop(this: &mut z_owned_shm_mut_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_shm_mut_drop(this: z_moved_shm_mut_t) {}
 
 /// @return the length of the ZShmMut slice
 #[no_mangle]

--- a/src/shm/buffer/zshmmut.rs
+++ b/src/shm/buffer/zshmmut.rs
@@ -17,8 +17,8 @@ use std::{borrow::BorrowMut, mem::MaybeUninit};
 use zenoh::shm::{zshmmut, ZShmMut};
 
 use crate::{
-    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
-    z_loaned_shm_mut_t, z_moved_shm_mut_t, z_owned_shm_mut_t, z_owned_shm_t,
+    transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    z_loaned_shm_mut_t, z_moved_shm_mut_t, z_moved_shm_t, z_owned_shm_mut_t,
 };
 
 decl_c_type!(
@@ -30,10 +30,10 @@ decl_c_type!(
 #[no_mangle]
 pub extern "C" fn z_shm_mut_try_from_immut(
     this: &mut MaybeUninit<z_owned_shm_mut_t>,
-    that: &mut z_owned_shm_t,
+    that: z_moved_shm_t,
 ) {
     let shm: Option<ZShmMut> = that
-        .as_rust_type_mut()
+        .into_rust_type()
         .take()
         .and_then(|val| val.try_into().ok());
     this.as_rust_type_mut_uninit().write(shm);

--- a/src/shm/buffer/zshmmut.rs
+++ b/src/shm/buffer/zshmmut.rs
@@ -18,11 +18,11 @@ use zenoh::shm::{zshmmut, ZShmMut};
 
 use crate::{
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
-    z_loaned_shm_mut_t, z_moved_shm_t, z_owned_shm_mut_t, z_owned_shm_t,
+    z_loaned_shm_mut_t, z_moved_shm_mut_t, z_owned_shm_mut_t, z_owned_shm_t,
 };
 
 decl_c_type!(
-    owned(z_owned_shm_mut_t, z_moved_shm_t, Option<ZShmMut>),
+    owned(z_owned_shm_mut_t, z_moved_shm_mut_t, Option<ZShmMut>),
     loaned(z_loaned_shm_mut_t, zshmmut)
 );
 

--- a/src/shm/client/shm_client.rs
+++ b/src/shm/client/shm_client.rs
@@ -94,6 +94,5 @@ pub extern "C" fn z_shm_client_check(this: &z_owned_shm_client_t) -> bool {
 
 /// Deletes SHM Client
 #[no_mangle]
-pub extern "C" fn z_shm_client_drop(this: &mut z_owned_shm_client_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_shm_client_drop(this: z_moved_shm_client_t) {}

--- a/src/shm/client/shm_client.rs
+++ b/src/shm/client/shm_client.rs
@@ -26,6 +26,7 @@ use crate::{
     shm::common::types::z_segment_id_t,
 };
 
+pub use crate::opaque_types::z_moved_shm_client_t;
 pub use crate::opaque_types::z_owned_shm_client_t;
 
 use super::shm_segment::{z_shm_segment_t, DynamicShmSegment};
@@ -41,7 +42,7 @@ pub struct zc_shm_client_callbacks_t {
     ) -> bool,
 }
 
-decl_c_type!(owned(z_owned_shm_client_t, Option<Arc<dyn ShmClient>>));
+decl_c_type!(owned(z_owned_shm_client_t, z_moved_shm_client_t, Option<Arc<dyn ShmClient>>));
 
 #[derive(Debug)]
 pub struct DynamicShmClient {

--- a/src/shm/client_storage/mod.rs
+++ b/src/shm/client_storage/mod.rs
@@ -16,14 +16,19 @@ use super::common::types::z_protocol_id_t;
 use crate::{
     errors::{z_error_t, Z_EINVAL, Z_OK},
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
-    z_loaned_shm_client_storage_t, z_owned_shm_client_storage_t, z_owned_shm_client_t,
-    zc_loaned_shm_client_list_t, zc_owned_shm_client_list_t,
+    z_loaned_shm_client_storage_t, z_moved_shm_client_storage_t, z_owned_shm_client_storage_t,
+    z_owned_shm_client_t, zc_loaned_shm_client_list_t, zc_moved_shm_client_list_t,
+    zc_owned_shm_client_list_t,
 };
 use std::{mem::MaybeUninit, sync::Arc};
 use zenoh::shm::{ProtocolID, ShmClient, ShmClientStorage, GLOBAL_CLIENT_STORAGE};
 
 decl_c_type!(
-    owned(zc_owned_shm_client_list_t, Option<Vec<(ProtocolID, Arc<dyn ShmClient>)>>),
+    owned(
+        zc_owned_shm_client_list_t,
+        zc_moved_shm_client_list_t,
+        Option<Vec<(ProtocolID, Arc<dyn ShmClient>)>>,
+    ),
     loaned(zc_loaned_shm_client_list_t, Vec<(ProtocolID, Arc<dyn ShmClient>)>)
 );
 
@@ -95,7 +100,11 @@ pub extern "C" fn zc_shm_client_list_add_client(
 }
 
 decl_c_type!(
-    owned(z_owned_shm_client_storage_t, Option<Arc<ShmClientStorage>>),
+    owned(
+        z_owned_shm_client_storage_t,
+        z_moved_shm_client_storage_t,
+        Option<Arc<ShmClientStorage>>,
+    ),
     loaned(z_loaned_shm_client_storage_t, Arc<ShmClientStorage>),
 );
 

--- a/src/shm/client_storage/mod.rs
+++ b/src/shm/client_storage/mod.rs
@@ -165,9 +165,8 @@ pub extern "C" fn z_shm_client_storage_check(this: &z_owned_shm_client_storage_t
 
 /// Derefs SHM Client Storage
 #[no_mangle]
-pub extern "C" fn z_shm_client_storage_drop(this: &mut z_owned_shm_client_storage_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_shm_client_storage_drop(this: z_moved_shm_client_storage_t) {}
 
 /// Borrows SHM Client Storage
 #[no_mangle]

--- a/src/shm/provider/alloc_layout.rs
+++ b/src/shm/provider/alloc_layout.rs
@@ -19,8 +19,8 @@ use crate::{
     errors::z_error_t,
     shm::protocol_implementations::posix::posix_shm_provider::PosixAllocLayout,
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
-    z_loaned_alloc_layout_t, z_loaned_shm_provider_t, z_owned_alloc_layout_t,
-    z_owned_buf_alloc_result_t,
+    z_loaned_alloc_layout_t, z_loaned_shm_provider_t, z_moved_alloc_layout_t,
+    z_owned_alloc_layout_t, z_owned_buf_alloc_result_t,
 };
 use libc::c_void;
 use zenoh::shm::{
@@ -48,7 +48,7 @@ pub enum CSHMLayout {
 }
 
 decl_c_type!(
-    owned(z_owned_alloc_layout_t, Option<CSHMLayout>),
+    owned(z_owned_alloc_layout_t, z_moved_alloc_layout_t, Option<CSHMLayout>),
     loaned(z_loaned_alloc_layout_t, CSHMLayout),
 );
 

--- a/src/shm/provider/alloc_layout.rs
+++ b/src/shm/provider/alloc_layout.rs
@@ -89,9 +89,8 @@ pub unsafe extern "C" fn z_alloc_layout_loan(
 
 /// Deletes Alloc Layout
 #[no_mangle]
-pub extern "C" fn z_alloc_layout_drop(this: &mut z_owned_alloc_layout_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_alloc_layout_drop(this: z_moved_alloc_layout_t) {}
 
 #[no_mangle]
 pub extern "C" fn z_alloc_layout_alloc(

--- a/src/shm/provider/shm_provider.rs
+++ b/src/shm/provider/shm_provider.rs
@@ -117,9 +117,8 @@ pub unsafe extern "C" fn z_shm_provider_loan(
 
 /// Deletes SHM Provider
 #[no_mangle]
-pub extern "C" fn z_shm_provider_drop(this: &mut z_owned_shm_provider_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_shm_provider_drop(this: z_moved_shm_provider_t) {}
 
 #[no_mangle]
 pub extern "C" fn z_shm_provider_alloc(

--- a/src/shm/provider/shm_provider.rs
+++ b/src/shm/provider/shm_provider.rs
@@ -28,7 +28,8 @@ use crate::{
         protocol_implementations::posix::posix_shm_provider::PosixShmProvider,
     },
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
-    z_loaned_shm_provider_t, z_owned_buf_alloc_result_t, z_owned_shm_mut_t, z_owned_shm_provider_t,
+    z_loaned_shm_provider_t, z_moved_shm_provider_t, z_owned_buf_alloc_result_t, z_owned_shm_mut_t,
+    z_owned_shm_provider_t,
 };
 
 use super::{
@@ -50,7 +51,7 @@ pub enum CSHMProvider {
 }
 
 decl_c_type!(
-    owned(z_owned_shm_provider_t, Option<CSHMProvider>),
+    owned(z_owned_shm_provider_t, z_moved_shm_provider_t, Option<CSHMProvider>),
     loaned(z_loaned_shm_provider_t, CSHMProvider),
 );
 

--- a/src/shm/provider/types.rs
+++ b/src/shm/provider/types.rs
@@ -124,9 +124,8 @@ pub unsafe extern "C" fn z_memory_layout_loan(
 
 /// Deletes Memory Layout
 #[no_mangle]
-pub extern "C" fn z_memory_layout_drop(this: &mut z_owned_memory_layout_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_memory_layout_drop(this: z_moved_memory_layout_t) {}
 
 /// Deletes Memory Layout
 #[no_mangle]
@@ -191,9 +190,8 @@ pub unsafe extern "C" fn z_chunk_alloc_result_loan(
 
 /// Deletes Chunk Alloc Result
 #[no_mangle]
-pub extern "C" fn z_chunk_alloc_result_drop(this: &mut z_owned_chunk_alloc_result_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_chunk_alloc_result_drop(this: z_moved_chunk_alloc_result_t) {}
 
 decl_c_type!(
     inequal
@@ -248,6 +246,5 @@ pub unsafe extern "C" fn z_buf_alloc_result_loan(
 
 /// Deletes Buf Alloc Result
 #[no_mangle]
-pub extern "C" fn z_buf_alloc_result_drop(this: &mut z_owned_buf_alloc_result_t) {
-    *this.as_rust_type_mut() = None;
-}
+#[allow(unused_variables)]
+pub extern "C" fn z_buf_alloc_result_drop(this: z_moved_buf_alloc_result_t) {}

--- a/src/shm/provider/types.rs
+++ b/src/shm/provider/types.rs
@@ -17,7 +17,7 @@ use std::mem::MaybeUninit;
 use zenoh::internal::zerror;
 use zenoh::shm::{AllocAlignment, BufAllocResult, ChunkAllocResult, MemoryLayout, ZAllocError};
 
-use crate::transmute::{IntoCType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit};
+use crate::transmute::{IntoCType, IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit};
 use crate::{
     errors::{z_error_t, Z_EINVAL, Z_OK},
     z_loaned_buf_alloc_result_t, z_loaned_chunk_alloc_result_t, z_loaned_memory_layout_t,
@@ -202,11 +202,11 @@ decl_c_type!(
 
 #[no_mangle]
 pub extern "C" fn z_buf_alloc_result_unwrap(
-    alloc_result: &mut z_owned_buf_alloc_result_t,
+    alloc_result: z_moved_buf_alloc_result_t,
     out_buf: &mut MaybeUninit<z_owned_shm_mut_t>,
     out_error: &mut MaybeUninit<z_alloc_error_t>,
 ) -> z_error_t {
-    match alloc_result.as_rust_type_mut().take() {
+    match alloc_result.into_rust_type().take() {
         Some(Ok(val)) => {
             out_buf.as_rust_type_mut_uninit().write(Some(val));
             Z_OK

--- a/src/shm/provider/types.rs
+++ b/src/shm/provider/types.rs
@@ -21,6 +21,7 @@ use crate::transmute::{IntoCType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit
 use crate::{
     errors::{z_error_t, Z_EINVAL, Z_OK},
     z_loaned_buf_alloc_result_t, z_loaned_chunk_alloc_result_t, z_loaned_memory_layout_t,
+    z_moved_buf_alloc_result_t, z_moved_chunk_alloc_result_t, z_moved_memory_layout_t,
     z_owned_buf_alloc_result_t, z_owned_chunk_alloc_result_t, z_owned_memory_layout_t,
     z_owned_shm_mut_t,
 };
@@ -73,7 +74,8 @@ decl_c_type!(copy(z_alloc_alignment_t, AllocAlignment),);
 
 decl_c_type!(
     inequal
-    owned(z_owned_memory_layout_t, Option<MemoryLayout>),
+    owned(z_owned_memory_layout_t, z_moved_memory_layout_t,
+         Option<MemoryLayout>),
     loaned(z_loaned_memory_layout_t, MemoryLayout)
 );
 
@@ -139,7 +141,7 @@ pub extern "C" fn z_memory_layout_get_data(
 }
 
 decl_c_type!(
-    owned(z_owned_chunk_alloc_result_t, Option<ChunkAllocResult>),
+    owned(z_owned_chunk_alloc_result_t, z_moved_chunk_alloc_result_t, Option<ChunkAllocResult>),
     loaned(z_loaned_chunk_alloc_result_t, ChunkAllocResult)
 );
 
@@ -195,7 +197,8 @@ pub extern "C" fn z_chunk_alloc_result_drop(this: &mut z_owned_chunk_alloc_resul
 
 decl_c_type!(
     inequal
-    owned(z_owned_buf_alloc_result_t, Option<BufAllocResult>),
+    owned(z_owned_buf_alloc_result_t, z_moved_buf_alloc_result_t,
+        Option<BufAllocResult>),
     loaned(z_loaned_buf_alloc_result_t, BufAllocResult)
 );
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -171,8 +171,8 @@ pub extern "C" fn z_undeclare_subscriber(this: &mut z_owned_subscriber_t) -> err
 
 /// Drops subscriber and resets it to its gravestone state. Also attempts to undeclare it.
 #[no_mangle]
-pub extern "C" fn z_subscriber_drop(this: &mut z_owned_subscriber_t) {
-    z_undeclare_subscriber(this);
+#[allow(unused_variables)]
+pub extern "C" fn z_subscriber_drop(this: z_moved_subscriber_t) {
 }
 
 /// Returns ``true`` if subscriber is valid, ``false`` otherwise.

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -60,9 +60,10 @@ impl From<z_reliability_t> for Reliability {
 }
 
 pub use crate::opaque_types::z_loaned_subscriber_t;
+pub use crate::opaque_types::z_moved_subscriber_t;
 pub use crate::opaque_types::z_owned_subscriber_t;
 decl_c_type!(
-    owned(z_owned_subscriber_t, Option<Subscriber<'static, ()>>),
+    owned(z_owned_subscriber_t, z_moved_subscriber_t, Option<Subscriber<'static, ()>>),
     loaned(z_loaned_subscriber_t, Subscriber<'static, ()>)
 );
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -16,6 +16,7 @@ use std::mem::MaybeUninit;
 
 use crate::errors;
 use crate::keyexpr::*;
+use crate::transmute::IntoRustType;
 use crate::transmute::LoanedCTypeRef;
 use crate::transmute::OwnedCTypeRef;
 use crate::transmute::RustTypeRef;
@@ -161,8 +162,8 @@ pub extern "C" fn z_subscriber_keyexpr(subscriber: &z_loaned_subscriber_t) -> &z
 /// @return 0 in case of success, negative error code otherwise.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_undeclare_subscriber(this: &mut z_owned_subscriber_t) -> errors::z_error_t {
-    if let Some(s) = this.as_rust_type_mut().take() {
+pub extern "C" fn z_undeclare_subscriber(this: z_moved_subscriber_t) -> errors::z_error_t {
+    if let Some(s) = this.into_rust_type().take() {
         if let Err(e) = s.undeclare().wait() {
             log::error!("{}", e);
             return errors::Z_EGENERIC;

--- a/src/transmute.rs
+++ b/src/transmute.rs
@@ -55,7 +55,7 @@ pub(crate) trait IntoCType: Sized + Copy {
     fn into_c_type(self) -> Self::CType;
 }
 
-macro_rules! validate_equivalence2 {
+macro_rules! validate_equivalence {
     ($type_a:ty, $type_b:ty) => {
         const _: () = {
             use const_format::concatcp;
@@ -187,52 +187,52 @@ macro_rules! impl_transmute {
 // In this case the "inequal" keyword should be used.
 #[macro_export]
 macro_rules! decl_c_type {
-    (owned ($c_owned_type:ty, $rust_owned_type:ty $(,)?),
+    (owned ($c_owned_type:ty, $c_moved_type:ty, $rust_owned_type:ty $(,)?),
      view ($c_view_type:ty, $rust_view_type:ty $(,)?),
      loaned ($c_loaned_type:ty, $rust_loaned_type:ty $(,)?) $(,)?) => {
         decl_c_type!(
-            owned($c_owned_type, $rust_owned_type),
+            owned($c_owned_type, $c_moved_type, $rust_owned_type),
             loaned($c_loaned_type, $rust_loaned_type)
         );
-        validate_equivalence2!($c_view_type, $rust_view_type);
-        validate_equivalence2!($c_view_type, $c_loaned_type);
+        validate_equivalence!($c_view_type, $rust_view_type);
+        validate_equivalence!($c_view_type, $c_loaned_type);
         impl_transmute!(as_c_view($rust_view_type, $c_view_type));
         impl_transmute!(as_rust($c_view_type, $rust_view_type));
     };
-    (owned ($c_owned_type:ty, $rust_owned_type:ty $(,)?),
+    (owned ($c_owned_type:ty, $c_moved_type:ty, $rust_owned_type:ty $(,)?),
      loaned ($c_loaned_type:ty, $rust_loaned_type:ty $(,)?) $(,)?) => {
         decl_c_type!( inequal
-            owned($c_owned_type, $rust_owned_type),
+            owned($c_owned_type, $c_moved_type, $rust_owned_type),
             loaned($c_loaned_type, $rust_loaned_type)
         );
-        validate_equivalence2!($c_owned_type, $c_loaned_type);
+        validate_equivalence!($c_owned_type, $c_loaned_type);
     };
     (inequal
-     owned ($c_owned_type:ty, $rust_owned_type:ty $(,)?),
+     owned ($c_owned_type:ty, $c_moved_type:ty, $rust_owned_type:ty $(,)?),
      loaned ($c_loaned_type:ty, $rust_loaned_type:ty $(,)?) $(,)?) => {
         decl_c_type!(loaned($c_loaned_type, $rust_loaned_type));
-        decl_c_type!(owned($c_owned_type, $rust_owned_type));
+        decl_c_type!(owned($c_owned_type, $c_moved_type, $rust_owned_type));
     };
-    (owned ($c_owned_type:ty, $rust_owned_type:ty $(,)?) $(,)?) => {
-        validate_equivalence2!($c_owned_type, $rust_owned_type);
+    (owned ($c_owned_type:ty, $c_moved_type:ty, $rust_owned_type:ty $(,)?) $(,)?) => {
+        validate_equivalence!($c_owned_type, $rust_owned_type);
         impl_transmute!(as_c_owned($rust_owned_type, $c_owned_type));
         impl_transmute!(as_rust($c_owned_type, $rust_owned_type));
     };
     (loaned ($c_loaned_type:ty, $rust_loaned_type:ty $(,)?) $(,)?) => {
-        validate_equivalence2!($c_loaned_type, $rust_loaned_type);
+        validate_equivalence!($c_loaned_type, $rust_loaned_type);
         impl_transmute!(as_c_loaned($rust_loaned_type, $c_loaned_type));
         impl_transmute!(as_rust($c_loaned_type, $rust_loaned_type));
     };
     (copy ($c_type:ty, $rust_type:ty $(,)?) $(,)?) => {
-        validate_equivalence2!($c_type, $rust_type);
+        validate_equivalence!($c_type, $rust_type);
         impl_transmute!(as_c($rust_type, $c_type));
         impl_transmute!(as_rust($c_type, $rust_type));
         impl_transmute!(into_c($rust_type, $c_type));
         impl_transmute!(into_rust($c_type, $rust_type));
     };
-    (owned ($c_owned_type:ty$ (,)?),
+    (owned ($c_owned_type:ty, $c_moved_type:ty $(,)?),
      loaned ($c_loaned_type:ty $(,)?) $(,)?) => {
-        validate_equivalence2!($c_owned_type, $c_loaned_type);
+        validate_equivalence!($c_owned_type, $c_loaned_type);
         impl_transmute!(as_c_owned($c_loaned_type, $c_owned_type));
         impl_transmute!(as_c_loaned($c_owned_type, $c_loaned_type));
     };

--- a/src/transmute.rs
+++ b/src/transmute.rs
@@ -250,5 +250,20 @@ macro_rules! decl_c_type {
         validate_equivalence!($c_owned_type, $c_loaned_type);
         impl_transmute!(as_c_owned($c_loaned_type, $c_owned_type));
         impl_transmute!(as_c_loaned($c_owned_type, $c_loaned_type));
+        impl $crate::transmute::OwnedCTypeRef for $c_moved_type {
+            type OwnedCType = $c_owned_type;
+            fn as_owned_c_type_ref(&self) -> &Self::OwnedCType {
+                self.ptr
+            }
+            fn as_owned_c_type_mut(&mut self) -> &mut Self::OwnedCType {
+                self.ptr
+            }
+        }
+        impl Drop for $c_moved_type {
+            fn drop(&mut self) {
+                use $crate::transmute::OwnedCTypeRef;
+                std::mem::take(self.as_owned_c_type_mut());
+            }
+        }
     };
 }

--- a/src/transmute.rs
+++ b/src/transmute.rs
@@ -45,12 +45,12 @@ pub(crate) trait RustTypeRefUninit: Sized {
     fn as_rust_type_mut_uninit(&mut self) -> &mut MaybeUninit<Self::RustType>;
 }
 
-pub(crate) trait IntoRustType: Sized + Copy {
+pub(crate) trait IntoRustType: Sized {
     type RustType;
     fn into_rust_type(self) -> Self::RustType;
 }
 
-pub(crate) trait IntoCType: Sized + Copy {
+pub(crate) trait IntoCType: Sized {
     type CType;
     fn into_c_type(self) -> Self::CType;
 }
@@ -224,6 +224,12 @@ macro_rules! decl_c_type {
             }
             fn as_rust_type_mut(&mut self) -> &mut Self::RustType {
                 self.ptr.as_rust_type_mut()
+            }
+        }
+        impl $crate::transmute::IntoRustType for $c_moved_type {
+            type RustType = $rust_owned_type;
+            fn into_rust_type(self) -> Self::RustType {
+                std::mem::take(self.ptr.as_rust_type_mut())
             }
         }
         impl Drop for $c_moved_type {

--- a/src/transmute.rs
+++ b/src/transmute.rs
@@ -217,6 +217,21 @@ macro_rules! decl_c_type {
         validate_equivalence!($c_owned_type, $rust_owned_type);
         impl_transmute!(as_c_owned($rust_owned_type, $c_owned_type));
         impl_transmute!(as_rust($c_owned_type, $rust_owned_type));
+        impl $crate::transmute::RustTypeRef for $c_moved_type {
+            type RustType = $rust_owned_type;
+            fn as_rust_type_ref(&self) -> &Self::RustType {
+                self.ptr.as_rust_type_ref()
+            }
+            fn as_rust_type_mut(&mut self) -> &mut Self::RustType {
+                self.ptr.as_rust_type_mut()
+            }
+        }
+        impl Drop for $c_moved_type {
+            fn drop(&mut self) {
+                use $crate::transmute::RustTypeRef;
+                std::mem::take(self.as_rust_type_mut());
+            }
+        }
     };
     (loaned ($c_loaned_type:ty, $rust_loaned_type:ty $(,)?) $(,)?) => {
         validate_equivalence!($c_loaned_type, $rust_loaned_type);

--- a/tests/z_api_keyexpr_test.c
+++ b/tests/z_api_keyexpr_test.c
@@ -93,7 +93,7 @@ void undeclare() {
     z_owned_keyexpr_t ke;
     z_declare_keyexpr(&ke, z_loan(s), z_loan(view_ke));
     assert(z_keyexpr_check(&ke));
-    z_undeclare_keyexpr(&ke, z_loan(s));
+    z_undeclare_keyexpr(z_move(ke), z_loan(s));
     assert(!z_keyexpr_check(&ke));
 }
 

--- a/tests/z_api_shm_test.c
+++ b/tests/z_api_shm_test.c
@@ -90,7 +90,7 @@ bool test_layouted_allocation(const z_loaned_alloc_layout_t* alloc_layout) {
 
     ASSERT_OK(z_buf_alloc_result_unwrap(z_move(alloc), &shm_buf, &shm_error));
     if (z_check(shm_buf)) {
-        ASSERT_OK(test_shm_buffer(z_move(shm_buf)));
+        ASSERT_OK(test_shm_buffer(&shm_buf));
         ASSERT_CHECK_ERR(shm_buf);
         return true;
     } else
@@ -108,7 +108,7 @@ bool test_allocation(const z_loaned_shm_provider_t* provider, size_t size, z_all
 
     ASSERT_OK(z_buf_alloc_result_unwrap(z_move(alloc), &shm_buf, &shm_error));
     if (z_check(shm_buf)) {
-        ASSERT_OK(test_shm_buffer(z_move(shm_buf)));
+        ASSERT_OK(test_shm_buffer(&shm_buf));
         ASSERT_CHECK_ERR(shm_buf);
         return true;
     } else


### PR DESCRIPTION
added `z_moved_xxx_t` types to make usage of `z_move` obligatory