### PR TITLE
fix string-related function names in docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -57,23 +57,23 @@ Types
 
 Functions
 ^^^^^^^^^
-.. doxygenfunction:: z_str_check
+.. doxygenfunction:: z_string_check
 .. doxygenfunction:: z_view_str_check
-.. doxygenfunction:: z_str_null
+.. doxygenfunction:: z_string_null
 .. doxygenfunction:: z_view_str_null
-.. doxygenfunction:: z_str_loan
+.. doxygenfunction:: z_string_loan
 .. doxygenfunction:: z_view_str_loan
-.. doxygenfunction:: z_str_drop
+.. doxygenfunction:: z_string_drop
 
-.. doxygenfunction:: z_str_empty
+.. doxygenfunction:: z_string_empty
 .. doxygenfunction:: z_view_str_empty
 
-.. doxygenfunction:: z_str_wrap
+.. doxygenfunction:: z_string_wrap
 .. doxygenfunction:: z_view_str_wrap
-.. doxygenfunction:: z_str_from_substr
-.. doxygenfunction:: z_str_data
-.. doxygenfunction:: z_str_len
-.. doxygenfunction:: z_str_is_empty
+.. doxygenfunction:: z_string_from_substr
+.. doxygenfunction:: z_string_data
+.. doxygenfunction:: z_string_len
+.. doxygenfunction:: z_string_is_empty
 
 Slice map
 ---------
@@ -107,16 +107,16 @@ Types
 
 Functions
 ^^^^^^^^^
-.. doxygenfunction:: z_str_array_check
-.. doxygenfunction:: z_str_array_null
-.. doxygenfunction:: z_str_array_drop
-.. doxygenfunction:: z_str_array_loan
-.. doxygenfunction:: z_str_array_loan_mut
+.. doxygenfunction:: z_string_array_check
+.. doxygenfunction:: z_string_array_null
+.. doxygenfunction:: z_string_array_drop
+.. doxygenfunction:: z_string_array_loan
+.. doxygenfunction:: z_string_array_loan_mut
 
-.. doxygenfunction:: z_str_array_new
-.. doxygenfunction:: z_str_array_get
-.. doxygenfunction:: z_str_array_len
-.. doxygenfunction:: z_str_array_is_empty
+.. doxygenfunction:: z_string_array_new
+.. doxygenfunction:: z_string_array_get
+.. doxygenfunction:: z_string_array_len
+.. doxygenfunction:: z_string_array_is_empty
 
 Common
 ======

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -70,7 +70,7 @@ Functions
 
 .. doxygenfunction:: z_str_wrap
 .. doxygenfunction:: z_view_str_wrap
-.. doxygenfunction:: z_str_from_substring
+.. doxygenfunction:: z_str_from_substr
 .. doxygenfunction:: z_str_data
 .. doxygenfunction:: z_str_len
 .. doxygenfunction:: z_str_is_empty
@@ -210,11 +210,11 @@ Functions
 .. doxygenfunction:: z_view_keyexpr_from_string_autocanonize
 .. doxygenfunction:: z_view_keyexpr_from_string_unchecked
 
-.. doxygenfunction:: z_keyexpr_from_substring
-.. doxygenfunction:: z_view_keyexpr_from_substring
-.. doxygenfunction:: z_keyexpr_from_substring_autocanonize
-.. doxygenfunction:: z_view_keyexpr_from_substring_autocanonize
-.. doxygenfunction:: z_view_keyexpr_from_substring_unchecked
+.. doxygenfunction:: z_keyexpr_from_substr
+.. doxygenfunction:: z_view_keyexpr_from_substr
+.. doxygenfunction:: z_keyexpr_from_substr_autocanonize
+.. doxygenfunction:: z_view_keyexpr_from_substr_autocanonize
+.. doxygenfunction:: z_view_keyexpr_from_substr_unchecked
 
 .. doxygenfunction:: z_keyexpr_loan
 .. doxygenfunction:: z_view_keyexpr_loan
@@ -253,7 +253,7 @@ Functions
 
 .. doxygenfunction:: z_encoding_loan_default
 .. doxygenfunction:: z_encoding_from_str
-.. doxygenfunction:: z_encoding_from_substring
+.. doxygenfunction:: z_encoding_from_substr
 .. doxygenfunction:: z_encoding_to_string
 
 Value

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -58,8 +58,8 @@ Subscribe
       z_owned_string_t payload_string;
       z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_string);
       printf(">> Received (%.*s, %.*s)\n", 
-          (int)z_str_len(z_loan(key_string)), z_str_data(z_loan(key_string)), 
-          (int)z_str_len(z_loan(payload_string)), z_str_data(z_loan(payload_string))
+          (int)z_string_len(z_loan(key_string)), z_string_data(z_loan(key_string)), 
+          (int)z_string_len(z_loan(payload_string)), z_string_data(z_loan(payload_string))
       );
 
       z_drop(z_move(payload_string));
@@ -131,8 +131,8 @@ Query
               z_owned_string_t payload_string;
               z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_string);
               printf(">> Received (%.*s, %.*s)\n",
-                  (int)z_str_len(z_loan(key_string)), z_str_data(z_loan(key_string)),
-                  (int)z_str_len(z_loan(payload_string)), z_str_data(z_loan(payload_string))
+                  (int)z_string_len(z_loan(key_string)), z_string_data(z_loan(key_string)),
+                  (int)z_string_len(z_loan(payload_string)), z_string_data(z_loan(payload_string))
               );
               z_drop(z_move(payload_string));
           }
@@ -163,11 +163,11 @@ Queryable
           z_bytes_deserialize_into_string(payload, &payload_string);
 
           printf(">> [Queryable ] Received Query '%.*s' with value '%.*s'\n", 
-              (int)z_str_len(z_loan(key_string)), z_str_data(z_loan(key_string)),
-              (int)z_str_len(z_loan(payload_string)), z_str_data(z_loan(payload_string)));
+              (int)z_string_len(z_loan(key_string)), z_string_data(z_loan(key_string)),
+              (int)z_string_len(z_loan(payload_string)), z_string_data(z_loan(payload_string)));
           z_drop(z_move(payload_string));
       } else {
-          printf(">> [Queryable ] Received Query '%s'\n", z_str_data(z_loan(key_string)));
+          printf(">> [Queryable ] Received Query '%s'\n", z_string_data(z_loan(key_string)));
       }
 
       z_owned_bytes_t reply_payload;


### PR DESCRIPTION
fix string-related function names in docs