### PR TITLE
change order of arguments for ..._clone methods to that of zenoh-pico

### DIFF
--- a/examples/z_pong.c
+++ b/examples/z_pong.c
@@ -7,7 +7,7 @@ void callback(const z_loaned_sample_t* sample, void* context) {
     const z_loaned_publisher_t* pub = z_loan(*(z_owned_publisher_t*)context);
 #ifdef ZENOH_C  // The z_owned_bytes_t API is exclusive to zenoh-c, but allows avoiding some copies.
     z_owned_bytes_t payload;
-    z_bytes_clone(z_sample_payload(sample), &payload);
+    z_bytes_clone(&payload, z_sample_payload(sample));
     z_publisher_put(pub, z_move(payload), NULL);
 #endif
 }

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1009,7 +1009,7 @@ ZENOHC_API bool z_bytes_check(const struct z_owned_bytes_t *this_);
 /**
  * Constructs an owned shallow copy of data in provided uninitialized memory location.
  */
-ZENOHC_API void z_bytes_clone(const struct z_loaned_bytes_t *this_, struct z_owned_bytes_t *dst);
+ZENOHC_API void z_bytes_clone(struct z_owned_bytes_t *dst, const struct z_loaned_bytes_t *this_);
 /**
  * Deserializes into a signed integer.
  * @return 0 in case of success, negative error code otherwise.
@@ -1643,7 +1643,7 @@ z_error_t z_config_client(struct z_owned_config_t *this_,
 /**
  * Clones the config into provided uninitialized memory location.
  */
-ZENOHC_API void z_config_clone(const struct z_loaned_config_t *this_, struct z_owned_config_t *dst);
+ZENOHC_API void z_config_clone(struct z_owned_config_t *dst, const struct z_loaned_config_t *this_);
 /**
  * Constructs a new empty configuration.
  */
@@ -2362,8 +2362,8 @@ ZENOHC_API bool z_query_check(const struct z_owned_query_t *query);
  * This operation is infallible, but may return a gravestone value if `query` itself was a gravestone value (which cannot be the case in a callback).
  */
 ZENOHC_API
-void z_query_clone(const struct z_loaned_query_t *this_,
-                   struct z_owned_query_t *dst);
+void z_query_clone(struct z_owned_query_t *dst,
+                   const struct z_loaned_query_t *this_);
 /**
  * Automatic query consolidation strategy selection.
  *
@@ -2553,7 +2553,7 @@ ZENOHC_API bool z_reply_check(const struct z_owned_reply_t *this_);
 /**
  * Constructs an owned shallow copy of reply in provided uninitialized memory location.
  */
-ZENOHC_API void z_reply_clone(const struct z_loaned_reply_t *this_, struct z_owned_reply_t *dst);
+ZENOHC_API void z_reply_clone(struct z_owned_reply_t *dst, const struct z_loaned_reply_t *this_);
 /**
  * Frees reply, resetting it to its gravestone state.
  */
@@ -2747,8 +2747,8 @@ ZENOHC_API bool z_sample_check(const struct z_owned_sample_t *this_);
  * Constructs an owned shallow copy of the sample (i.e. all modficiations applied to the copy, might be visible in the original) in provided uninitilized memory location.
  */
 ZENOHC_API
-void z_sample_clone(const struct z_loaned_sample_t *this_,
-                    struct z_owned_sample_t *dst);
+void z_sample_clone(struct z_owned_sample_t *dst,
+                    const struct z_loaned_sample_t *this_);
 /**
  * Returns sample qos congestion control value.
  */
@@ -2908,7 +2908,7 @@ ZENOHC_API void z_shm_client_storage_null(z_owned_shm_client_storage_t *this_);
  * Converts borrowed ZShm slice to owned ZShm slice by performing a shallow SHM reference copy
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_clone(const z_loaned_shm_t *this_, z_owned_shm_t *out);
+ZENOHC_API void z_shm_clone(z_owned_shm_t *out, const z_loaned_shm_t *this_);
 #endif
 /**
  * @return the pointer of the ZShm slice
@@ -3131,7 +3131,7 @@ ZENOHC_API bool z_slice_check(const struct z_owned_slice_t *this_);
 /**
  * Constructs an owned copy of a slice.
  */
-ZENOHC_API void z_slice_clone(const struct z_loaned_slice_t *this_, struct z_owned_slice_t *dst);
+ZENOHC_API void z_slice_clone(struct z_owned_slice_t *dst, const struct z_loaned_slice_t *this_);
 /**
  * @return the pointer to the slice data.
  */
@@ -3344,7 +3344,7 @@ ZENOHC_API bool z_string_check(const struct z_owned_string_t *this_);
 /**
  * Constructs an owned copy of a string.
  */
-ZENOHC_API void z_string_clone(const struct z_loaned_string_t *this_, struct z_owned_string_t *dst);
+ZENOHC_API void z_string_clone(struct z_owned_string_t *dst, const struct z_loaned_string_t *this_);
 /**
  * @return the pointer of the string data.
  */
@@ -3827,8 +3827,8 @@ ZENOHC_API z_error_t zc_liveliness_undeclare_token(struct zc_owned_liveliness_to
  * Constructs an owned shallow copy of the session in provided uninitialized memory location.
  */
 ZENOHC_API
-void zc_session_clone(const struct z_loaned_session_t *this_,
-                      struct z_owned_session_t *dst);
+void zc_session_clone(struct z_owned_session_t *dst,
+                      const struct z_loaned_session_t *this_);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_error_t zc_shm_client_list_add_client(z_protocol_id_t id,

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -343,7 +343,7 @@ pub extern "C" fn z_slice_loan(this: &z_owned_slice_t) -> &z_loaned_slice_t {
 
 /// Constructs an owned copy of a slice.
 #[no_mangle]
-pub extern "C" fn z_slice_clone(this: &z_loaned_slice_t, dst: &mut MaybeUninit<z_owned_slice_t>) {
+pub extern "C" fn z_slice_clone(dst: &mut MaybeUninit<z_owned_slice_t>, this: &z_loaned_slice_t) {
     dst.as_rust_type_mut_uninit()
         .write(this.as_rust_type_ref().clone_to_owned());
 }
@@ -612,8 +612,8 @@ pub extern "C" fn z_string_data(this: &z_loaned_string_t) -> *const libc::c_char
 /// Constructs an owned copy of a string.
 #[no_mangle]
 pub extern "C" fn z_string_clone(
-    this: &z_loaned_string_t,
     dst: &mut MaybeUninit<z_owned_string_t>,
+    this: &z_loaned_string_t,
 ) {
     let slice = this.as_rust_type_ref().clone_to_owned();
     dst.as_rust_type_mut_uninit()

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -169,8 +169,8 @@ pub extern "C" fn z_sample_source_info(this: &z_loaned_sample_t) -> &z_loaned_so
 /// Constructs an owned shallow copy of the sample (i.e. all modficiations applied to the copy, might be visible in the original) in provided uninitilized memory location.
 #[no_mangle]
 pub extern "C" fn z_sample_clone(
-    this: &z_loaned_sample_t,
     dst: &mut MaybeUninit<z_owned_sample_t>,
+    this: &z_loaned_sample_t,
 ) {
     dst.as_rust_type_mut_uninit()
         .write(Some(this.as_rust_type_ref().clone()));

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,8 +101,8 @@ pub extern "C" fn z_config_null(this: &mut MaybeUninit<z_owned_config_t>) {
 /// Clones the config into provided uninitialized memory location.
 #[no_mangle]
 pub extern "C" fn z_config_clone(
-    this: &z_loaned_config_t,
     dst: &mut MaybeUninit<z_owned_config_t>,
+    this: &z_loaned_config_t,
 ) {
     let src = Some(this.as_rust_type_ref().clone());
     let dst = dst.as_rust_type_mut_uninit();

--- a/src/get.rs
+++ b/src/get.rs
@@ -183,7 +183,7 @@ pub extern "C" fn z_reply_null(this: &mut MaybeUninit<z_owned_reply_t>) {
 }
 /// Constructs an owned shallow copy of reply in provided uninitialized memory location.
 #[no_mangle]
-pub extern "C" fn z_reply_clone(this: &z_loaned_reply_t, dst: &mut MaybeUninit<z_owned_reply_t>) {
+pub extern "C" fn z_reply_clone(dst: &mut MaybeUninit<z_owned_reply_t>, this: &z_loaned_reply_t) {
     dst.as_rust_type_mut_uninit()
         .write(Some(this.as_rust_type_ref().clone()));
 }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -87,7 +87,7 @@ extern "C" fn z_bytes_is_empty(this: &z_loaned_bytes_t) -> bool {
 
 /// Constructs an owned shallow copy of data in provided uninitialized memory location.
 #[no_mangle]
-extern "C" fn z_bytes_clone(this: &z_loaned_bytes_t, dst: &mut MaybeUninit<z_owned_bytes_t>) {
+extern "C" fn z_bytes_clone(dst: &mut MaybeUninit<z_owned_bytes_t>, this: &z_loaned_bytes_t) {
     dst.as_rust_type_mut_uninit()
         .write(this.as_rust_type_ref().clone());
 }

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -89,7 +89,7 @@ pub extern "C" fn z_query_drop(this: &mut z_owned_query_t) {
 ///
 /// This operation is infallible, but may return a gravestone value if `query` itself was a gravestone value (which cannot be the case in a callback).
 #[no_mangle]
-pub extern "C" fn z_query_clone(this: &z_loaned_query_t, dst: &mut MaybeUninit<z_owned_query_t>) {
+pub extern "C" fn z_query_clone(dst: &mut MaybeUninit<z_owned_query_t>, this: &z_loaned_query_t) {
     dst.as_rust_type_mut_uninit()
         .write(Some(this.as_rust_type_ref().clone()));
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -157,8 +157,8 @@ pub extern "C" fn z_session_drop(this: &mut z_owned_session_t) {
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub extern "C" fn zc_session_clone(
-    this: &z_loaned_session_t,
     dst: &mut MaybeUninit<z_owned_session_t>,
+    this: &z_loaned_session_t,
 ) {
     dst.as_rust_type_mut_uninit()
         .write(Some(this.as_rust_type_ref().clone()));

--- a/src/shm/buffer/zshm.rs
+++ b/src/shm/buffer/zshm.rs
@@ -53,7 +53,7 @@ pub extern "C" fn z_shm_check(this: &z_owned_shm_t) -> bool {
 
 /// Converts borrowed ZShm slice to owned ZShm slice by performing a shallow SHM reference copy
 #[no_mangle]
-pub extern "C" fn z_shm_clone(this: &z_loaned_shm_t, out: &mut MaybeUninit<z_owned_shm_t>) {
+pub extern "C" fn z_shm_clone(out: &mut MaybeUninit<z_owned_shm_t>, this: &z_loaned_shm_t) {
     let this = this.as_rust_type_ref();
     let copy = this.to_owned();
     out.as_rust_type_mut_uninit().write(Some(copy));

--- a/tests/z_api_shm_test.c
+++ b/tests/z_api_shm_test.c
@@ -63,7 +63,7 @@ int test_shm_buffer(z_owned_shm_mut_t* buf) {
     }
 
     z_owned_shm_t immut2;
-    z_shm_clone(z_loan(immut), &immut2);
+    z_shm_clone(&immut2, z_loan(immut));
     ASSERT_CHECK(immut2);
 
     z_owned_shm_mut_t mut;


### PR DESCRIPTION
change order of arguments for ..._clone methods to that of zenoh-pico