### PR TITLE
String names normalization

### DIFF
--- a/examples/z_delete.c
+++ b/examples/z_delete.c
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
 
     printf("Deleting resources matching '%s'...\n", keyexpr);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     int res = z_delete(z_loan(s), z_loan(ke), NULL);
     if (res < 0) {
         printf("Delete failed...\n");

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
             break;
     }
     z_view_keyexpr_t keyexpr;
-    if (z_view_keyexpr_from_string(&keyexpr, expr) < 0) {
+    if (z_view_keyexpr_from_str(&keyexpr, expr) < 0) {
         printf("%s is not a valid key expression", expr);
         exit(-1);
     }
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
 
     z_owned_bytes_t payload;
     if (value != NULL) {
-        z_bytes_serialize_from_string(&payload, value);
+        z_bytes_serialize_from_str(&payload, value);
         opts.payload = &payload;
     }
     z_get(z_loan(s), z_loan(keyexpr), "", z_move(closure),

--- a/examples/z_get_liveliness.c
+++ b/examples/z_get_liveliness.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t keyexpr;
-    if (z_view_keyexpr_from_string(&keyexpr, expr) < 0) {
+    if (z_view_keyexpr_from_str(&keyexpr, expr) < 0) {
         printf("%s is not a valid key expression\n", expr);
         exit(-1);
     }

--- a/examples/z_get_shm.c
+++ b/examples/z_get_shm.c
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
     size_t value_len = value ? strlen(value) : 0;
 
     z_view_keyexpr_t keyexpr;
-    if (z_view_keyexpr_from_string(&keyexpr, expr) < 0) {
+    if (z_view_keyexpr_from_str(&keyexpr, expr) < 0) {
         printf("%s is not a valid key expression", expr);
         exit(-1);
     }

--- a/examples/z_liveliness.c
+++ b/examples/z_liveliness.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t keyexpr;
-    if (z_view_keyexpr_from_string(&keyexpr, expr) < 0) {
+    if (z_view_keyexpr_from_str(&keyexpr, expr) < 0) {
         printf("%s is not a valid key expression\n", expr);
         exit(-1);
     }

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
         expr = argv[1];
     }
     z_view_keyexpr_t keyexpr;
-    if (z_view_keyexpr_from_string(&keyexpr, expr) < 0) {
+    if (z_view_keyexpr_from_str(&keyexpr, expr) < 0) {
         printf("%s is not a valid key expression", expr);
         exit(-1);
     }

--- a/examples/z_ping.c
+++ b/examples/z_ping.c
@@ -56,9 +56,9 @@ int main(int argc, char** argv) {
     z_owned_session_t session;
     z_open(&session, z_move(config));
     z_view_keyexpr_t ping;
-    z_view_keyexpr_from_string_unchecked(&ping, "test/ping");
+    z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_view_keyexpr_t pong;
-    z_view_keyexpr_from_string_unchecked(&pong, "test/pong");
+    z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
     z_declare_publisher(&pub, z_loan(session), z_loan(ping), NULL);
     z_owned_closure_sample_t respond;

--- a/examples/z_ping_shm.c
+++ b/examples/z_ping_shm.c
@@ -56,9 +56,9 @@ int main(int argc, char** argv) {
     z_owned_session_t session;
     z_open(&session, z_move(config));
     z_view_keyexpr_t ping;
-    z_view_keyexpr_from_string_unchecked(&ping, "test/ping");
+    z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_view_keyexpr_t pong;
-    z_view_keyexpr_from_string_unchecked(&pong, "test/pong");
+    z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
     z_declare_publisher(&pub, z_loan(session), z_loan(ping), NULL);
     z_owned_closure_sample_t respond;

--- a/examples/z_pong.c
+++ b/examples/z_pong.c
@@ -42,9 +42,9 @@ int main(int argc, char** argv) {
     z_owned_session_t session;
     z_open(&session, z_move(config));
     z_view_keyexpr_t ping;
-    z_view_keyexpr_from_string_unchecked(&ping, "test/ping");
+    z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_view_keyexpr_t pong;
-    z_view_keyexpr_from_string_unchecked(&pong, "test/pong");
+    z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
     z_declare_publisher(&pub, z_loan(session), z_loan(pong), NULL);
     z_owned_closure_sample_t respond;

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
     printf("Declaring Publisher on '%s'...\n", keyexpr);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare Publisher for key expression!\n");
         exit(-1);
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
         z_publisher_put_options_default(&options);
 
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
 
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -33,8 +33,8 @@ bool create_attachment_iter(z_owned_bytes_t* kv_pair, void* context) {
     if (kvs->current_idx >= kvs->len) {
         return false;
     } else {
-        z_bytes_serialize_from_string(&k, kvs->data[kvs->current_idx].key);
-        z_bytes_serialize_from_string(&v, kvs->data[kvs->current_idx].value);
+        z_bytes_serialize_from_str(&k, kvs->data[kvs->current_idx].key);
+        z_bytes_serialize_from_str(&v, kvs->data[kvs->current_idx].value);
         z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
         kvs->current_idx++;
         return true;
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
 
     printf("Declaring Publisher on '%s'...\n", keyexpr);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     z_owned_publisher_t pub;
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL)) {
         printf("Unable to declare Publisher for key expression!\n");
@@ -101,7 +101,7 @@ int main(int argc, char** argv) {
         sprintf(buf, "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
 
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
 

--- a/examples/z_pub_cache.c
+++ b/examples/z_pub_cache.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
     printf("Declaring publication cache on '%s'...\n", keyexpr);
     ze_owned_publication_cache_t pub_cache;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     ze_declare_publication_cache(&pub_cache, z_loan(s), z_loan(ke), &pub_cache_opts);
     if (!z_check(pub_cache)) {
         printf("Unable to declare publication cache for key expression!\n");
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
         sprintf(buf, "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
 
         z_put(z_loan(s), z_loan(ke), z_move(payload), NULL);
     }

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
     printf("Declaring Publisher on '%s'...\n", keyexpr);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare Publisher for key expression!\n");
         exit(-1);

--- a/examples/z_pub_shm_thr.c
+++ b/examples/z_pub_shm_thr.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
 
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), &options)) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
 
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), &options)) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
 
     printf("Declaring Subscriber on '%s'...\n", expr);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, expr);
+    z_view_keyexpr_from_str(&ke, expr);
     z_owned_subscriber_t sub;
 
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -46,14 +46,14 @@ int main(int argc, char **argv) {
     printf("Putting Data ('%s': '%s')...\n", keyexpr, value);
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
 
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_string(&payload, value);
+    z_bytes_serialize_from_str(&payload, value);
 
     z_owned_bytes_t attachment, key, val;
-    z_bytes_serialize_from_string(&key, "hello");
-    z_bytes_serialize_from_string(&val, "there");
+    z_bytes_serialize_from_str(&key, "hello");
+    z_bytes_serialize_from_str(&val, "there");
     z_bytes_serialize_from_pair(&attachment, z_move(key), z_move(val));
 
     z_put_options_t options;

--- a/examples/z_query_sub.c
+++ b/examples/z_query_sub.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
 
     ze_querying_subscriber_options_t sub_opts;
     ze_querying_subscriber_options_default(&sub_opts);

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -44,10 +44,10 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     z_query_reply_options_default(&options);
 
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, value);
+    z_bytes_serialize_from_str(&reply_payload, value);
 
     z_view_keyexpr_t reply_keyexpr;
-    z_view_keyexpr_from_string(&reply_keyexpr, (const char *)context);
+    z_view_keyexpr_from_str(&reply_keyexpr, (const char *)context);
 
     z_query_reply(query, z_loan(reply_keyexpr), z_move(reply_payload), &options);
 }
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    if (z_view_keyexpr_from_string(&ke, keyexpr)) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr)) {
         printf("%s is not a valid key expression", keyexpr);
         exit(-1);
     }

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression", keyexpr);
         exit(-1);
     }
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         z_query_reply_options_default(&options);
 
         z_owned_bytes_t reply_payload;
-        z_bytes_serialize_from_string(&reply_payload, value);
+        z_bytes_serialize_from_str(&reply_payload, value);
         z_query_reply(query, z_loan(ke), z_move(reply_payload), &options);
         z_drop(z_move(oquery));
     }

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
 
     z_owned_config_t config;
     z_config_default(&config);

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
 
     z_owned_config_t config;
     z_config_default(&config);

--- a/examples/z_sub_liveliness.c
+++ b/examples/z_sub_liveliness.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression\n", keyexpr);
         exit(-1);
     }

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, "test/thr");
+    z_view_keyexpr_from_str(&ke, "test/thr");
     z_owned_keyexpr_t declared_ke;
     z_declare_keyexpr(&declared_ke, z_loan(s), z_loan(ke));
 

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1332,11 +1332,11 @@ void z_bytes_serialize_from_slice_map_copy(struct z_owned_bytes_t *this_,
 /**
  * Serializes a null-terminated string by aliasing.
  */
-ZENOHC_API void z_bytes_serialize_from_string(struct z_owned_bytes_t *this_, const char *s);
+ZENOHC_API void z_bytes_serialize_from_str(struct z_owned_bytes_t *this_, const char *s);
 /**
  * Serializes a null-terminated string by copying.
  */
-ZENOHC_API void z_bytes_serialize_from_string_copy(struct z_owned_bytes_t *this_, const char *s);
+ZENOHC_API void z_bytes_serialize_from_str_copy(struct z_owned_bytes_t *this_, const char *s);
 /**
  * Serializes an unsigned integer.
  */
@@ -1766,9 +1766,9 @@ ZENOHC_API z_error_t z_encoding_from_str(struct z_owned_encoding_t *this_, const
  * Constructs a `z_owned_encoding_t` from a specified substring.
  */
 ZENOHC_API
-z_error_t z_encoding_from_substring(struct z_owned_encoding_t *this_,
-                                    const char *s,
-                                    size_t len);
+z_error_t z_encoding_from_substr(struct z_owned_encoding_t *this_,
+                                 const char *s,
+                                 size_t len);
 /**
  * Borrows encoding.
  */
@@ -2066,16 +2066,16 @@ bool z_keyexpr_equals(const struct z_loaned_keyexpr_t *left,
  * not in canon form.
  */
 ZENOHC_API
-z_error_t z_keyexpr_from_string(struct z_owned_keyexpr_t *this_,
-                                const char *expr);
+z_error_t z_keyexpr_from_str(struct z_owned_keyexpr_t *this_,
+                             const char *expr);
 /**
  * Constructs `z_owned_keyexpr_t` from a string, copying the passed string. The copied string is canonized.
  * @return 0 in case of success, negative error code in case of failure (for example if expr is not a valid key expression
  * even despite canonization).
  */
 ZENOHC_API
-z_error_t z_keyexpr_from_string_autocanonize(struct z_owned_keyexpr_t *this_,
-                                             const char *expr);
+z_error_t z_keyexpr_from_str_autocanonize(struct z_owned_keyexpr_t *this_,
+                                          const char *expr);
 /**
  * Constructs a `z_owned_keyexpr_t` by copying a substring.
  *
@@ -2085,9 +2085,9 @@ z_error_t z_keyexpr_from_string_autocanonize(struct z_owned_keyexpr_t *this_,
  * @return 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API
-z_error_t z_keyexpr_from_substring(struct z_owned_keyexpr_t *this_,
-                                   const char *expr,
-                                   size_t len);
+z_error_t z_keyexpr_from_substr(struct z_owned_keyexpr_t *this_,
+                                const char *expr,
+                                size_t len);
 /**
  * Constructs a `z_keyexpr_t` by copying a substring.
  *
@@ -2097,9 +2097,9 @@ z_error_t z_keyexpr_from_substring(struct z_owned_keyexpr_t *this_,
  * @return 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API
-z_error_t z_keyexpr_from_substring_autocanonize(struct z_owned_keyexpr_t *this_,
-                                                const char *start,
-                                                size_t *len);
+z_error_t z_keyexpr_from_substr_autocanonize(struct z_owned_keyexpr_t *this_,
+                                             const char *start,
+                                             size_t *len);
 /**
  * Returns ``true`` if ``left`` includes ``right``, i.e. the set defined by ``left`` contains every key belonging to the set
  * defined by ``right``, ``false`` otherwise.
@@ -3358,14 +3358,22 @@ ZENOHC_API void z_string_drop(struct z_owned_string_t *this_);
  */
 ZENOHC_API void z_string_empty(struct z_owned_string_t *this_);
 /**
+ * Constructs an owned string by copying `str` into it (including terminating 0), using `strlen` (this should therefore not be used with untrusted inputs).
+ *
+ * @return -1 if `str == NULL` (and creates a string in a gravestone state), 0 otherwise.
+ */
+ZENOHC_API
+z_error_t z_string_from_str(struct z_owned_string_t *this_,
+                            const char *str);
+/**
  * Constructs an owned string by copying a `str` substring of length `len`.
  *
  * @return -1 if `str == NULL` and `len > 0` (and creates a string in a gravestone state), 0 otherwise.
  */
 ZENOHC_API
-z_error_t z_string_from_substring(struct z_owned_string_t *this_,
-                                  const char *str,
-                                  size_t len);
+z_error_t z_string_from_substr(struct z_owned_string_t *this_,
+                               const char *str,
+                               size_t len);
 /**
  * @return ``true`` if string is empty, ``false`` otherwise.
  */
@@ -3382,14 +3390,6 @@ ZENOHC_API const struct z_loaned_string_t *z_string_loan(const struct z_owned_st
  * Constructs owned string in a gravestone state.
  */
 ZENOHC_API void z_string_null(struct z_owned_string_t *this_);
-/**
- * Constructs an owned string by copying `str` into it (including terminating 0), using `strlen` (this should therefore not be used with untrusted inputs).
- *
- * @return -1 if `str == NULL` (and creates a string in a gravestone state), 0 otherwise.
- */
-ZENOHC_API
-z_error_t z_string_wrap(struct z_owned_string_t *this_,
-                        const char *str);
 /**
  * Returns ``true`` if subscriber is valid, ``false`` otherwise.
  */
@@ -3523,8 +3523,8 @@ ZENOHC_API bool z_view_keyexpr_check(const struct z_view_keyexpr_t *this_);
  * `expr` must outlive the constucted key expression.
  */
 ZENOHC_API
-z_error_t z_view_keyexpr_from_string(struct z_view_keyexpr_t *this_,
-                                     const char *expr);
+z_error_t z_view_keyexpr_from_str(struct z_view_keyexpr_t *this_,
+                                  const char *expr);
 /**
  * Constructs a `z_view_keyexpr_t` by aliasing a string.
  * The string is canonized in-place before being passed to keyexpr, possibly shortening it by modifying `len`.
@@ -3532,8 +3532,8 @@ z_error_t z_view_keyexpr_from_string(struct z_view_keyexpr_t *this_,
  * `expr` must outlive the constucted key expression.
  */
 ZENOHC_API
-z_error_t z_view_keyexpr_from_string_autocanonize(struct z_view_keyexpr_t *this_,
-                                                  char *expr);
+z_error_t z_view_keyexpr_from_str_autocanonize(struct z_view_keyexpr_t *this_,
+                                               char *expr);
 /**
  * Constructs a `z_view_keyexpr_t` by aliasing a string without checking any of `z_view_keyexpr_t`'s assertions:
  *
@@ -3546,8 +3546,8 @@ z_error_t z_view_keyexpr_from_string_autocanonize(struct z_view_keyexpr_t *this_
  * `s` must outlive constructed key expression.
  */
 ZENOHC_API
-void z_view_keyexpr_from_string_unchecked(struct z_view_keyexpr_t *this_,
-                                          const char *s);
+void z_view_keyexpr_from_str_unchecked(struct z_view_keyexpr_t *this_,
+                                       const char *s);
 /**
  * Constructs a `z_view_keyexpr_t` by aliasing a substring.
  * `expr` must outlive the constucted key expression.
@@ -3558,9 +3558,9 @@ void z_view_keyexpr_from_string_unchecked(struct z_view_keyexpr_t *this_,
  * @return 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API
-z_error_t z_view_keyexpr_from_substring(struct z_view_keyexpr_t *this_,
-                                        const char *expr,
-                                        size_t len);
+z_error_t z_view_keyexpr_from_substr(struct z_view_keyexpr_t *this_,
+                                     const char *expr,
+                                     size_t len);
 /**
  * Constructs a `z_view_keyexpr_t` by aliasing a substring.
  * May SEGFAULT if `start` is NULL or lies in read-only memory (as values initialized with string litterals do).
@@ -3572,9 +3572,9 @@ z_error_t z_view_keyexpr_from_substring(struct z_view_keyexpr_t *this_,
  * @return 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API
-z_error_t z_view_keyexpr_from_substring_autocanonize(struct z_view_keyexpr_t *this_,
-                                                     char *start,
-                                                     size_t *len);
+z_error_t z_view_keyexpr_from_substr_autocanonize(struct z_view_keyexpr_t *this_,
+                                                  char *start,
+                                                  size_t *len);
 /**
  * Constructs a `z_view_keyexpr_t` by aliasing a substring without checking any of `z_view_keyexpr_t`'s assertions:
  *
@@ -3587,9 +3587,9 @@ z_error_t z_view_keyexpr_from_substring_autocanonize(struct z_view_keyexpr_t *th
  * `start` must outlive constructed key expression.
  */
 ZENOHC_API
-void z_view_keyexpr_from_substring_unchecked(struct z_view_keyexpr_t *this_,
-                                             const char *start,
-                                             size_t len);
+void z_view_keyexpr_from_substr_unchecked(struct z_view_keyexpr_t *this_,
+                                          const char *start,
+                                          size_t len);
 /**
  * Borrows `z_view_keyexpr_t`.
  */
@@ -3646,9 +3646,9 @@ ZENOHC_API void z_view_string_empty(struct z_view_string_t *this_);
  * @return -1 if `str == NULL` and `len > 0` (and creates a string in a gravestone state), 0 otherwise.
  */
 ZENOHC_API
-z_error_t z_view_string_from_substring(struct z_view_string_t *this_,
-                                       const char *str,
-                                       size_t len);
+z_error_t z_view_string_from_substr(struct z_view_string_t *this_,
+                                    const char *str,
+                                    size_t len);
 /**
  * Borrows view string.
  */
@@ -3696,17 +3696,17 @@ z_error_t zc_config_from_str(struct z_owned_config_t *this_,
  * Gets the property with the given path key from the configuration, and constructs and owned string from it.
  */
 ZENOHC_API
-z_error_t zc_config_get_from_string(const struct z_loaned_config_t *this_,
-                                    const char *key,
-                                    struct z_owned_string_t *out_value_string);
+z_error_t zc_config_get_from_str(const struct z_loaned_config_t *this_,
+                                 const char *key,
+                                 struct z_owned_string_t *out_value_string);
 /**
  * Gets the property with the given path key from the configuration, and constructs and owned string from it.
  */
 ZENOHC_API
-z_error_t zc_config_get_from_substring(const struct z_loaned_config_t *this_,
-                                       const char *key,
-                                       size_t key_len,
-                                       struct z_owned_string_t *out_value_string);
+z_error_t zc_config_get_from_substr(const struct z_loaned_config_t *this_,
+                                    const char *key,
+                                    size_t key_len,
+                                    struct z_owned_string_t *out_value_string);
 /**
  * Inserts a JSON-serialized `value` at the `key` position of the configuration.
  *
@@ -3722,11 +3722,11 @@ z_error_t zc_config_insert_json(struct z_loaned_config_t *this_,
  * Returns 0 if successful, a negative error code otherwise.
  */
 ZENOHC_API
-z_error_t zc_config_insert_json_from_substring(struct z_loaned_config_t *this_,
-                                               const char *key,
-                                               size_t key_len,
-                                               const char *value,
-                                               size_t value_len);
+z_error_t zc_config_insert_json_from_substr(struct z_loaned_config_t *this_,
+                                            const char *key,
+                                            size_t key_len,
+                                            const char *value,
+                                            size_t value_len);
 /**
  * Constructs a json string representation of the `config`, such as '{"mode":"client","connect":{"endpoints":["tcp/127.0.0.1:7447"]}}'.
  *

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -522,11 +522,11 @@ pub extern "C" fn z_view_string_loan(this: &z_view_string_t) -> &z_loaned_string
 /// @return -1 if `str == NULL` (and creates a string in a gravestone state), 0 otherwise.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_string_wrap(
+pub unsafe extern "C" fn z_string_from_str(
     this: &mut MaybeUninit<z_owned_string_t>,
     str: *const libc::c_char,
 ) -> z_error_t {
-    z_string_from_substring(this, str, strlen(str))
+    z_string_from_substr(this, str, strlen(str))
 }
 
 /// Constructs an owned string by copying a `str` substring of length `len`.
@@ -534,7 +534,7 @@ pub unsafe extern "C" fn z_string_wrap(
 /// @return -1 if `str == NULL` and `len > 0` (and creates a string in a gravestone state), 0 otherwise.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_string_from_substring(
+pub unsafe extern "C" fn z_string_from_substr(
     this: &mut MaybeUninit<z_owned_string_t>,
     str: *const libc::c_char,
     len: usize,
@@ -579,7 +579,7 @@ pub unsafe extern "C" fn z_view_string_wrap(
 /// @return -1 if `str == NULL` and `len > 0` (and creates a string in a gravestone state), 0 otherwise.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_view_string_from_substring(
+pub unsafe extern "C" fn z_view_string_from_substr(
     this: &mut MaybeUninit<z_view_string_t>,
     str: *const libc::c_char,
     len: usize,

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -30,7 +30,7 @@ use crate::z_id_t;
 use crate::z_loaned_bytes_t;
 use crate::z_loaned_keyexpr_t;
 use crate::z_owned_string_t;
-use crate::z_string_from_substring;
+use crate::z_string_from_substr;
 use libc::{c_char, c_ulong};
 use unwrap_infallible::UnwrapInfallible;
 use zenoh::core::Priority;
@@ -233,7 +233,7 @@ decl_c_type!(
 /// Constructs a `z_owned_encoding_t` from a specified substring.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_encoding_from_substring(
+pub unsafe extern "C" fn z_encoding_from_substr(
     this: &mut MaybeUninit<z_owned_encoding_t>,
     s: *const c_char,
     len: usize,
@@ -265,7 +265,7 @@ pub unsafe extern "C" fn z_encoding_from_str(
     this: &mut MaybeUninit<z_owned_encoding_t>,
     s: *const c_char,
 ) -> errors::z_error_t {
-    z_encoding_from_substring(this, s, libc::strlen(s))
+    z_encoding_from_substr(this, s, libc::strlen(s))
 }
 
 /// Constructs an owned non-null-terminated string from encoding
@@ -279,7 +279,7 @@ pub unsafe extern "C" fn z_encoding_to_string(
     out_str: &mut MaybeUninit<z_owned_string_t>,
 ) {
     let s: Cow<'static, str> = this.as_rust_type_ref().into();
-    z_string_from_substring(out_str, s.as_bytes().as_ptr() as _, s.as_bytes().len());
+    z_string_from_substr(out_str, s.as_bytes().as_ptr() as _, s.as_bytes().len());
 }
 
 /// Returns a loaned default `z_loaned_encoding_t`.

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -18,7 +18,7 @@ use crate::transmute::LoanedCTypeRef;
 use crate::transmute::RustTypeRef;
 use crate::transmute::RustTypeRefUninit;
 use crate::z_loaned_session_t;
-use crate::z_view_string_from_substring;
+use crate::z_view_string_from_substr;
 use crate::z_view_string_t;
 use libc::c_char;
 use std::error::Error;
@@ -96,7 +96,7 @@ unsafe fn keyexpr_create(
 /// not in canon form.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_keyexpr_from_string(
+pub unsafe extern "C" fn z_keyexpr_from_str(
     this: &mut MaybeUninit<z_owned_keyexpr_t>,
     expr: *const c_char,
 ) -> errors::z_error_t {
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn z_keyexpr_from_string(
     } else {
         libc::strlen(expr)
     };
-    z_keyexpr_from_substring(this, expr, len)
+    z_keyexpr_from_substr(this, expr, len)
 }
 
 /// Constructs `z_owned_keyexpr_t` from a string, copying the passed string. The copied string is canonized.
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn z_keyexpr_from_string(
 /// even despite canonization).
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_keyexpr_from_string_autocanonize(
+pub unsafe extern "C" fn z_keyexpr_from_str_autocanonize(
     this: &mut MaybeUninit<z_owned_keyexpr_t>,
     expr: *const c_char,
 ) -> z_error_t {
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn z_keyexpr_from_string_autocanonize(
     } else {
         libc::strlen(expr)
     };
-    z_keyexpr_from_substring_autocanonize(this, expr, &mut len)
+    z_keyexpr_from_substr_autocanonize(this, expr, &mut len)
 }
 
 /// Borrows `z_owned_keyexpr_t`.
@@ -227,7 +227,7 @@ pub unsafe extern "C" fn z_keyexpr_canonize(start: *mut c_char, len: &mut usize)
 /// @return 0 in case of success, negative error code otherwise.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_view_keyexpr_from_substring(
+pub unsafe extern "C" fn z_view_keyexpr_from_substr(
     this: &mut MaybeUninit<z_view_keyexpr_t>,
     expr: *const c_char,
     len: usize,
@@ -258,7 +258,7 @@ pub unsafe extern "C" fn z_view_keyexpr_from_substring(
 /// @return 0 in case of success, negative error code otherwise.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_keyexpr_from_substring(
+pub unsafe extern "C" fn z_keyexpr_from_substr(
     this: &mut MaybeUninit<z_owned_keyexpr_t>,
     expr: *const c_char,
     len: usize,
@@ -291,7 +291,7 @@ pub unsafe extern "C" fn z_keyexpr_from_substring(
 /// @return 0 in case of success, negative error code otherwise.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_view_keyexpr_from_substring_autocanonize(
+pub unsafe extern "C" fn z_view_keyexpr_from_substr_autocanonize(
     this: &mut MaybeUninit<z_view_keyexpr_t>,
     start: *mut c_char,
     len: &mut usize,
@@ -324,7 +324,7 @@ pub unsafe extern "C" fn z_view_keyexpr_from_substring_autocanonize(
 /// @return 0 in case of success, negative error code otherwise.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_keyexpr_from_substring_autocanonize(
+pub unsafe extern "C" fn z_keyexpr_from_substr_autocanonize(
     this: &mut MaybeUninit<z_owned_keyexpr_t>,
     start: *const c_char,
     len: &mut usize,
@@ -355,7 +355,7 @@ pub unsafe extern "C" fn z_keyexpr_from_substring_autocanonize(
 /// `expr` must outlive the constucted key expression.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_view_keyexpr_from_string(
+pub unsafe extern "C" fn z_view_keyexpr_from_str(
     this: &mut MaybeUninit<z_view_keyexpr_t>,
     expr: *const c_char,
 ) -> z_error_t {
@@ -368,7 +368,7 @@ pub unsafe extern "C" fn z_view_keyexpr_from_string(
         } else {
             libc::strlen(expr)
         };
-        z_view_keyexpr_from_substring(this, expr, len)
+        z_view_keyexpr_from_substr(this, expr, len)
     }
 }
 
@@ -378,7 +378,7 @@ pub unsafe extern "C" fn z_view_keyexpr_from_string(
 /// `expr` must outlive the constucted key expression.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_view_keyexpr_from_string_autocanonize(
+pub unsafe extern "C" fn z_view_keyexpr_from_str_autocanonize(
     this: &mut MaybeUninit<z_view_keyexpr_t>,
     expr: *mut c_char,
 ) -> z_error_t {
@@ -387,7 +387,7 @@ pub unsafe extern "C" fn z_view_keyexpr_from_string_autocanonize(
         errors::Z_EINVAL
     } else {
         let mut len = libc::strlen(expr);
-        let res = z_view_keyexpr_from_substring_autocanonize(this, expr, &mut len);
+        let res = z_view_keyexpr_from_substr_autocanonize(this, expr, &mut len);
         if res == errors::Z_OK {
             *expr.add(len) = 0;
         }
@@ -406,7 +406,7 @@ pub unsafe extern "C" fn z_view_keyexpr_from_string_autocanonize(
 /// `start` must outlive constructed key expression.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_view_keyexpr_from_substring_unchecked(
+pub unsafe extern "C" fn z_view_keyexpr_from_substr_unchecked(
     this: &mut MaybeUninit<z_view_keyexpr_t>,
     start: *const c_char,
     len: usize,
@@ -432,12 +432,12 @@ pub unsafe extern "C" fn z_view_keyexpr_from_substring_unchecked(
 /// `s` must outlive constructed key expression.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn z_view_keyexpr_from_string_unchecked(
+pub unsafe extern "C" fn z_view_keyexpr_from_str_unchecked(
     this: &mut MaybeUninit<z_view_keyexpr_t>,
     s: *const c_char,
 ) {
     let len = if s.is_null() { 0 } else { libc::strlen(s) };
-    z_view_keyexpr_from_substring_unchecked(this, s, len)
+    z_view_keyexpr_from_substr_unchecked(this, s, len)
 }
 
 /// Constructs a non-owned non-null-terminated string from key expression.
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn z_keyexpr_as_view_string(
 ) {
     let this = this.as_rust_type_ref();
     unsafe {
-        z_view_string_from_substring(
+        z_view_string_from_substr(
             out_string,
             this.as_bytes().as_ptr() as _,
             this.as_bytes().len(),

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -525,7 +525,7 @@ pub unsafe extern "C" fn z_bytes_serialize_from_slice_map_copy(
 /// Serializes a null-terminated string by aliasing.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_serialize_from_string(
+pub unsafe extern "C" fn z_bytes_serialize_from_str(
     this: &mut MaybeUninit<z_owned_bytes_t>,
     s: *const libc::c_char,
 ) {
@@ -535,7 +535,7 @@ pub unsafe extern "C" fn z_bytes_serialize_from_string(
 /// Serializes a null-terminated string by copying.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_serialize_from_string_copy(
+pub unsafe extern "C" fn z_bytes_serialize_from_str_copy(
     this: &mut MaybeUninit<z_owned_bytes_t>,
     s: *const libc::c_char,
 ) {

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -16,7 +16,7 @@ use crate::{
     errors, z_closure_query_call, z_closure_query_loan, z_congestion_control_t, z_loaned_bytes_t,
     z_loaned_encoding_t, z_loaned_keyexpr_t, z_loaned_session_t, z_owned_bytes_t,
     z_owned_closure_query_t, z_owned_encoding_t, z_owned_source_info_t, z_priority_t,
-    z_timestamp_t, z_view_string_from_substring, z_view_string_t,
+    z_timestamp_t, z_view_string_from_substr, z_view_string_t,
 };
 use std::mem::MaybeUninit;
 use std::ptr::null_mut;
@@ -430,7 +430,7 @@ pub unsafe extern "C" fn z_query_parameters(
 ) {
     let query = this.as_rust_type_ref();
     let params = query.parameters().as_str();
-    unsafe { z_view_string_from_substring(parameters, params.as_ptr() as _, params.len()) };
+    unsafe { z_view_string_from_substr(parameters, params.as_ptr() as _, params.len()) };
 }
 
 /// Gets query <a href="https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Query%20Payload.md">payload</a>.

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -64,7 +64,7 @@ void query_handler(const z_loaned_query_t *query, void *arg) {
     z_query_reply_options_default(&_ret_qreply_opt);
 
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_string(&payload, value);
+    z_bytes_serialize_from_str(&payload, value);
     z_query_reply(query, query_ke, z_move(payload), &_ret_qreply_opt);
 }
 
@@ -109,9 +109,9 @@ int main(int argc, char **argv) {
 #endif
 
     z_view_keyexpr_t key_demo_example, key_demo_example_a, key_demo_example_starstar;
-    z_view_keyexpr_from_string(&key_demo_example, "demo/example");
-    z_view_keyexpr_from_string(&key_demo_example_a, "demo/example/a");
-    z_view_keyexpr_from_string(&key_demo_example_starstar, "demo/example/**");
+    z_view_keyexpr_from_str(&key_demo_example, "demo/example");
+    z_view_keyexpr_from_str(&key_demo_example_a, "demo/example/a");
+    z_view_keyexpr_from_str(&key_demo_example_starstar, "demo/example/**");
     _Bool _ret_bool = z_view_keyexpr_check(&key_demo_example);
     assert(_ret_bool == true);
 
@@ -261,7 +261,7 @@ int main(int argc, char **argv) {
     z_subscriber_options_default(&_ret_sub_opt);
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr_str);
+    z_view_keyexpr_from_str(&ke, keyexpr_str);
     z_owned_subscriber_t _ret_sub;
     z_declare_subscriber(&_ret_sub, z_loan(s2), z_loan(ke), z_move(_ret_closure_sample), &_ret_sub_opt);
     assert(z_check(_ret_sub));
@@ -271,7 +271,7 @@ int main(int argc, char **argv) {
     char s1_res[64];
     sprintf(s1_res, "%s/chunk/%d", keyexpr_str, 1);
     z_view_keyexpr_t s1_key;
-    z_view_keyexpr_from_string(&s1_key, s1_res);
+    z_view_keyexpr_from_str(&s1_key, s1_res);
     z_owned_keyexpr_t _ret_expr;
     z_declare_keyexpr(&_ret_expr, z_loan(s1), z_loan(s1_key));
     assert(z_check(_ret_expr));
@@ -281,7 +281,7 @@ int main(int argc, char **argv) {
     // TODO: set encoding option
 
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_string(&payload, value);
+    z_bytes_serialize_from_str(&payload, value);
     _ret_int8 = z_put(z_loan(s1), z_loan(_ret_expr), z_move(payload), &_ret_put_opt);
     assert(_ret_int8 == 0);
 

--- a/tests/z_api_config_test.c
+++ b/tests/z_api_config_test.c
@@ -23,7 +23,7 @@ void config_client() {
     z_owned_config_t config;
     z_config_client(&config, peers, 3);
     z_owned_string_t endpoints;
-    zc_config_get_from_string(z_loan(config), "connect/endpoints", &endpoints);
+    zc_config_get_from_str(z_loan(config), "connect/endpoints", &endpoints);
     assert(strncmp(z_string_data(z_loan(endpoints)), "[\"tcp/127.0.0.1\",\"tcp/192.168.0.1\",\"tcp/10.0.0.1\"]",
                    z_string_len(z_loan(endpoints))) == 0);
     z_drop(z_move(endpoints));
@@ -34,7 +34,7 @@ void config_peer() {
     z_owned_config_t config;
     z_config_peer(&config);
     z_owned_string_t mode;
-    zc_config_get_from_string(z_loan(config), "mode", &mode);
+    zc_config_get_from_str(z_loan(config), "mode", &mode);
     assert(strncmp(z_string_data(z_loan(mode)), "\"peer\"", z_string_len(z_loan(mode))) == 0);
     z_drop(z_move(mode));
 }

--- a/tests/z_api_double_drop_test.c
+++ b/tests/z_api_double_drop_test.c
@@ -42,7 +42,7 @@ void test_publisher() {
     z_open(&s, z_move(config));
 
     z_owned_keyexpr_t keyexpr;
-    z_keyexpr_from_string(&keyexpr, URL);
+    z_keyexpr_from_str(&keyexpr, URL);
 
     z_owned_publisher_t pub;
     z_declare_publisher(&pub, z_loan(s), z_loan(keyexpr), NULL);
@@ -56,7 +56,7 @@ void test_publisher() {
 
 void test_keyexpr() {
     z_owned_keyexpr_t keyexpr;
-    z_keyexpr_from_string(&keyexpr, URL);
+    z_keyexpr_from_str(&keyexpr, URL);
 
     assert(z_check(keyexpr));
     z_drop(z_move(keyexpr));
@@ -86,7 +86,7 @@ void test_subscriber() {
     z_closure(&callback, data_handler, NULL, NULL);
 
     z_view_keyexpr_t keyexpr;
-    z_view_keyexpr_from_string(&keyexpr, URL);
+    z_view_keyexpr_from_str(&keyexpr, URL);
     z_owned_subscriber_t sub;
     z_declare_subscriber(&sub, z_loan(s), z_loan(keyexpr), z_move(callback), NULL);
     assert(z_check(sub));
@@ -108,7 +108,7 @@ void test_queryable() {
     z_closure(&callback, query_handler, NULL, NULL);
 
     z_view_keyexpr_t keyexpr;
-    z_view_keyexpr_from_string(&keyexpr, URL);
+    z_view_keyexpr_from_str(&keyexpr, URL);
     z_owned_queryable_t queryable;
     z_declare_queryable(&queryable, z_loan(s), z_loan(keyexpr), z_move(callback), NULL);
     assert(z_check(queryable));

--- a/tests/z_api_drop_options.c
+++ b/tests/z_api_drop_options.c
@@ -32,7 +32,7 @@ void put() {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, "zenoh/test_put");
+    z_view_keyexpr_from_str(&ke, "zenoh/test_put");
     z_put_options_t opts;
     z_put_options_default(&opts);
     z_owned_bytes_t payload, attachment;
@@ -56,7 +56,7 @@ void get() {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, "zenoh/test_get");
+    z_view_keyexpr_from_str(&ke, "zenoh/test_get");
     z_get_options_t opts;
     z_get_options_default(&opts);
     z_owned_bytes_t payload, attachment;

--- a/tests/z_api_keyexpr_drop_test.c
+++ b/tests/z_api_keyexpr_drop_test.c
@@ -29,11 +29,11 @@ void test_publisher() {
     char keyexpr[256];
     strncpy(keyexpr, "foo/bar", 256);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     z_owned_publisher_t pub;
     z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL);
     strncpy(keyexpr, "baz/quax", 256);  // Update source string to ensure that the keyexpr is copied into publisher
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     const z_loaned_keyexpr_t *pub_ke = z_publisher_keyexpr(z_loan(pub));
     z_view_string_t pub_keyexpr;
     z_keyexpr_as_view_string(pub_ke, &pub_keyexpr);
@@ -55,11 +55,11 @@ void test_subscriber() {
     char keyexpr[256];
     strncpy(keyexpr, "foo/bar", 256);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     z_owned_subscriber_t sub;
     z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL);
     strncpy(keyexpr, "baz/quax", 256);  // Update source string to ensure that the keyexpr is copied into the subscriber
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     const z_loaned_keyexpr_t *sub_ke = z_subscriber_keyexpr(z_loan(sub));
     z_view_string_t sub_keyexpr;
     z_keyexpr_as_view_string(sub_ke, &sub_keyexpr);

--- a/tests/z_api_keyexpr_test.c
+++ b/tests/z_api_keyexpr_test.c
@@ -44,7 +44,7 @@ void canonize() {
 
     strcpy(keyexpr, "a/**/**/c");
     z_view_keyexpr_t key_expr_canonized;
-    z_view_keyexpr_from_string_autocanonize(&key_expr_canonized, keyexpr);
+    z_view_keyexpr_from_str_autocanonize(&key_expr_canonized, keyexpr);
     assert(z_view_keyexpr_check(&key_expr_canonized) == true);
     assert(strcmp(keyexpr, "a/**/c") == 0);
     z_view_string_t key_exp_canonized_bytes;
@@ -54,7 +54,7 @@ void canonize() {
 
     strcpy(keyexpr, "a/**/**/c");
     len_new = len_old;
-    int8_t res = z_view_keyexpr_from_substring_autocanonize(&key_expr_canonized, keyexpr, &len_new);
+    int8_t res = z_view_keyexpr_from_substr_autocanonize(&key_expr_canonized, keyexpr, &len_new);
     assert(res == 0);
     assert(len_new == len_old - 3);
     assert(strncmp(keyexpr, "a/**/c", len_new) == 0);
@@ -65,8 +65,8 @@ void canonize() {
 
 void includes() {
     z_view_keyexpr_t foobar, foostar;
-    z_view_keyexpr_from_string(&foobar, "foo/bar");
-    z_view_keyexpr_from_string(&foostar, "foo/*");
+    z_view_keyexpr_from_str(&foobar, "foo/bar");
+    z_view_keyexpr_from_str(&foostar, "foo/*");
 
     assert(z_keyexpr_includes(z_loan(foostar), z_loan(foobar)) == true);
     assert(z_keyexpr_includes(z_loan(foobar), z_loan(foostar)) == false);
@@ -74,9 +74,9 @@ void includes() {
 
 void intersects() {
     z_view_keyexpr_t foobar, foostar, barstar;
-    z_view_keyexpr_from_string(&foobar, "foo/bar");
-    z_view_keyexpr_from_string(&foostar, "foo/*");
-    z_view_keyexpr_from_string(&barstar, "bar/*");
+    z_view_keyexpr_from_str(&foobar, "foo/bar");
+    z_view_keyexpr_from_str(&foostar, "foo/*");
+    z_view_keyexpr_from_str(&barstar, "bar/*");
 
     assert(z_keyexpr_intersects(z_loan(foostar), z_loan(foobar)) == true);
     assert(z_keyexpr_intersects(z_loan(barstar), z_loan(foobar)) == false);
@@ -89,7 +89,7 @@ void undeclare() {
     z_open(&s, z_move(config));
 
     z_view_keyexpr_t view_ke;
-    z_view_keyexpr_from_string(&view_ke, "test/thr");
+    z_view_keyexpr_from_str(&view_ke, "test/thr");
     z_owned_keyexpr_t ke;
     z_declare_keyexpr(&ke, z_loan(s), z_loan(view_ke));
     assert(z_keyexpr_check(&ke));
@@ -99,9 +99,9 @@ void undeclare() {
 
 void relation_to() {
     z_view_keyexpr_t foobar, foostar, barstar;
-    z_view_keyexpr_from_string(&foobar, "foo/bar");
-    z_view_keyexpr_from_string(&foostar, "foo/*");
-    z_view_keyexpr_from_string(&barstar, "bar/*");
+    z_view_keyexpr_from_str(&foobar, "foo/bar");
+    z_view_keyexpr_from_str(&foostar, "foo/*");
+    z_view_keyexpr_from_str(&barstar, "bar/*");
 
     assert(z_keyexpr_relation_to(z_loan(foostar), z_loan(foobar)) == Z_KEYEXPR_INTERSECTION_LEVEL_INCLUDES);
     assert(z_keyexpr_relation_to(z_loan(foobar), z_loan(foostar)) == Z_KEYEXPR_INTERSECTION_LEVEL_INTERSECTS);

--- a/tests/z_api_liveliness.c
+++ b/tests/z_api_liveliness.c
@@ -59,9 +59,9 @@ void test_liveliness_sub() {
     z_config_default(&c1);
     z_config_default(&c2);
     z_view_keyexpr_t k, k1, k2;
-    z_view_keyexpr_from_string(&k, expr);
-    z_view_keyexpr_from_string(&k1, token1_expr);
-    z_view_keyexpr_from_string(&k2, token2_expr);
+    z_view_keyexpr_from_str(&k, expr);
+    z_view_keyexpr_from_str(&k1, token1_expr);
+    z_view_keyexpr_from_str(&k2, token2_expr);
 
     z_open(&s1, z_move(c1));
     z_open(&s2, z_move(c2));
@@ -102,8 +102,8 @@ void test_liveliness_get() {
     z_config_default(&c1);
     z_config_default(&c2);
     z_view_keyexpr_t k, k1;
-    z_view_keyexpr_from_string(&k, expr);
-    z_view_keyexpr_from_string(&k1, token1_expr);
+    z_view_keyexpr_from_str(&k, expr);
+    z_view_keyexpr_from_str(&k1, token1_expr);
 
     z_open(&s1, z_move(c1));
     z_open(&s2, z_move(c2));

--- a/tests/z_api_unitinialized_check.c
+++ b/tests/z_api_unitinialized_check.c
@@ -23,18 +23,18 @@
 
 int main(int argc, char **argv) {
     z_owned_keyexpr_t owned_keyexpr;
-    assert(z_keyexpr_from_string(&owned_keyexpr, NULL) == Z_EINVAL);
+    assert(z_keyexpr_from_str(&owned_keyexpr, NULL) == Z_EINVAL);
     assert(!z_check(owned_keyexpr));
-    assert(z_keyexpr_from_string_autocanonize(&owned_keyexpr, NULL) == Z_EINVAL);
+    assert(z_keyexpr_from_str_autocanonize(&owned_keyexpr, NULL) == Z_EINVAL);
     assert(!z_check(owned_keyexpr));
 
     assert(z_keyexpr_canonize_null_terminated(NULL) == Z_EINVAL);
 
     z_view_keyexpr_t keyexpr;
-    assert(z_view_keyexpr_from_string(&keyexpr, NULL) == Z_EINVAL);
+    assert(z_view_keyexpr_from_str(&keyexpr, NULL) == Z_EINVAL);
     assert(!z_check(keyexpr));
-    z_view_keyexpr_from_string_unchecked(&keyexpr, NULL);
+    z_view_keyexpr_from_str_unchecked(&keyexpr, NULL);
     assert(!z_check(keyexpr));
-    z_view_keyexpr_from_substring_unchecked(&keyexpr, NULL, 0);
+    z_view_keyexpr_from_substr_unchecked(&keyexpr, NULL, 0);
     assert(!z_check(keyexpr));
 }

--- a/tests/z_int_pub_cache_query_sub_test.c
+++ b/tests/z_int_pub_cache_query_sub_test.c
@@ -49,7 +49,7 @@ int run_publisher() {
     pub_cache_opts.history = 42;
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     ze_owned_publication_cache_t pub_cache;
     ;
     if (ze_declare_publication_cache(&pub_cache, z_loan(s), z_loan(ke), &pub_cache_opts) < 0) {
@@ -66,7 +66,7 @@ int run_publisher() {
     // values for cache
     for (int i = 0; i < values_count / 2; ++i) {
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, values[i]);
+        z_bytes_serialize_from_str(&payload, values[i]);
         z_put(z_loan(s), z_loan(ke), z_move(payload), NULL);
     }
 
@@ -77,7 +77,7 @@ int run_publisher() {
     // values for subscribe
     for (int i = values_count / 2; i < values_count; ++i) {
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, values[i]);
+        z_bytes_serialize_from_str(&payload, values[i]);
         z_put(z_loan(s), z_loan(ke), z_move(payload), NULL);
     }
 
@@ -129,7 +129,7 @@ int run_subscriber() {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
 
     z_owned_closure_sample_t callback;
     z_closure(&callback, data_handler, NULL, NULL);

--- a/tests/z_int_pub_sub_attachment_test.c
+++ b/tests/z_int_pub_sub_attachment_test.c
@@ -44,8 +44,8 @@ bool create_attachement_it(z_owned_bytes_t *kv_pair, void *context) {
     if (ctx->iteration_index >= ctx->num_items) {
         return false;
     } else {
-        z_bytes_serialize_from_string(&k, ctx->keys[ctx->iteration_index]);
-        z_bytes_serialize_from_string(&v, ctx->values[ctx->iteration_index]);
+        z_bytes_serialize_from_str(&k, ctx->keys[ctx->iteration_index]);
+        z_bytes_serialize_from_str(&v, ctx->values[ctx->iteration_index]);
     }
 
     z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
@@ -98,7 +98,7 @@ int run_publisher() {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     z_owned_publisher_t pub;
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         perror("Unable to declare Publisher for key expression!");
@@ -175,7 +175,7 @@ int run_subscriber() {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
 
     z_owned_closure_sample_t callback;
     z_closure(&callback, data_handler, NULL, NULL);

--- a/tests/z_int_pub_sub_test.c
+++ b/tests/z_int_pub_sub_test.c
@@ -45,7 +45,7 @@ int run_publisher() {
     z_id_t self_id = z_info_zid(z_loan(s));
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     z_publisher_options_t publisher_options;
     z_publisher_options_default(&publisher_options);
     publisher_options.priority = Z_PRIORITY_DATA;
@@ -72,7 +72,7 @@ int run_publisher() {
         options.timestamp = &ts;
 
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, values[i]);
+        z_bytes_serialize_from_str(&payload, values[i]);
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
 
@@ -157,7 +157,7 @@ int run_subscriber() {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
 
     z_owned_closure_sample_t callback;
     z_closure(&callback, data_handler, NULL, NULL);

--- a/tests/z_int_queryable_attachment_test.c
+++ b/tests/z_int_queryable_attachment_test.c
@@ -42,8 +42,8 @@ bool create_attachement_it(z_owned_bytes_t *kv_pair, void *context) {
     if (ctx->iteration_index >= ctx->num_items) {
         return false;
     } else {
-        z_bytes_serialize_from_string(&k, ctx->keys[ctx->iteration_index]);
-        z_bytes_serialize_from_string(&v, ctx->values[ctx->iteration_index]);
+        z_bytes_serialize_from_str(&k, ctx->keys[ctx->iteration_index]);
+        z_bytes_serialize_from_str(&v, ctx->values[ctx->iteration_index]);
     }
 
     z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
@@ -114,10 +114,10 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     options.attachment = &reply_attachment;
 
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_string(&payload, values[value_num]);
+    z_bytes_serialize_from_str(&payload, values[value_num]);
 
     z_view_keyexpr_t reply_ke;
-    z_view_keyexpr_from_string(&reply_ke, (const char *)context);
+    z_view_keyexpr_from_str(&reply_ke, (const char *)context);
     z_query_reply(query, z_loan(reply_ke), z_move(payload), &options);
 
     if (++value_num == values_count) {
@@ -138,7 +138,7 @@ int run_queryable() {
     z_closure(&callback, query_handler, NULL, keyexpr);
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
 
     z_owned_queryable_t qable;
     if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
@@ -166,7 +166,7 @@ int run_get() {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
 
     z_get_options_t opts;
     z_get_options_default(&opts);

--- a/tests/z_int_queryable_test.c
+++ b/tests/z_int_queryable_test.c
@@ -54,10 +54,10 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     options.timestamp = &ts;
 
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_string(&payload, values[value_num]);
+    z_bytes_serialize_from_str(&payload, values[value_num]);
 
     z_view_keyexpr_t reply_ke;
-    z_view_keyexpr_from_string(&reply_ke, (const char *)context);
+    z_view_keyexpr_from_str(&reply_ke, (const char *)context);
     z_query_reply(query, z_loan(reply_ke), z_move(payload), &options);
 
     if (++value_num == values_count) {
@@ -75,7 +75,7 @@ int run_queryable() {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     z_owned_closure_query_t callback;
     z_closure(&callback, query_handler, NULL, keyexpr);
     z_owned_queryable_t qable;
@@ -105,7 +105,7 @@ int run_get() {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
 
     for (int val_num = 0; val_num < values_count; ++val_num) {
         z_owned_fifo_handler_reply_t handler;


### PR DESCRIPTION
- z_view_keyexpr_from_string -> z_view_keyexpr_from_str
- z_view_keyexpr_from_string_autocanonize -> z_view_keyexpr_from_str_autocanonize
- z_view_keyexpr_from_string_unchecked -> z_view_keyexpr_from_str_unchecked
- z_view_keyexpr_from_substring -> z_view_keyexpr_from_substr
- z_view_keyexpr_from_substring_autocanonize -> z_view_keyexpr_from_substr_autocanonize
- z_view_keyexpr_from_substring_unchecked -> z_view_keyexpr_from_substr_unchecked
- z_bytes_serialize_from_string -> z_bytes_serialize_from_str
- z_encoding_from_substring -> z_encoding_from_substr
- z_keyexpr_from_string - > z_keyexpr_from_str
- z_keyexpr_from_string_autocanonize -> z_keyexpr_from_str_autocanonize
- z_keyexpr_from_substring -> z_keyexpr_from_sub
- z_keyexpr_from_substring_autocanonize -> z_keyexpr_from_sub_autocanonize
- z_string_wrap -> z_string_from_str
- z_view_string_from_substring -> z_view_string_from_substr
- zc_config_get_from_string -> zc_config_get_from_str
- zc_config_get_from_substring -> zc_config_get_from_substr

Closes:
https://github.com/eclipse-zenoh/zenoh-c/issues/484
https://github.com/eclipse-zenoh/zenoh-c/issues/452
https://github.com/eclipse-zenoh/zenoh-c/issues/475 (partially)