### PR TITLE
Encoding alignment with Zenoh-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3617,8 +3617,6 @@ dependencies = [
  "unwrap-infallible",
  "zenoh",
  "zenoh-ext",
- "zenoh-protocol",
- "zenoh-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ build = "build.rs"
 
 [features]
 logger-autoinit = []
-shared-memory = ["zenoh/shared-memory", "zenoh-ext/shared-memory", "zenoh-protocol/shared-memory"]
+shared-memory = ["zenoh/shared-memory", "zenoh-ext/shared-memory"]
 unstable = ["zenoh/unstable", "zenoh-ext/unstable"]
 default = ["zenoh/default"]
 
@@ -53,8 +53,6 @@ spin = "0.9.5"
 unwrap-infallible = "0.1.5"
 const_format = "0.2.32"
 zenoh = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0", default-features = false }
-zenoh-protocol = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0" }
-zenoh-util = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0" }
 zenoh-ext = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0" }
 flume = "*"
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -227,6 +227,8 @@ Functions
 .. doxygenfunction:: z_encoding_check
 .. doxygenfunction:: z_encoding_drop
 
+.. doxygenfunction:: z_encoding_drop
+
 .. doxygenfunction:: z_encoding_loan_default
 .. doxygenfunction:: z_encoding_from_str
 .. doxygenfunction:: z_encoding_from_substr

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -75,7 +75,7 @@ Functions
 .. doxygenfunction:: z_string_len
 .. doxygenfunction:: z_string_is_empty
 
-string array
+String Array
 -----------
 Types
 ^^^^^
@@ -223,13 +223,85 @@ Functions
 ^^^^^^^^^
 .. doxygenfunction:: z_encoding_null
 .. doxygenfunction:: z_encoding_loan
+.. doxygenfunction:: z_encoding_loan_mut
 .. doxygenfunction:: z_encoding_check
 .. doxygenfunction:: z_encoding_drop
 
 .. doxygenfunction:: z_encoding_loan_default
 .. doxygenfunction:: z_encoding_from_str
 .. doxygenfunction:: z_encoding_from_substr
+.. doxygenfunction:: z_encoding_set_schema_from_str
+.. doxygenfunction:: z_encoding_set_schema_from_substr
 .. doxygenfunction:: z_encoding_to_string
+
+Predefined Encodings
+^^^^^^^^^^^^^^^^^^^^
+.. doxygenfunction:: z_encoding_zenoh_bytes
+.. doxygenfunction:: z_encoding_zenoh_int8
+.. doxygenfunction:: z_encoding_zenoh_int16
+.. doxygenfunction:: z_encoding_zenoh_int32
+.. doxygenfunction:: z_encoding_zenoh_int64
+.. doxygenfunction:: z_encoding_zenoh_int128
+.. doxygenfunction:: z_encoding_zenoh_uint8
+.. doxygenfunction:: z_encoding_zenoh_uint16
+.. doxygenfunction:: z_encoding_zenoh_uint32
+.. doxygenfunction:: z_encoding_zenoh_uint64
+.. doxygenfunction:: z_encoding_zenoh_uint128
+.. doxygenfunction:: z_encoding_zenoh_float32
+.. doxygenfunction:: z_encoding_zenoh_float64
+.. doxygenfunction:: z_encoding_zenoh_bool
+.. doxygenfunction:: z_encoding_zenoh_string
+.. doxygenfunction:: z_encoding_zenoh_error
+.. doxygenfunction:: z_encoding_application_octet_stream
+.. doxygenfunction:: z_encoding_text_plain
+.. doxygenfunction:: z_encoding_application_json
+.. doxygenfunction:: z_encoding_text_json
+.. doxygenfunction:: z_encoding_application_cdr
+.. doxygenfunction:: z_encoding_application_cbor
+.. doxygenfunction:: z_encoding_application_yaml
+.. doxygenfunction:: z_encoding_text_yaml
+.. doxygenfunction:: z_encoding_text_json5
+.. doxygenfunction:: z_encoding_application_python_serialized_objects
+.. doxygenfunction:: z_encoding_application_protobuf
+.. doxygenfunction:: z_encoding_application_java_serialized_object
+.. doxygenfunction:: z_encoding_application_openmetrics_text
+.. doxygenfunction:: z_encoding_image_png
+.. doxygenfunction:: z_encoding_image_jpeg
+.. doxygenfunction:: z_encoding_image_gif
+.. doxygenfunction:: z_encoding_image_bmp
+.. doxygenfunction:: z_encoding_image_webp
+.. doxygenfunction:: z_encoding_application_xml
+.. doxygenfunction:: z_encoding_application_x_www_form_urlencoded
+.. doxygenfunction:: z_encoding_text_html
+.. doxygenfunction:: z_encoding_text_xml
+.. doxygenfunction:: z_encoding_text_css
+.. doxygenfunction:: z_encoding_text_javascript
+.. doxygenfunction:: z_encoding_text_markdown
+.. doxygenfunction:: z_encoding_text_csv
+.. doxygenfunction:: z_encoding_application_sql
+.. doxygenfunction:: z_encoding_application_coap_payload
+.. doxygenfunction:: z_encoding_application_json_patch_json
+.. doxygenfunction:: z_encoding_application_json_seq
+.. doxygenfunction:: z_encoding_application_jsonpath
+.. doxygenfunction:: z_encoding_application_jwt
+.. doxygenfunction:: z_encoding_application_mp4
+.. doxygenfunction:: z_encoding_application_soap_xml
+.. doxygenfunction:: z_encoding_application_yang
+.. doxygenfunction:: z_encoding_audio_aac
+.. doxygenfunction:: z_encoding_audio_flac
+.. doxygenfunction:: z_encoding_audio_mp4
+.. doxygenfunction:: z_encoding_audio_ogg
+.. doxygenfunction:: z_encoding_audio_vorbis
+.. doxygenfunction:: z_encoding_video_h261
+.. doxygenfunction:: z_encoding_video_h263
+.. doxygenfunction:: z_encoding_video_h264
+.. doxygenfunction:: z_encoding_video_h265
+.. doxygenfunction:: z_encoding_video_h266
+.. doxygenfunction:: z_encoding_video_mp4
+.. doxygenfunction:: z_encoding_video_ogg
+.. doxygenfunction:: z_encoding_video_raw
+.. doxygenfunction:: z_encoding_video_vp8
+.. doxygenfunction:: z_encoding_video_vp9
 
 Value
 -----

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1695,9 +1695,169 @@ z_error_t z_delete(const struct z_loaned_session_t *session,
  */
 ZENOHC_API void z_delete_options_default(struct z_delete_options_t *this_);
 /**
+ * A Concise Binary Object Representation (CBOR)-encoded data.
+ *
+ * Constant alias for string: `"application/cbor"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_cbor(void);
+/**
+ * A Common Data Representation (CDR)-encoded data.
+ *
+ * Constant alias for string: `"application/cdr"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_cdr(void);
+/**
+ * Constrained Application Protocol (CoAP) data intended for CoAP-to-HTTP and HTTP-to-CoAP proxies.
+ *
+ * Constant alias for string: `"application/coap-payload"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_coap_payload(void);
+/**
+ * A Java serialized object.
+ *
+ * Constant alias for string: `"application/java-serialized-object"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_java_serialized_object(void);
+/**
+ * JSON data intended to be consumed by an application.
+ *
+ * Constant alias for string: `"application/json"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_json(void);
+/**
+ * Defines a JSON document structure for expressing a sequence of operations to apply to a JSON document.
+ *
+ * Constant alias for string: `"application/json-patch+json"`.
+ */
+ZENOHC_API
+const struct z_loaned_encoding_t *z_encoding_application_json_patch_json(void);
+/**
+ * A JSON text sequence consists of any number of JSON texts, all encoded in UTF-8.
+ *
+ * Constant alias for string: `"application/json-seq"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_json_seq(void);
+/**
+ * A JSONPath defines a string syntax for selecting and extracting JSON values from within a given JSON value.
+ *
+ * Constant alias for string: `"application/jsonpath"`.
+ */
+ZENOHC_API
+const struct z_loaned_encoding_t *z_encoding_application_jsonpath(void);
+/**
+ * A JSON Web Token (JWT).
+ *
+ * Constant alias for string: `"application/jwt"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_jwt(void);
+/**
+ * An application-specific MPEG-4 encoded data, either audio or video.
+ *
+ * Constant alias for string: `"application/mp4"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_mp4(void);
+/**
+ * An application-specific stream of bytes.
+ *
+ * Constant alias for string: `"application/octet-stream"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_octet_stream(void);
+/**
+ * An [openmetrics](https://github.com/OpenObservability/OpenMetrics) data, common used by [Prometheus](https://prometheus.io/).
+ *
+ * Constant alias for string: `"application/openmetrics-text"`.
+ */
+ZENOHC_API
+const struct z_loaned_encoding_t *z_encoding_application_openmetrics_text(void);
+/**
+ * An application-specific protobuf-encoded data.
+ *
+ * Constant alias for string: `"application/protobuf"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_protobuf(void);
+/**
+ * A Python object serialized using [pickle](https://docs.python.org/3/library/pickle.html).
+ *
+ * Constant alias for string: `"application/python-serialized-object"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_python_serialized_objects(void);
+/**
+ * A SOAP 1.2 message serialized as XML 1.0.
+ *
+ * Constant alias for string: `"application/soap+xml"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_soap_xml(void);
+/**
+ * An application-specific SQL query.
+ *
+ * Constant alias for string: `"application/sql"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_sql(void);
+/**
+ * An encoded a list of tuples, each consisting of a name and a value.
+ *
+ * Constant alias for string: `"application/x-www-form-urlencoded"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_x_www_form_urlencoded(void);
+/**
+ * An XML file intended to be consumed by an application..
+ *
+ * Constant alias for string: `"application/xml"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_xml(void);
+/**
+ * YAML data intended to be consumed by an application.
+ *
+ * Constant alias for string: `"application/yaml"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_yaml(void);
+/**
+ * A YANG-encoded data commonly used by the Network Configuration Protocol (NETCONF).
+ *
+ * Constant alias for string: `"application/yang"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_application_yang(void);
+/**
+ * A MPEG-4 Advanced Audio Coding (AAC) media.
+ *
+ * Constant alias for string: `"audio/aac"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_audio_aac(void);
+/**
+ * A Free Lossless Audio Codec (FLAC) media.
+ *
+ * Constant alias for string: `"audio/flac"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_audio_flac(void);
+/**
+ * An audio codec defined in MPEG-1, MPEG-2, MPEG-4, or registered at the MP4 registration authority.
+ *
+ * Constant alias for string: `"audio/mp4"`.
+ */
+ZENOHC_API
+const struct z_loaned_encoding_t *z_encoding_audio_mp4(void);
+/**
+ * An Ogg-encapsulated audio stream.
+ *
+ * Constant alias for string: `"audio/ogg"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_audio_ogg(void);
+/**
+ * A Vorbis-encoded audio stream.
+ *
+ * Constant alias for string: `"audio/vorbis"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_audio_vorbis(void);
+/**
  * Returns ``true`` if encoding is in non-default state, ``false`` otherwise.
  */
 ZENOHC_API bool z_encoding_check(const struct z_owned_encoding_t *this_);
+/**
+ * Constructs an owned copy of the encoding in provided uninitilized memory location.
+ */
+ZENOHC_API
+void z_encoding_clone(struct z_owned_encoding_t *dst,
+                      const struct z_loaned_encoding_t *this_);
 /**
  * Frees the memory and resets the encoding it to its default value.
  */
@@ -1714,6 +1874,36 @@ z_error_t z_encoding_from_substr(struct z_owned_encoding_t *this_,
                                  const char *s,
                                  size_t len);
 /**
+ * A BitMap (BMP) image.
+ *
+ * Constant alias for string: `"image/bmp"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_image_bmp(void);
+/**
+ * A Graphics Interchange Format (GIF) image.
+ *
+ * Constant alias for string: `"image/gif"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_image_gif(void);
+/**
+ * A Joint Photographic Experts Group (JPEG) image.
+ *
+ * Constant alias for string: `"image/jpeg"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_image_jpeg(void);
+/**
+ * A Portable Network Graphics (PNG) image.
+ *
+ * Constant alias for string: `"image/png"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_image_png(void);
+/**
+ * A Web Portable (WebP) image.
+ *
+ *  Constant alias for string: `"image/webp"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_image_webp(void);
+/**
  * Borrows encoding.
  */
 ZENOHC_API
@@ -1723,9 +1913,88 @@ const struct z_loaned_encoding_t *z_encoding_loan(const struct z_owned_encoding_
  */
 ZENOHC_API const struct z_loaned_encoding_t *z_encoding_loan_default(void);
 /**
+ * Mutably borrows encoding.
+ */
+ZENOHC_API struct z_loaned_encoding_t *z_encoding_loan_mut(struct z_owned_encoding_t *this_);
+/**
  * Constructs a default `z_owned_encoding_t`.
  */
 ZENOHC_API void z_encoding_null(struct z_owned_encoding_t *this_);
+/**
+ * Set a schema to this encoding from a c string. Zenoh does not define what a schema is and its semantichs is left to the implementer.
+ * E.g. a common schema for `text/plain` encoding is `utf-8`.
+ */
+ZENOHC_API
+z_error_t z_encoding_set_schema_from_str(struct z_loaned_encoding_t *this_,
+                                         const char *s);
+/**
+ * Set a schema to this encoding from a c substring. Zenoh does not define what a schema is and its semantichs is left to the implementer.
+ * E.g. a common schema for `text/plain` encoding is `utf-8`.
+ */
+ZENOHC_API
+z_error_t z_encoding_set_schema_from_substr(struct z_loaned_encoding_t *this_,
+                                            const char *s,
+                                            size_t len);
+/**
+ * A CSS file.
+ *
+ * Constant alias for string: `"text/css"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_text_css(void);
+/**
+ * A CSV file.
+ *
+ * Constant alias for string: `"text/csv"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_text_csv(void);
+/**
+ * An HTML file.
+ *
+ * Constant alias for string: `"text/html"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_text_html(void);
+/**
+ * A JavaScript file.
+ *
+ * Constant alias for string: `"text/javascript"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_text_javascript(void);
+/**
+ * JSON data intended to be human readable.
+ *
+ * Constant alias for string: `"text/json"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_text_json(void);
+/**
+ * JSON5 encoded data that are human readable.
+ *
+ * Constant alias for string: `"text/json5"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_text_json5(void);
+/**
+ * A MarkDown file.
+ *
+ * Constant alias for string: `"text/markdown"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_text_markdown(void);
+/**
+ * A textual file.
+ *
+ * Constant alias for string: `"text/plain"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_text_plain(void);
+/**
+ * An XML file that is human readable.
+ *
+ * Constant alias for string: `"text/xml"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_text_xml(void);
+/**
+ * YAML data intended to be human readable.
+ *
+ * Constant alias for string: `"text/yaml"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_text_yaml(void);
 /**
  * Constructs an owned non-null-terminated string from encoding
  *
@@ -1735,6 +2004,194 @@ ZENOHC_API void z_encoding_null(struct z_owned_encoding_t *this_);
 ZENOHC_API
 void z_encoding_to_string(const struct z_loaned_encoding_t *this_,
                           struct z_owned_string_t *out_str);
+/**
+ * A h261-encoded video stream.
+ *
+ * Constant alias for string: `"video/h261"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_video_h261(void);
+/**
+ * A h263-encoded video stream.
+ *
+ * Constant alias for string: `"video/h263"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_video_h263(void);
+/**
+ * A h264-encoded video stream.
+ *
+ * Constant alias for string: `"video/h264"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_video_h264(void);
+/**
+ * A h265-encoded video stream.
+ *
+ * Constant alias for string: `"video/h265"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_video_h265(void);
+/**
+ * A h266-encoded video stream.
+ *
+ * Constant alias for string: `"video/h266"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_video_h266(void);
+/**
+ * A video codec defined in MPEG-1, MPEG-2, MPEG-4, or registered at the MP4 registration authority.
+ *
+ * Constant alias for string: `"video/mp4"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_video_mp4(void);
+/**
+ * An Ogg-encapsulated video stream.
+ *
+ * Constant alias for string: `"video/ogg"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_video_ogg(void);
+/**
+ * An uncompressed, studio-quality video stream.
+ *
+ * Constant alias for string: `"video/raw"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_video_raw(void);
+/**
+ * A VP8-encoded video stream.
+ *
+ * Constant alias for string: `"video/vp8"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_video_vp8(void);
+/**
+ * A VP9-encoded video stream.
+ *
+ * Constant alias for string: `"video/vp9"`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_video_vp9(void);
+/**
+ * A boolean. `0` is `false`, `1` is `true`. Other values are invalid.
+ *
+ * Constant alias for string: `"zenoh/bool"`.
+ *
+ * Usually used for types: `bool`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_bool(void);
+/**
+ * Just some bytes.
+ *
+ * Constant alias for string: `"zenoh/bytes"`.
+ *
+ * Usually used for types: `uint8_t[]`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_bytes(void);
+/**
+ * A zenoh error.
+ *
+ * Constant alias for string: `"zenoh/error"`.
+ *
+ * Usually used for types: `z_reply_error_t`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_error(void);
+/**
+ * A VLE-encoded 32bit float. Binary representation uses *IEEE 754-2008* *binary32* .
+ *
+ * Constant alias for string: `"zenoh/float32"`.
+ *
+ * Usually used for types: `float`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_float32(void);
+/**
+ * A VLE-encoded 64bit float. Binary representation uses *IEEE 754-2008* *binary64*.
+ *
+ * Constant alias for string: `"zenoh/float64"`.
+ *
+ * Usually used for types: `double`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_float64(void);
+/**
+ * A VLE-encoded signed little-endian 128bit integer. Binary representation uses two's complement.
+ *
+ * Constant alias for string: `"zenoh/int128"`.
+ *
+ * Usually used for types: `int128_t`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_int128(void);
+/**
+ * A VLE-encoded signed little-endian 16bit integer. Binary representation uses two's complement.
+ *
+ * Constant alias for string: `"zenoh/int16"`.
+ *
+ * Usually used for types: `int16_t`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_int16(void);
+/**
+ * A VLE-encoded signed little-endian 32bit integer. Binary representation uses two's complement.
+ *
+ * Constant alias for string: `"zenoh/int32"`.
+ *
+ * Usually used for types: `int32_t`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_int32(void);
+/**
+ * A VLE-encoded signed little-endian 64bit integer. Binary representation uses two's complement.
+ *
+ * Constant alias for string: `"zenoh/int64"`.
+ *
+ * Usually used for types: `int64_t`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_int64(void);
+/**
+ * A VLE-encoded signed little-endian 8bit integer. Binary representation uses two's complement.
+ *
+ * Constant alias for string: `"zenoh/int8"`.
+ *
+ * Usually used for types: `int8_t`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_int8(void);
+/**
+ * A UTF-8 string.
+ *
+ * Constant alias for string: `"zenoh/string"`.
+ *
+ * Usually used for types: `const char*`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_string(void);
+/**
+ * A VLE-encoded unsigned little-endian 128bit integer.
+ *
+ * Constant alias for string: `"zenoh/uint128"`.
+ *
+ * Usually used for types: `uint128_t`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint128(void);
+/**
+ * A VLE-encoded unsigned little-endian 16bit integer.
+ *
+ * Constant alias for string: `"zenoh/uint16"`.
+ *
+ * Usually used for types: `uint16_t`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint16(void);
+/**
+ * A VLE-encoded unsigned little-endian 32bit integer.
+ *
+ * Constant alias for string: `"zenoh/uint32"`.
+ *
+ * Usually used for types: `uint32_t`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint32(void);
+/**
+ * A VLE-encoded unsigned little-endian 64bit integer.
+ *
+ * Constant alias for string: `"zenoh/uint64"`.
+ *
+ * Usually used for types: `uint64_t`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint64(void);
+/**
+ * A VLE-encoded unsigned little-endian 8bit integer.
+ *
+ * Constant alias for string: `"zenoh/uint8"`.
+ *
+ * Usually used for types: `uint8_t`.
+ */
+ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint8(void);
 /**
  * Returns the entity id of the entity global id.
  */

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -50,6 +50,7 @@
         z_owned_bytes_writer_t : z_bytes_writer_loan_mut, \
         z_owned_condvar_t : z_condvar_loan_mut, \
         z_owned_config_t : z_config_loan_mut, \
+        z_owned_encoding_t : z_encoding_loan_mut, \
         z_owned_mutex_t : z_mutex_loan_mut, \
         z_owned_publisher_t : z_publisher_loan_mut, \
         z_owned_string_array_t : z_string_array_loan_mut \
@@ -260,6 +261,7 @@ inline z_loaned_bytes_t* z_loan_mut(z_owned_bytes_t& this_) { return z_bytes_loa
 inline z_loaned_bytes_writer_t* z_loan_mut(z_owned_bytes_writer_t& this_) { return z_bytes_writer_loan_mut(&this_); };
 inline z_loaned_condvar_t* z_loan_mut(z_owned_condvar_t& this_) { return z_condvar_loan_mut(&this_); };
 inline z_loaned_config_t* z_loan_mut(z_owned_config_t& this_) { return z_config_loan_mut(&this_); };
+inline z_loaned_encoding_t* z_loan_mut(z_owned_encoding_t& this_) { return z_encoding_loan_mut(&this_); };
 inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t& this_) { return z_mutex_loan_mut(&this_); };
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& this_) { return z_publisher_loan_mut(&this_); };
 inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { return z_string_array_loan_mut(&this_); };

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,0 +1,672 @@
+//
+// Copyright (c) 2017, 2024 ZettaScale Technology.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh team, <zenoh@zettascale.tech>
+//
+
+use std::{
+    borrow::Cow,
+    mem::MaybeUninit,
+    slice::from_raw_parts,
+    str::{from_utf8, FromStr},
+};
+
+use libc::{c_char, strlen};
+use unwrap_infallible::UnwrapInfallible;
+use zenoh::bytes::Encoding;
+
+use crate::{
+    errors::{self, z_error_t},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    z_owned_string_t, z_string_from_substr,
+};
+
+pub use crate::opaque_types::{z_loaned_encoding_t, z_owned_encoding_t};
+
+decl_c_type!(
+    owned(z_owned_encoding_t, Encoding),
+    loaned(z_loaned_encoding_t, Encoding),
+);
+
+/// Constructs a `z_owned_encoding_t` from a specified substring.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn z_encoding_from_substr(
+    this: &mut MaybeUninit<z_owned_encoding_t>,
+    s: *const c_char,
+    len: usize,
+) -> errors::z_error_t {
+    let encoding = this.as_rust_type_mut_uninit();
+    if s.is_null() {
+        encoding.write(Encoding::default());
+        errors::Z_OK
+    } else {
+        let s = from_raw_parts(s as *const u8, len);
+        match from_utf8(s) {
+            Ok(s) => {
+                encoding.write(Encoding::from_str(s).unwrap_infallible());
+                errors::Z_OK
+            }
+            Err(e) => {
+                tracing::error!("Can not create encoding from non UTF-8 string: {}", e);
+                encoding.write(Encoding::default());
+                errors::Z_EINVAL
+            }
+        }
+    }
+}
+
+/// Set a schema to this encoding from a c substring. Zenoh does not define what a schema is and its semantichs is left to the implementer.
+/// E.g. a common schema for `text/plain` encoding is `utf-8`.
+#[no_mangle]
+pub extern "C" fn z_encoding_set_schema_from_substr(
+    this: &mut z_loaned_encoding_t,
+    s: *const c_char,
+    len: usize,
+) -> errors::z_error_t {
+    let encoding = this.as_rust_type_mut();
+    if len == 0 {
+        *encoding = std::mem::take(encoding).with_schema(String::new());
+        return errors::Z_OK;
+    } else if s.is_null() {
+        return errors::Z_EINVAL;
+    }
+    let schema_bytes = unsafe { from_raw_parts(s as *const u8, len) };
+    match from_utf8(schema_bytes) {
+        Ok(schema_str) => {
+            *encoding = std::mem::take(encoding).with_schema(schema_str);
+            errors::Z_OK
+        }
+        Err(e) => {
+            tracing::error!("{}", e);
+            errors::Z_EINVAL
+        }
+    }
+}
+
+/// Set a schema to this encoding from a c string. Zenoh does not define what a schema is and its semantichs is left to the implementer.
+/// E.g. a common schema for `text/plain` encoding is `utf-8`.
+#[no_mangle]
+pub extern "C" fn z_encoding_set_schema_from_str(
+    this: &mut z_loaned_encoding_t,
+    s: *const c_char,
+) -> z_error_t {
+    z_encoding_set_schema_from_substr(this, s, unsafe { strlen(s) })
+}
+
+/// Constructs a `z_owned_encoding_t` from a specified string.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn z_encoding_from_str(
+    this: &mut MaybeUninit<z_owned_encoding_t>,
+    s: *const c_char,
+) -> errors::z_error_t {
+    z_encoding_from_substr(this, s, libc::strlen(s))
+}
+
+/// Constructs an owned non-null-terminated string from encoding
+///
+/// @param this_: Encoding.
+/// @param out_str: Uninitialized memory location where a string to be constructed.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn z_encoding_to_string(
+    this: &z_loaned_encoding_t,
+    out_str: &mut MaybeUninit<z_owned_string_t>,
+) {
+    let s: Cow<'static, str> = this.as_rust_type_ref().into();
+    z_string_from_substr(out_str, s.as_bytes().as_ptr() as _, s.as_bytes().len());
+}
+
+/// Returns a loaned default `z_loaned_encoding_t`.
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub extern "C" fn z_encoding_loan_default() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_BYTES.as_loaned_c_type_ref()
+}
+
+/// Constructs a default `z_owned_encoding_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_null(this: &mut MaybeUninit<z_owned_encoding_t>) {
+    this.as_rust_type_mut_uninit().write(Encoding::default());
+}
+
+/// Frees the memory and resets the encoding it to its default value.
+#[no_mangle]
+pub extern "C" fn z_encoding_drop(this: &mut z_owned_encoding_t) {
+    *this.as_rust_type_mut() = Encoding::default();
+}
+
+/// Returns ``true`` if encoding is in non-default state, ``false`` otherwise.
+#[no_mangle]
+pub extern "C" fn z_encoding_check(this: &'static z_owned_encoding_t) -> bool {
+    *this.as_rust_type_ref() != Encoding::default()
+}
+
+/// Borrows encoding.
+#[no_mangle]
+pub extern "C" fn z_encoding_loan(this: &z_owned_encoding_t) -> &z_loaned_encoding_t {
+    this.as_rust_type_ref().as_loaned_c_type_ref()
+}
+
+/// Mutably borrows encoding.
+#[no_mangle]
+pub extern "C" fn z_encoding_loan_mut(this: &mut z_owned_encoding_t) -> &mut z_loaned_encoding_t {
+    this.as_rust_type_mut().as_loaned_c_type_mut()
+}
+
+/// Constructs an owned copy of the encoding in provided uninitilized memory location.
+#[no_mangle]
+pub extern "C" fn z_encoding_clone(
+    dst: &mut MaybeUninit<z_owned_encoding_t>,
+    this: &z_loaned_encoding_t,
+) {
+    dst.as_rust_type_mut_uninit()
+        .write(this.as_rust_type_ref().clone());
+}
+
+/// Just some bytes.
+///
+/// Constant alias for string: `"zenoh/bytes"`.
+///
+/// Usually used for types: `uint8_t[]`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_bytes() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_BYTES.as_loaned_c_type_ref()
+}
+/// A VLE-encoded signed little-endian 8bit integer. Binary representation uses two's complement.
+///
+/// Constant alias for string: `"zenoh/int8"`.
+///
+/// Usually used for types: `int8_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_int8() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_INT8.as_loaned_c_type_ref()
+}
+/// A VLE-encoded signed little-endian 16bit integer. Binary representation uses two's complement.
+///
+/// Constant alias for string: `"zenoh/int16"`.
+///
+/// Usually used for types: `int16_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_int16() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_INT16.as_loaned_c_type_ref()
+}
+/// A VLE-encoded signed little-endian 32bit integer. Binary representation uses two's complement.
+///
+/// Constant alias for string: `"zenoh/int32"`.
+///
+/// Usually used for types: `int32_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_int32() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_INT32.as_loaned_c_type_ref()
+}
+/// A VLE-encoded signed little-endian 64bit integer. Binary representation uses two's complement.
+///
+/// Constant alias for string: `"zenoh/int64"`.
+///
+/// Usually used for types: `int64_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_int64() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_INT64.as_loaned_c_type_ref()
+}
+/// A VLE-encoded signed little-endian 128bit integer. Binary representation uses two's complement.
+///
+/// Constant alias for string: `"zenoh/int128"`.
+///
+/// Usually used for types: `int128_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_int128() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_INT128.as_loaned_c_type_ref()
+}
+/// A VLE-encoded unsigned little-endian 8bit integer.
+///
+/// Constant alias for string: `"zenoh/uint8"`.
+///
+/// Usually used for types: `uint8_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_uint8() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_UINT8.as_loaned_c_type_ref()
+}
+/// A VLE-encoded unsigned little-endian 16bit integer.
+///
+/// Constant alias for string: `"zenoh/uint16"`.
+///
+/// Usually used for types: `uint16_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_uint16() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_UINT16.as_loaned_c_type_ref()
+}
+/// A VLE-encoded unsigned little-endian 32bit integer.
+///
+/// Constant alias for string: `"zenoh/uint32"`.
+///
+/// Usually used for types: `uint32_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_uint32() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_UINT32.as_loaned_c_type_ref()
+}
+/// A VLE-encoded unsigned little-endian 64bit integer.
+///
+/// Constant alias for string: `"zenoh/uint64"`.
+///
+/// Usually used for types: `uint64_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_uint64() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_UINT64.as_loaned_c_type_ref()
+}
+/// A VLE-encoded unsigned little-endian 128bit integer.
+///
+/// Constant alias for string: `"zenoh/uint128"`.
+///
+/// Usually used for types: `uint128_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_uint128() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_UINT128.as_loaned_c_type_ref()
+}
+/// A VLE-encoded 32bit float. Binary representation uses *IEEE 754-2008* *binary32* .
+///
+/// Constant alias for string: `"zenoh/float32"`.
+///
+/// Usually used for types: `float`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_float32() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_FLOAT32.as_loaned_c_type_ref()
+}
+/// A VLE-encoded 64bit float. Binary representation uses *IEEE 754-2008* *binary64*.
+///
+/// Constant alias for string: `"zenoh/float64"`.
+///
+/// Usually used for types: `double`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_float64() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_FLOAT64.as_loaned_c_type_ref()
+}
+/// A boolean. `0` is `false`, `1` is `true`. Other values are invalid.
+///
+/// Constant alias for string: `"zenoh/bool"`.
+///
+/// Usually used for types: `bool`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_bool() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_BOOL.as_loaned_c_type_ref()
+}
+/// A UTF-8 string.
+///
+/// Constant alias for string: `"zenoh/string"`.
+///
+/// Usually used for types: `const char*`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_string() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_STRING.as_loaned_c_type_ref()
+}
+/// A zenoh error.
+///
+/// Constant alias for string: `"zenoh/error"`.
+///
+/// Usually used for types: `z_reply_error_t`.
+#[no_mangle]
+pub extern "C" fn z_encoding_zenoh_error() -> &'static z_loaned_encoding_t {
+    Encoding::ZENOH_ERROR.as_loaned_c_type_ref()
+}
+
+// - Advanced types may be supported in some of the Zenoh bindings.
+/// An application-specific stream of bytes.
+///
+/// Constant alias for string: `"application/octet-stream"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_octet_stream() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_OCTET_STREAM.as_loaned_c_type_ref()
+}
+/// A textual file.
+///
+/// Constant alias for string: `"text/plain"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_text_plain() -> &'static z_loaned_encoding_t {
+    Encoding::TEXT_PLAIN.as_loaned_c_type_ref()
+}
+/// JSON data intended to be consumed by an application.
+///
+/// Constant alias for string: `"application/json"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_json() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_JSON.as_loaned_c_type_ref()
+}
+/// JSON data intended to be human readable.
+///
+/// Constant alias for string: `"text/json"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_text_json() -> &'static z_loaned_encoding_t {
+    Encoding::TEXT_JSON.as_loaned_c_type_ref()
+}
+/// A Common Data Representation (CDR)-encoded data.
+///
+/// Constant alias for string: `"application/cdr"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_cdr() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_CDR.as_loaned_c_type_ref()
+}
+/// A Concise Binary Object Representation (CBOR)-encoded data.
+///
+/// Constant alias for string: `"application/cbor"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_cbor() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_CBOR.as_loaned_c_type_ref()
+}
+/// YAML data intended to be consumed by an application.
+///
+/// Constant alias for string: `"application/yaml"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_yaml() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_YAML.as_loaned_c_type_ref()
+}
+/// YAML data intended to be human readable.
+///
+/// Constant alias for string: `"text/yaml"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_text_yaml() -> &'static z_loaned_encoding_t {
+    Encoding::TEXT_YAML.as_loaned_c_type_ref()
+}
+/// JSON5 encoded data that are human readable.
+///
+/// Constant alias for string: `"text/json5"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_text_json5() -> &'static z_loaned_encoding_t {
+    Encoding::TEXT_JSON5.as_loaned_c_type_ref()
+}
+/// A Python object serialized using [pickle](https://docs.python.org/3/library/pickle.html).
+///
+/// Constant alias for string: `"application/python-serialized-object"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_python_serialized_objects() -> &'static z_loaned_encoding_t
+{
+    Encoding::APPLICATION_PYTHON_SERIALIZED_OBJECT.as_loaned_c_type_ref()
+}
+/// An application-specific protobuf-encoded data.
+///
+/// Constant alias for string: `"application/protobuf"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_protobuf() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_PROTOBUF.as_loaned_c_type_ref()
+}
+/// A Java serialized object.
+///
+/// Constant alias for string: `"application/java-serialized-object"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_java_serialized_object() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_JAVA_SERIALIZED_OBJECT.as_loaned_c_type_ref()
+}
+/// An [openmetrics](https://github.com/OpenObservability/OpenMetrics) data, common used by [Prometheus](https://prometheus.io/).
+///
+/// Constant alias for string: `"application/openmetrics-text"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_openmetrics_text() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_OPENMETRICS_TEXT.as_loaned_c_type_ref()
+}
+/// A Portable Network Graphics (PNG) image.
+///
+/// Constant alias for string: `"image/png"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_image_png() -> &'static z_loaned_encoding_t {
+    Encoding::IMAGE_PNG.as_loaned_c_type_ref()
+}
+/// A Joint Photographic Experts Group (JPEG) image.
+///
+/// Constant alias for string: `"image/jpeg"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_image_jpeg() -> &'static z_loaned_encoding_t {
+    Encoding::IMAGE_JPEG.as_loaned_c_type_ref()
+}
+/// A Graphics Interchange Format (GIF) image.
+///
+/// Constant alias for string: `"image/gif"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_image_gif() -> &'static z_loaned_encoding_t {
+    Encoding::IMAGE_GIF.as_loaned_c_type_ref()
+}
+/// A BitMap (BMP) image.
+///
+/// Constant alias for string: `"image/bmp"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_image_bmp() -> &'static z_loaned_encoding_t {
+    Encoding::IMAGE_BMP.as_loaned_c_type_ref()
+}
+/// A Web Portable (WebP) image.
+///
+///  Constant alias for string: `"image/webp"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_image_webp() -> &'static z_loaned_encoding_t {
+    Encoding::IMAGE_WEBP.as_loaned_c_type_ref()
+}
+/// An XML file intended to be consumed by an application..
+///
+/// Constant alias for string: `"application/xml"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_xml() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_XML.as_loaned_c_type_ref()
+}
+/// An encoded a list of tuples, each consisting of a name and a value.
+///
+/// Constant alias for string: `"application/x-www-form-urlencoded"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_x_www_form_urlencoded() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_X_WWW_FORM_URLENCODED.as_loaned_c_type_ref()
+}
+/// An HTML file.
+///
+/// Constant alias for string: `"text/html"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_text_html() -> &'static z_loaned_encoding_t {
+    Encoding::TEXT_HTML.as_loaned_c_type_ref()
+}
+/// An XML file that is human readable.
+///
+/// Constant alias for string: `"text/xml"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_text_xml() -> &'static z_loaned_encoding_t {
+    Encoding::TEXT_XML.as_loaned_c_type_ref()
+}
+/// A CSS file.
+///
+/// Constant alias for string: `"text/css"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_text_css() -> &'static z_loaned_encoding_t {
+    Encoding::TEXT_CSS.as_loaned_c_type_ref()
+}
+/// A JavaScript file.
+///
+/// Constant alias for string: `"text/javascript"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_text_javascript() -> &'static z_loaned_encoding_t {
+    Encoding::TEXT_JAVASCRIPT.as_loaned_c_type_ref()
+}
+/// A MarkDown file.
+///
+/// Constant alias for string: `"text/markdown"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_text_markdown() -> &'static z_loaned_encoding_t {
+    Encoding::TEXT_MARKDOWN.as_loaned_c_type_ref()
+}
+/// A CSV file.
+///
+/// Constant alias for string: `"text/csv"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_text_csv() -> &'static z_loaned_encoding_t {
+    Encoding::TEXT_CSV.as_loaned_c_type_ref()
+}
+/// An application-specific SQL query.
+///
+/// Constant alias for string: `"application/sql"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_sql() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_SQL.as_loaned_c_type_ref()
+}
+/// Constrained Application Protocol (CoAP) data intended for CoAP-to-HTTP and HTTP-to-CoAP proxies.
+///
+/// Constant alias for string: `"application/coap-payload"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_coap_payload() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_COAP_PAYLOAD.as_loaned_c_type_ref()
+}
+/// Defines a JSON document structure for expressing a sequence of operations to apply to a JSON document.
+///
+/// Constant alias for string: `"application/json-patch+json"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_json_patch_json() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_JSON_PATCH_JSON.as_loaned_c_type_ref()
+}
+/// A JSON text sequence consists of any number of JSON texts, all encoded in UTF-8.
+///
+/// Constant alias for string: `"application/json-seq"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_json_seq() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_JSON_SEQ.as_loaned_c_type_ref()
+}
+/// A JSONPath defines a string syntax for selecting and extracting JSON values from within a given JSON value.
+///
+/// Constant alias for string: `"application/jsonpath"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_jsonpath() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_JSONPATH.as_loaned_c_type_ref()
+}
+/// A JSON Web Token (JWT).
+///
+/// Constant alias for string: `"application/jwt"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_jwt() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_JWT.as_loaned_c_type_ref()
+}
+/// An application-specific MPEG-4 encoded data, either audio or video.
+///
+/// Constant alias for string: `"application/mp4"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_mp4() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_MP4.as_loaned_c_type_ref()
+}
+/// A SOAP 1.2 message serialized as XML 1.0.
+///
+/// Constant alias for string: `"application/soap+xml"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_soap_xml() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_SOAP_XML.as_loaned_c_type_ref()
+}
+/// A YANG-encoded data commonly used by the Network Configuration Protocol (NETCONF).
+///
+/// Constant alias for string: `"application/yang"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_application_yang() -> &'static z_loaned_encoding_t {
+    Encoding::APPLICATION_YANG.as_loaned_c_type_ref()
+}
+/// A MPEG-4 Advanced Audio Coding (AAC) media.
+///
+/// Constant alias for string: `"audio/aac"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_audio_aac() -> &'static z_loaned_encoding_t {
+    Encoding::AUDIO_AAC.as_loaned_c_type_ref()
+}
+/// A Free Lossless Audio Codec (FLAC) media.
+///
+/// Constant alias for string: `"audio/flac"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_audio_flac() -> &'static z_loaned_encoding_t {
+    Encoding::AUDIO_FLAC.as_loaned_c_type_ref()
+}
+/// An audio codec defined in MPEG-1, MPEG-2, MPEG-4, or registered at the MP4 registration authority.
+///
+/// Constant alias for string: `"audio/mp4"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_audio_mp4() -> &'static z_loaned_encoding_t {
+    Encoding::AUDIO_MP4.as_loaned_c_type_ref()
+}
+/// An Ogg-encapsulated audio stream.
+///
+/// Constant alias for string: `"audio/ogg"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_audio_ogg() -> &'static z_loaned_encoding_t {
+    Encoding::AUDIO_OGG.as_loaned_c_type_ref()
+}
+/// A Vorbis-encoded audio stream.
+///
+/// Constant alias for string: `"audio/vorbis"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_audio_vorbis() -> &'static z_loaned_encoding_t {
+    Encoding::AUDIO_VORBIS.as_loaned_c_type_ref()
+}
+/// A h261-encoded video stream.
+///
+/// Constant alias for string: `"video/h261"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_video_h261() -> &'static z_loaned_encoding_t {
+    Encoding::VIDEO_H261.as_loaned_c_type_ref()
+}
+/// A h263-encoded video stream.
+///
+/// Constant alias for string: `"video/h263"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_video_h263() -> &'static z_loaned_encoding_t {
+    Encoding::VIDEO_H263.as_loaned_c_type_ref()
+}
+/// A h264-encoded video stream.
+///
+/// Constant alias for string: `"video/h264"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_video_h264() -> &'static z_loaned_encoding_t {
+    Encoding::VIDEO_H264.as_loaned_c_type_ref()
+}
+/// A h265-encoded video stream.
+///
+/// Constant alias for string: `"video/h265"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_video_h265() -> &'static z_loaned_encoding_t {
+    Encoding::VIDEO_H265.as_loaned_c_type_ref()
+}
+/// A h266-encoded video stream.
+///
+/// Constant alias for string: `"video/h266"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_video_h266() -> &'static z_loaned_encoding_t {
+    Encoding::VIDEO_H266.as_loaned_c_type_ref()
+}
+/// A video codec defined in MPEG-1, MPEG-2, MPEG-4, or registered at the MP4 registration authority.
+///
+/// Constant alias for string: `"video/mp4"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_video_mp4() -> &'static z_loaned_encoding_t {
+    Encoding::VIDEO_MP4.as_loaned_c_type_ref()
+}
+/// An Ogg-encapsulated video stream.
+///
+/// Constant alias for string: `"video/ogg"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_video_ogg() -> &'static z_loaned_encoding_t {
+    Encoding::VIDEO_OGG.as_loaned_c_type_ref()
+}
+/// An uncompressed, studio-quality video stream.
+///
+/// Constant alias for string: `"video/raw"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_video_raw() -> &'static z_loaned_encoding_t {
+    Encoding::VIDEO_RAW.as_loaned_c_type_ref()
+}
+/// A VP8-encoded video stream.
+///
+/// Constant alias for string: `"video/vp8"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_video_vp8() -> &'static z_loaned_encoding_t {
+    Encoding::VIDEO_VP8.as_loaned_c_type_ref()
+}
+/// A VP9-encoded video stream.
+///
+/// Constant alias for string: `"video/vp9"`.
+#[no_mangle]
+pub extern "C" fn z_encoding_video_vp9() -> &'static z_loaned_encoding_t {
+    Encoding::VIDEO_VP9.as_loaned_c_type_ref()
+}

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -23,13 +23,12 @@ use libc::{c_char, strlen};
 use unwrap_infallible::UnwrapInfallible;
 use zenoh::bytes::Encoding;
 
+pub use crate::opaque_types::{z_loaned_encoding_t, z_owned_encoding_t};
 use crate::{
     errors::{self, z_error_t},
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
     z_owned_string_t, z_string_from_substr,
 };
-
-pub use crate::opaque_types::{z_loaned_encoding_t, z_owned_encoding_t};
 
 decl_c_type!(
     owned(z_owned_encoding_t, Encoding),

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -67,7 +67,8 @@ pub unsafe extern "C" fn z_encoding_from_substr(
 /// Set a schema to this encoding from a c substring. Zenoh does not define what a schema is and its semantichs is left to the implementer.
 /// E.g. a common schema for `text/plain` encoding is `utf-8`.
 #[no_mangle]
-pub extern "C" fn z_encoding_set_schema_from_substr(
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn z_encoding_set_schema_from_substr(
     this: &mut z_loaned_encoding_t,
     s: *const c_char,
     len: usize,
@@ -79,7 +80,7 @@ pub extern "C" fn z_encoding_set_schema_from_substr(
     } else if s.is_null() {
         return errors::Z_EINVAL;
     }
-    let schema_bytes = unsafe { from_raw_parts(s as *const u8, len) };
+    let schema_bytes = from_raw_parts(s as *const u8, len);
     match from_utf8(schema_bytes) {
         Ok(schema_str) => {
             *encoding = std::mem::take(encoding).with_schema(schema_str);
@@ -95,11 +96,12 @@ pub extern "C" fn z_encoding_set_schema_from_substr(
 /// Set a schema to this encoding from a c string. Zenoh does not define what a schema is and its semantichs is left to the implementer.
 /// E.g. a common schema for `text/plain` encoding is `utf-8`.
 #[no_mangle]
-pub extern "C" fn z_encoding_set_schema_from_str(
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn z_encoding_set_schema_from_str(
     this: &mut z_loaned_encoding_t,
     s: *const c_char,
 ) -> z_error_t {
-    z_encoding_set_schema_from_substr(this, s, unsafe { strlen(s) })
+    z_encoding_set_schema_from_substr(this, s,strlen(s))
 }
 
 /// Constructs a `z_owned_encoding_t` from a specified string.

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn z_encoding_set_schema_from_str(
     this: &mut z_loaned_encoding_t,
     s: *const c_char,
 ) -> z_error_t {
-    z_encoding_set_schema_from_substr(this, s,strlen(s))
+    z_encoding_set_schema_from_substr(this, s, strlen(s))
 }
 
 /// Constructs a `z_owned_encoding_t` from a specified string.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub mod errors;
 pub use crate::collections::*;
 mod config;
 pub use crate::config::*;
+pub mod encoding;
+pub use crate::encoding::*;
 mod commons;
 pub use crate::commons::*;
 mod payload;

--- a/src/put.rs
+++ b/src/put.rs
@@ -19,8 +19,8 @@ use zenoh::{
 };
 
 use crate::{
-    commons::*, errors, keyexpr::*, transmute::RustTypeRef, z_loaned_session_t, z_owned_bytes_t,
-    z_timestamp_t,
+    commons::*, encoding::*, errors, keyexpr::*, transmute::RustTypeRef, z_loaned_session_t,
+    z_owned_bytes_t, z_timestamp_t,
 };
 
 /// Options passed to the `z_put()` function.

--- a/tests/z_api_encoding_test.c
+++ b/tests/z_api_encoding_test.c
@@ -75,8 +75,41 @@ void test_encoding_with_id(void) {
     z_string_drop(z_move(s));
 }
 
+void test_with_schema(void) {
+    z_owned_encoding_t e;
+    z_encoding_null(&e);
+    z_encoding_set_schema_from_str(z_encoding_loan_mut(&e), "my_schema");
+
+    z_owned_string_t s;
+    z_encoding_to_string(z_encoding_loan_mut(&e), &s);
+    assert(strncmp("zenoh/bytes;my_schema", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    z_encoding_drop(z_move(e));
+
+    z_encoding_clone(&e, z_encoding_zenoh_string());
+    z_encoding_set_schema_from_substr(z_encoding_loan_mut(&e), "my_schema", 3);
+
+    z_encoding_to_string(z_encoding_loan(&e), &s);
+    assert(strncmp("zenoh/string;my_", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    z_encoding_drop(z_move(e));
+    z_string_drop(z_move(s));
+}
+
+void test_constants() {
+    z_owned_string_t s;
+    z_encoding_to_string(z_encoding_zenoh_bytes(), &s);
+    assert(strncmp("zenoh/bytes", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    z_string_drop(z_move(s));
+
+    z_encoding_to_string(z_encoding_zenoh_string(), &s);
+    assert(strncmp("zenoh/string", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+
+    z_string_drop(z_move(s));
+}
+
 int main(int argc, char **argv) {
     test_null_encoding();
     test_encoding_without_id();
     test_encoding_with_id();
+    test_constants();
+    test_with_schema();
 }


### PR DESCRIPTION
add z_encoding_set_schema functions (corresponding to zenoh-rust Encoding::with_schema)
add predefined encoding constants;
add z_encoding_clone function;
Closes #365.