### PR TITLE
move SourceInfo, liveliness, KeyExpr::relation_to and zenoh-ext functionality under UNSTABLE feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,10 @@ if(ZENOHC_BUILD_WITH_LOGGER_AUTOINIT)
 	set(cargo_flags ${cargo_flags} --features=logger-autoinit)
 endif()
 
+if(ZENOHC_BUILD_WITH_SHARED_MEMORY AND NOT ZENOHC_BUILD_WITH_UNSTABLE_API)
+	message( FATAL_ERROR "ZENOHC_BUILD_WITH_SHARED_MEMORY feature requires ZENOHC_BUILD_WITH_UNSTABLE_API to be enabled." )
+endif()
+
 if(ZENOHC_BUILD_WITH_SHARED_MEMORY)
 	set(cargo_flags ${cargo_flags} --features=shared-memory)
 endif()

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ build = "build.rs"
 
 [features]
 logger-autoinit = []
-shared-memory = ["zenoh/shared-memory", "zenoh-ext/shared-memory"]
-unstable = ["zenoh/unstable", "zenoh-ext/unstable"]
+shared-memory = ["zenoh/shared-memory", "dep:zenoh-ext", "zenoh-ext/shared-memory"]
+unstable = ["dep:zenoh-ext"]
 default = ["zenoh/default"]
 
 [badges]
@@ -52,8 +52,8 @@ rand = "0.8.5"
 spin = "0.9.5"
 unwrap-infallible = "0.1.5"
 const_format = "0.2.32"
-zenoh = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0", default-features = false }
-zenoh-ext = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0" }
+zenoh = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0", default-features = false, features = ["unstable", "internal"] }
+zenoh-ext = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0" , optional = true, features = ["unstable"] }
 flume = "*"
 
 [build-dependencies]

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -32,8 +32,8 @@ build = "@CARGO_PROJECT_DIR@build.rs"
 
 [features]
 logger-autoinit = []
-shared-memory = ["zenoh/shared-memory", "zenoh-ext/shared-memory"]
-unstable = ["zenoh/unstable", "zenoh-ext/unstable"]
+shared-memory = ["zenoh/shared-memory", "dep:zenoh-ext", "zenoh-ext/shared-memory"]
+unstable = ["dep:zenoh-ext"]
 default = ["zenoh/default"]
 
 [badges]
@@ -52,8 +52,8 @@ rand = "0.8.5"
 spin = "0.9.5"
 unwrap-infallible = "0.1.5"
 const_format = "0.2.32"
-zenoh = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0", default-features = false }
-zenoh-ext = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0" }
+zenoh = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0", default-features = false, features = ["unstable", "internal"] }
+zenoh-ext = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0" , optional = true, features = ["unstable"] }
 flume = "*"
 
 [build-dependencies]

--- a/build-resources/opaque-types/Cargo.toml
+++ b/build-resources/opaque-types/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-shared-memory = ["zenoh/shared-memory", "zenoh-ext/shared-memory", "zenoh-protocol/shared-memory"]
-unstable = ["zenoh/unstable", "zenoh-ext/unstable"]
+shared-memory = ["zenoh/shared-memory", "dep:zenoh-ext", "zenoh-ext/shared-memory", "zenoh-protocol/shared-memory"]
+unstable = ["dep:zenoh-ext"]
 default = ["zenoh/default"]
 
 [dependencies]
-zenoh = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0", default-features = false }
-zenoh-ext = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0" }
+zenoh = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0", default-features = false, features = ["unstable", "internal"]  }
+zenoh-ext = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0", optional = true , features = ["unstable"]}
 zenoh-protocol = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/1.0.0" }
 const_format = "0.2.32"
 flume = "*"

--- a/build-resources/opaque-types/src/lib.rs
+++ b/build-resources/opaque-types/src/lib.rs
@@ -122,7 +122,7 @@ get_opaque_type_data!(Query, z_loaned_query_t);
 get_opaque_type_data!(Option<Queryable<'static, ()>>, z_owned_queryable_t);
 /// A loaned Zenoh queryable.
 get_opaque_type_data!(Queryable<'static, ()>, z_loaned_queryable_t);
-
+#[cfg(feature = "unstable")]
 /// An owned Zenoh querying subscriber.
 ///
 /// In addition to receiving the data it is subscribed to,
@@ -131,6 +131,7 @@ get_opaque_type_data!(
     Option<(zenoh_ext::FetchingSubscriber<'static, ()>, &'static Session)>,
     ze_owned_querying_subscriber_t
 );
+#[cfg(feature = "unstable")]
 /// A loaned Zenoh querying subscriber.
 get_opaque_type_data!(
     (zenoh_ext::FetchingSubscriber<'static, ()>, &'static Session),
@@ -211,6 +212,7 @@ get_opaque_type_data!(Option<Subscriber<'static, ()>>, z_owned_subscriber_t);
 /// A loaned Zenoh subscriber.
 get_opaque_type_data!(Subscriber<'static, ()>, z_loaned_subscriber_t);
 
+#[cfg(feature = "unstable")]
 /// A liveliness token that can be used to provide the network with information about connectivity to its
 /// declarer: when constructed, a PUT sample will be received by liveliness subscribers on intersecting key
 /// expressions.
@@ -220,8 +222,9 @@ get_opaque_type_data!(
     Option<LivelinessToken<'static>>,
     zc_owned_liveliness_token_t
 );
+#[cfg(feature = "unstable")]
 get_opaque_type_data!(LivelinessToken<'static>, zc_loaned_liveliness_token_t);
-
+#[cfg(feature = "unstable")]
 /// An owned Zenoh publication cache.
 ///
 /// Used to store publications on intersecting key expressions. Can be queried later via `z_get()` to retrieve this data
@@ -230,6 +233,7 @@ get_opaque_type_data!(
     Option<zenoh_ext::PublicationCache<'static>>,
     ze_owned_publication_cache_t
 );
+#[cfg(feature = "unstable")]
 /// A loaned Zenoh publication cache.
 get_opaque_type_data!(
     zenoh_ext::PublicationCache<'static>,
@@ -450,10 +454,12 @@ get_opaque_type_data!(
 /// An loaned Zenoh ring reply handler.
 get_opaque_type_data!(RingChannelHandler<Reply>, z_loaned_ring_handler_reply_t);
 
+#[cfg(feature = "unstable")]
 /// An owned Zenoh-allocated source info`.
 get_opaque_type_data!(SourceInfo, z_owned_source_info_t);
+#[cfg(feature = "unstable")]
 /// A loaned source info.
 get_opaque_type_data!(SourceInfo, z_loaned_source_info_t);
-
+#[cfg(feature = "unstable")]
 /// An entity gloabal id.
 get_opaque_type_data!(EntityGlobalId, z_entity_global_id_t);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,6 +23,16 @@ foreach(file ${files})
             continue()
         endif()
     endif()
+    # Exclude Liveliness and zenoh-ext examples if unstable api feature is disabled
+    if(NOT(ZENOHC_BUILD_WITH_UNSTABLE_API))
+        if(
+            (${target} MATCHES "^.*_liveliness.*$") 
+            OR (${target} MATCHES "^.*_pub_cache.*$") 
+            OR (${target} MATCHES "^.*_query_sub.*$")
+        )
+            continue()
+        endif()
+    endif()
 
     # FIXME: remove once zenoh time primitives are available and examples updated
     if(NOT(UNIX) AND(${target} STREQUAL "z_ping" OR ${target} STREQUAL "z_pong" OR ${target} STREQUAL "z_sub_thr"))

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -76,6 +76,7 @@ typedef enum z_consolidation_mode_t {
 /**
  * Intersection level of 2 key expressions.
  */
+#if defined(UNSTABLE)
 typedef enum z_keyexpr_intersection_level_t {
   /**
    * 2 key expressions do not intersect.
@@ -94,6 +95,7 @@ typedef enum z_keyexpr_intersection_level_t {
    */
   Z_KEYEXPR_INTERSECTION_LEVEL_EQUALS = 3,
 } z_keyexpr_intersection_level_t;
+#endif
 /**
  * The priority of zenoh messages.
  */
@@ -528,10 +530,12 @@ typedef struct z_get_options_t {
    * The priority of the query.
    */
   enum z_priority_t priority;
+#if defined(UNSTABLE)
   /**
    * The source info for the query.
    */
   struct z_owned_source_info_t *source_info;
+#endif
   /**
    * An optional attachment to attach to the query.
    */
@@ -563,10 +567,12 @@ typedef struct z_publisher_put_options_t {
    * The timestamp of the publication.
    */
   struct z_timestamp_t *timestamp;
+#if defined(UNSTABLE)
   /**
    * The source info for the publication.
    */
   struct z_owned_source_info_t *source_info;
+#endif
   /**
    * The attachment to attach to the publication.
    */
@@ -602,10 +608,12 @@ typedef struct z_put_options_t {
    */
   enum zc_locality_t allowed_destination;
 #endif
+#if defined(UNSTABLE)
   /**
    * The source info for the message.
    */
   struct z_owned_source_info_t *source_info;
+#endif
   /**
    * The attachment to this message.
    */
@@ -636,10 +644,12 @@ typedef struct z_query_reply_options_t {
    * The timestamp of the reply.
    */
   struct z_timestamp_t *timestamp;
+#if defined(UNSTABLE)
   /**
    * The source info for the reply.
    */
   struct z_owned_source_info_t *source_info;
+#endif
   /**
    * The attachment to this reply.
    */
@@ -666,10 +676,12 @@ typedef struct z_query_reply_del_options_t {
    * The timestamp of the reply.
    */
   struct z_timestamp_t *timestamp;
+#if defined(UNSTABLE)
   /**
    * The source info for the reply.
    */
   struct z_owned_source_info_t *source_info;
+#endif
   /**
    * The attachment to this reply.
    */
@@ -820,24 +832,31 @@ typedef struct zc_owned_closure_matching_status_t {
 /**
  * The options for `zc_liveliness_declare_token()`.
  */
+#if defined(UNSTABLE)
 typedef struct zc_liveliness_declaration_options_t {
   uint8_t _dummy;
 } zc_liveliness_declaration_options_t;
+#endif
 /**
  * The options for `zc_liveliness_declare_subscriber()`
  */
+#if defined(UNSTABLE)
 typedef struct zc_liveliness_subscriber_options_t {
   uint8_t _dummy;
 } zc_liveliness_subscriber_options_t;
+#endif
 /**
  * The options for `zc_liveliness_get()`
  */
+#if defined(UNSTABLE)
 typedef struct zc_liveliness_get_options_t {
   uint32_t timeout_ms;
 } zc_liveliness_get_options_t;
+#endif
 /**
  * Options passed to the `ze_declare_publication_cache()` function.
  */
+#if defined(UNSTABLE)
 typedef struct ze_publication_cache_options_t {
   /**
    * The prefix used for queryable.
@@ -862,11 +881,13 @@ typedef struct ze_publication_cache_options_t {
    */
   size_t resources_limit;
 } ze_publication_cache_options_t;
+#endif
 /**
  * A set of options that can be applied to a querying subscriber,
  * upon its declaration via `ze_declare_querying_subscriber()`.
  *
  */
+#if defined(UNSTABLE)
 typedef struct ze_querying_subscriber_options_t {
   /**
    * The subscription reliability.
@@ -901,6 +922,7 @@ typedef struct ze_querying_subscriber_options_t {
    */
   uint64_t query_timeout_ms;
 } ze_querying_subscriber_options_t;
+#endif
 ZENOHC_API extern const unsigned int Z_ROUTER;
 ZENOHC_API extern const unsigned int Z_PEER;
 ZENOHC_API extern const unsigned int Z_CLIENT;
@@ -2215,11 +2237,15 @@ ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint8(void);
 /**
  * Returns the entity id of the entity global id.
  */
+#if defined(UNSTABLE)
 ZENOHC_API uint32_t z_entity_global_id_eid(const struct z_entity_global_id_t *this_);
+#endif
 /**
  * Returns the zenoh id of entity global id.
  */
+#if defined(UNSTABLE)
 ZENOHC_API struct z_id_t z_entity_global_id_zid(const struct z_entity_global_id_t *this_);
+#endif
 /**
  * Constructs send and recieve ends of the fifo channel
  */
@@ -2554,9 +2580,11 @@ ZENOHC_API void z_keyexpr_null(struct z_owned_keyexpr_t *this_);
  *
  * Note that this is slower than `z_keyexpr_intersects` and `keyexpr_includes`, so you should favor these methods for most applications.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 enum z_keyexpr_intersection_level_t z_keyexpr_relation_to(const struct z_loaned_keyexpr_t *left,
                                                           const struct z_loaned_keyexpr_t *right);
+#endif
 /**
  * Returns ``true`` if `this` is valid.
  */
@@ -2697,7 +2725,9 @@ ZENOHC_API void z_publisher_drop(struct z_owned_publisher_t *this_);
 /**
  * Returns the ID of the publisher.
  */
+#if defined(UNSTABLE)
 ZENOHC_API struct z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
+#endif
 /**
  * Returns the key expression of the publisher.
  */
@@ -3210,8 +3240,10 @@ ZENOHC_API enum z_priority_t z_sample_priority(const struct z_loaned_sample_t *t
 /**
  * Returns the sample source_info.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 const struct z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
+#endif
 /**
  * Returns the sample timestamp.
  *
@@ -3599,35 +3631,49 @@ ZENOHC_API z_error_t z_slice_wrap(struct z_owned_slice_t *this_, const uint8_t *
 /**
  * Returns ``true`` if source info is valid, ``false`` if it is in gravestone state.
  */
+#if defined(UNSTABLE)
 ZENOHC_API bool z_source_info_check(const struct z_owned_source_info_t *this_);
+#endif
 /**
  * Frees the memory and invalidates the source info, resetting it to a gravestone state.
  */
+#if defined(UNSTABLE)
 ZENOHC_API void z_source_info_drop(struct z_owned_source_info_t *this_);
+#endif
 /**
  * Returns the source_id of the source info.
  */
+#if defined(UNSTABLE)
 ZENOHC_API struct z_entity_global_id_t z_source_info_id(const struct z_loaned_source_info_t *this_);
+#endif
 /**
  * Borrows source info.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 const struct z_loaned_source_info_t *z_source_info_loan(const struct z_owned_source_info_t *this_);
+#endif
 /**
  * Create source info
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 z_error_t z_source_info_new(struct z_owned_source_info_t *this_,
                             const struct z_entity_global_id_t *source_id,
                             uint64_t source_sn);
+#endif
 /**
  * Constructs source info in its gravestone state.
  */
+#if defined(UNSTABLE)
 ZENOHC_API void z_source_info_null(struct z_owned_source_info_t *this_);
+#endif
 /**
  * Returns the source_sn of the source info.
  */
+#if defined(UNSTABLE)
 ZENOHC_API uint64_t z_source_info_sn(const struct z_loaned_source_info_t *this_);
+#endif
 /**
  * @return ``true`` if the string array is valid, ``false`` if it is in a gravestone state.
  */
@@ -4062,14 +4108,12 @@ const struct zc_loaned_closure_matching_status_t *zc_closure_matching_status_loa
 #if defined(UNSTABLE)
 ZENOHC_API void zc_closure_matching_status_null(struct zc_owned_closure_matching_status_t *this_);
 #endif
-
 /**
  * Constructs a configuration by parsing a file path stored in ZENOH_CONFIG environmental variable.
  *
  * Returns 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API z_error_t zc_config_from_env(struct z_owned_config_t *this_);
-
 /**
  * Constructs a configuration by parsing a file at `path`. Currently supported format is JSON5, a superset of JSON.
  *
@@ -4139,8 +4183,10 @@ ZENOHC_API void zc_init_logger(void);
 /**
  * Constructs default value for `zc_liveliness_declaration_options_t`.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 void zc_liveliness_declaration_options_default(struct zc_liveliness_declaration_options_t *this_);
+#endif
 /**
  * Declares a subscriber on liveliness tokens that intersect `key_expr`.
  *
@@ -4152,12 +4198,14 @@ void zc_liveliness_declaration_options_default(struct zc_liveliness_declaration_
  *
  * @return 0 in case of success, negative error values otherwise.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 z_error_t zc_liveliness_declare_subscriber(struct z_owned_subscriber_t *this_,
                                            const struct z_loaned_session_t *session,
                                            const struct z_loaned_keyexpr_t *key_expr,
                                            struct z_owned_closure_sample_t *callback,
                                            struct zc_liveliness_subscriber_options_t *_options);
+#endif
 /**
  * Constructs and declares a liveliness token on the network.
  *
@@ -4169,11 +4217,13 @@ z_error_t zc_liveliness_declare_subscriber(struct z_owned_subscriber_t *this_,
  * @param key_expr: A keyexpr to declare a liveliess token for.
  * @param _options: Liveliness token declaration properties.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 z_error_t zc_liveliness_declare_token(struct zc_owned_liveliness_token_t *this_,
                                       const struct z_loaned_session_t *session,
                                       const struct z_loaned_keyexpr_t *key_expr,
                                       const struct zc_liveliness_declaration_options_t *_options);
+#endif
 /**
  * Queries liveliness tokens currently on the network with a key expression intersecting with `key_expr`.
  *
@@ -4182,41 +4232,57 @@ z_error_t zc_liveliness_declare_token(struct zc_owned_liveliness_token_t *this_,
  * @param callback: The callback function that will be called for each received reply.
  * @param options: Additional options for the liveliness get operation.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 z_error_t zc_liveliness_get(const struct z_loaned_session_t *session,
                             const struct z_loaned_keyexpr_t *key_expr,
                             struct z_owned_closure_reply_t *callback,
                             struct zc_liveliness_get_options_t *options);
+#endif
 /**
  * Constructs default value `zc_liveliness_get_options_t`.
  */
+#if defined(UNSTABLE)
 ZENOHC_API void zc_liveliness_get_options_default(struct zc_liveliness_get_options_t *this_);
+#endif
 /**
  * Constucts default value for `zc_liveliness_declare_subscriber_options_t`.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 void zc_liveliness_subscriber_options_default(struct zc_liveliness_subscriber_options_t *this_);
+#endif
 /**
  * Returns ``true`` if liveliness token is valid, ``false`` otherwise.
  */
+#if defined(UNSTABLE)
 ZENOHC_API bool zc_liveliness_token_check(const struct zc_owned_liveliness_token_t *this_);
+#endif
 /**
  * Undeclares liveliness token, frees memory and resets it to a gravestone state.
  */
+#if defined(UNSTABLE)
 ZENOHC_API void zc_liveliness_token_drop(struct zc_owned_liveliness_token_t *this_);
+#endif
 /**
  * Borrows token.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 const struct zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const struct zc_owned_liveliness_token_t *this_);
+#endif
 /**
  * Constructs liveliness token in its gravestone state.
  */
+#if defined(UNSTABLE)
 ZENOHC_API void zc_liveliness_token_null(struct zc_owned_liveliness_token_t *this_);
+#endif
 /**
  * Destroys a liveliness token, notifying subscribers of its destruction.
  */
+#if defined(UNSTABLE)
 ZENOHC_API z_error_t zc_liveliness_undeclare_token(struct zc_owned_liveliness_token_t *this_);
+#endif
 /**
  * Returns default value of `zc_locality_t`
  */
@@ -4307,11 +4373,13 @@ ZENOHC_API void zc_shm_client_list_null(zc_owned_shm_client_list_t *this_);
  *
  * @returns 0 in case of success, negative error code otherwise.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 z_error_t ze_declare_publication_cache(struct ze_owned_publication_cache_t *this_,
                                        const struct z_loaned_session_t *session,
                                        const struct z_loaned_keyexpr_t *key_expr,
                                        struct ze_publication_cache_options_t *options);
+#endif
 /**
  * Constructs and declares a querying subscriber for a given key expression.
  *
@@ -4323,67 +4391,93 @@ z_error_t ze_declare_publication_cache(struct ze_owned_publication_cache_t *this
  *
  * @return 0 in case of success, negative error code otherwise.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 z_error_t ze_declare_querying_subscriber(struct ze_owned_querying_subscriber_t *this_,
                                          const struct z_loaned_session_t *session,
                                          const struct z_loaned_keyexpr_t *key_expr,
                                          struct z_owned_closure_sample_t *callback,
                                          struct ze_querying_subscriber_options_t *options);
+#endif
 /**
  * Returns ``true`` if publication cache is valid, ``false`` otherwise.
  */
+#if defined(UNSTABLE)
 ZENOHC_API bool ze_publication_cache_check(const struct ze_owned_publication_cache_t *this_);
+#endif
 /**
  * Drops publication cache. Also attempts to undeclare it.
  */
+#if defined(UNSTABLE)
 ZENOHC_API void ze_publication_cache_drop(struct ze_owned_publication_cache_t *this_);
+#endif
 /**
  * Constructs a publication cache in a gravestone state.
  */
+#if defined(UNSTABLE)
 ZENOHC_API void ze_publication_cache_null(struct ze_owned_publication_cache_t *this_);
+#endif
 /**
  * Constructs the default value for `ze_publication_cache_options_t`.
  */
+#if defined(UNSTABLE)
 ZENOHC_API void ze_publication_cache_options_default(struct ze_publication_cache_options_t *this_);
+#endif
 /**
  * Returns ``true`` if querying subscriber is valid, ``false`` otherwise.
  */
+#if defined(UNSTABLE)
 ZENOHC_API bool ze_querying_subscriber_check(const struct ze_owned_querying_subscriber_t *this_);
+#endif
 /**
  * Drops querying subscriber. Also attempts to undeclare it.
  */
+#if defined(UNSTABLE)
 ZENOHC_API void ze_querying_subscriber_drop(struct ze_owned_querying_subscriber_t *this_);
+#endif
 /**
  * Make querying subscriber perform an additional query on a specified selector.
  * The queried samples will be merged with the received publications and made available in the subscriber callback.
  * @return 0 in case of success, negative error code otherwise.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 z_error_t ze_querying_subscriber_get(const struct ze_loaned_querying_subscriber_t *this_,
                                      const struct z_loaned_keyexpr_t *selector,
                                      const struct z_get_options_t *options);
+#endif
 /**
  * Borrows querying subscriber.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 const struct ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const struct ze_owned_querying_subscriber_t *this_);
+#endif
 /**
  * Constructs a querying subscriber in a gravestone state.
  */
+#if defined(UNSTABLE)
 ZENOHC_API void ze_querying_subscriber_null(struct ze_owned_querying_subscriber_t *this_);
+#endif
 /**
  * Constructs the default value for `ze_querying_subscriber_options_t`.
  */
+#if defined(UNSTABLE)
 ZENOHC_API
 void ze_querying_subscriber_options_default(struct ze_querying_subscriber_options_t *this_);
+#endif
 /**
  * Undeclares and drops publication cache.
  * @return 0 in case of success, negative error code otherwise.
  */
+#if defined(UNSTABLE)
 ZENOHC_API z_error_t ze_undeclare_publication_cache(struct ze_owned_publication_cache_t *this_);
+#endif
 /**
  * Undeclares the given querying subscriber, drops it and resets to a gravestone state.
  *
  * @return 0 in case of success, negative error code otherwise.
  */
+#if defined(UNSTABLE)
 ZENOHC_API z_error_t ze_undeclare_querying_subscriber(struct ze_owned_querying_subscriber_t *this_);
+#endif

--- a/splitguide.yaml
+++ b/splitguide.yaml
@@ -33,8 +33,8 @@ zenoh_opaque.h:
   - z_loaned_query_t!
   - z_owned_queryable_t!
   - z_loaned_queryable_t!
-  - ze_owned_querying_subscriber_t!
-  - ze_loaned_querying_subscriber_t!
+  - ze_owned_querying_subscriber_t!#unstable
+  - ze_loaned_querying_subscriber_t!#unstable
   - z_owned_keyexpr_t!
   - z_view_keyexpr_t!
   - z_loaned_keyexpr_t!
@@ -42,9 +42,9 @@ zenoh_opaque.h:
   - z_loaned_session_t!
   - z_owned_config_t!
   - z_loaned_config_t!
-  - z_owned_source_info_t!
-  - z_loaned_source_info_t!
-  - z_entity_global_id_t!
+  - z_owned_source_info_t!#unstable
+  - z_loaned_source_info_t!#unstable
+  - z_entity_global_id_t!#unstable
   - z_id_t!
   - z_timestamp_t!
   - z_owned_publisher_t!
@@ -52,9 +52,9 @@ zenoh_opaque.h:
   - zc_owned_matching_listener_t!#unstable
   - z_owned_subscriber_t!
   - z_loaned_subscriber_t!
-  - zc_owned_liveliness_token_t!
-  - zc_loaned_liveliness_token_t!
-  - ze_owned_publication_cache_t!
+  - zc_owned_liveliness_token_t!#unstable
+  - zc_loaned_liveliness_token_t!#unstable
+  - ze_owned_publication_cache_t!#unstable
   - z_owned_mutex_t!
   - z_loaned_mutex_t!
   - z_owned_condvar_t!

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -18,16 +18,21 @@ use libc::c_ulong;
 use zenoh::{
     qos::{CongestionControl, Priority},
     query::{ConsolidationMode, QueryTarget},
-    sample::{Sample, SampleKind, SourceInfo},
-    session::EntityGlobalId,
+    sample::{Sample, SampleKind},
     time::Timestamp,
 };
 #[cfg(feature = "unstable")]
-use zenoh::{query::ReplyKeyExpr, sample::Locality};
+use zenoh::{
+    query::ReplyKeyExpr,
+    sample::{Locality, SourceInfo},
+    session::EntityGlobalId,
+};
 
+#[cfg(feature = "unstable")]
+use crate::transmute::IntoCType;
 use crate::{
     errors,
-    transmute::{CTypeRef, IntoCType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{CTypeRef, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
     z_id_t, z_loaned_bytes_t, z_loaned_encoding_t, z_loaned_keyexpr_t, z_loaned_session_t,
 };
 
@@ -138,7 +143,7 @@ pub extern "C" fn z_sample_attachment(this: &z_loaned_sample_t) -> *const z_loan
         None => null(),
     }
 }
-
+#[cfg(feature = "unstable")]
 /// Returns the sample source_info.
 #[no_mangle]
 pub extern "C" fn z_sample_source_info(this: &z_loaned_sample_t) -> &z_loaned_source_info_t {
@@ -450,25 +455,32 @@ impl From<z_congestion_control_t> for CongestionControl {
     }
 }
 
+#[cfg(feature = "unstable")]
 use crate::z_entity_global_id_t;
+#[cfg(feature = "unstable")]
 decl_c_type!(copy(z_entity_global_id_t, EntityGlobalId));
 
+#[cfg(feature = "unstable")]
 /// Returns the zenoh id of entity global id.
 #[no_mangle]
 pub extern "C" fn z_entity_global_id_zid(this: &z_entity_global_id_t) -> z_id_t {
     this.as_rust_type_ref().zid().into_c_type()
 }
+#[cfg(feature = "unstable")]
 /// Returns the entity id of the entity global id.
 #[no_mangle]
 pub extern "C" fn z_entity_global_id_eid(this: &z_entity_global_id_t) -> u32 {
     this.as_rust_type_ref().eid()
 }
+#[cfg(feature = "unstable")]
 pub use crate::opaque_types::{z_loaned_source_info_t, z_owned_source_info_t};
+#[cfg(feature = "unstable")]
 decl_c_type!(
     owned(z_owned_source_info_t, SourceInfo),
     loaned(z_loaned_source_info_t, SourceInfo)
 );
 
+#[cfg(feature = "unstable")]
 /// Create source info
 #[no_mangle]
 pub extern "C" fn z_source_info_new(
@@ -485,6 +497,7 @@ pub extern "C" fn z_source_info_new(
     errors::Z_OK
 }
 
+#[cfg(feature = "unstable")]
 /// Returns the source_id of the source info.
 #[no_mangle]
 pub extern "C" fn z_source_info_id(this: &z_loaned_source_info_t) -> z_entity_global_id_t {
@@ -495,30 +508,35 @@ pub extern "C" fn z_source_info_id(this: &z_loaned_source_info_t) -> z_entity_gl
     .into_c_type()
 }
 
+#[cfg(feature = "unstable")]
 /// Returns the source_sn of the source info.
 #[no_mangle]
 pub extern "C" fn z_source_info_sn(this: &z_loaned_source_info_t) -> u64 {
     this.as_rust_type_ref().source_sn.unwrap_or(0)
 }
 
+#[cfg(feature = "unstable")]
 /// Returns ``true`` if source info is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
 pub extern "C" fn z_source_info_check(this: &z_owned_source_info_t) -> bool {
     this.as_rust_type_ref().source_id.is_some() || this.as_rust_type_ref().source_sn.is_some()
 }
 
+#[cfg(feature = "unstable")]
 /// Borrows source info.
 #[no_mangle]
 pub extern "C" fn z_source_info_loan(this: &z_owned_source_info_t) -> &z_loaned_source_info_t {
     this.as_rust_type_ref().as_loaned_c_type_ref()
 }
 
+#[cfg(feature = "unstable")]
 /// Frees the memory and invalidates the source info, resetting it to a gravestone state.
 #[no_mangle]
 pub extern "C" fn z_source_info_drop(this: &mut z_owned_source_info_t) {
     *this.as_rust_type_mut() = SourceInfo::default();
 }
 
+#[cfg(feature = "unstable")]
 /// Constructs source info in its gravestone state.
 #[no_mangle]
 pub extern "C" fn z_source_info_null(this: &mut MaybeUninit<z_owned_source_info_t>) {

--- a/src/get.rs
+++ b/src/get.rs
@@ -32,13 +32,13 @@ use crate::{
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
     z_closure_reply_call, z_closure_reply_loan, z_congestion_control_t, z_consolidation_mode_t,
     z_loaned_bytes_t, z_loaned_encoding_t, z_loaned_keyexpr_t, z_loaned_sample_t,
-    z_loaned_session_t, z_owned_bytes_t, z_owned_closure_reply_t, z_owned_encoding_t,
-    z_owned_source_info_t, z_priority_t, z_query_target_t,
+    z_loaned_session_t, z_owned_bytes_t, z_owned_closure_reply_t, z_owned_encoding_t, z_priority_t,
+    z_query_target_t,
 };
 #[cfg(feature = "unstable")]
 use crate::{
-    transmute::IntoCType, z_id_t, zc_locality_default, zc_locality_t, zc_reply_keyexpr_default,
-    zc_reply_keyexpr_t,
+    transmute::IntoCType, z_id_t, z_owned_source_info_t, zc_locality_default, zc_locality_t,
+    zc_reply_keyexpr_default, zc_reply_keyexpr_t,
 };
 
 // we need to add Default to ReplyError
@@ -202,6 +202,7 @@ pub struct z_get_options_t {
     pub accept_replies: zc_reply_keyexpr_t,
     /// The priority of the query.
     pub priority: z_priority_t,
+    #[cfg(feature = "unstable")]
     /// The source info for the query.
     pub source_info: *mut z_owned_source_info_t,
     /// An optional attachment to attach to the query.
@@ -226,6 +227,7 @@ pub extern "C" fn z_get_options_default(this: &mut z_get_options_t) {
         timeout_ms: 0,
         payload: null_mut(),
         encoding: null_mut(),
+        #[cfg(feature = "unstable")]
         source_info: null_mut(),
         attachment: null_mut(),
     };
@@ -269,6 +271,7 @@ pub unsafe extern "C" fn z_get(
             let encoding = std::mem::take(encoding.as_rust_type_mut());
             get = get.encoding(encoding);
         }
+        #[cfg(feature = "unstable")]
         if let Some(source_info) = unsafe { options.source_info.as_mut() } {
             let source_info = std::mem::take(source_info.as_rust_type_mut());
             get = get.source_info(source_info);

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -14,8 +14,10 @@
 use std::{error::Error, mem::MaybeUninit};
 
 use libc::c_char;
+#[cfg(feature = "unstable")]
+use zenoh::key_expr::SetIntersectionLevel;
 use zenoh::{
-    key_expr::{keyexpr, Canonize, KeyExpr, SetIntersectionLevel},
+    key_expr::{keyexpr, Canonize, KeyExpr},
     prelude::*,
 };
 
@@ -600,7 +602,7 @@ pub extern "C" fn z_keyexpr_join(
         }
     }
 }
-
+#[cfg(feature = "unstable")]
 /// Intersection level of 2 key expressions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(C)]
@@ -614,7 +616,7 @@ pub enum z_keyexpr_intersection_level_t {
     /// 2 key expressions are equal.
     EQUALS = 3,
 }
-
+#[cfg(feature = "unstable")]
 impl From<SetIntersectionLevel> for z_keyexpr_intersection_level_t {
     fn from(val: SetIntersectionLevel) -> Self {
         match val {
@@ -625,7 +627,7 @@ impl From<SetIntersectionLevel> for z_keyexpr_intersection_level_t {
         }
     }
 }
-
+#[cfg(feature = "unstable")]
 #[no_mangle]
 /// Returns the relation between `left` and `right` from `left`'s point of view.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,22 +50,27 @@ mod session;
 pub use crate::session::*;
 mod subscriber;
 pub use crate::subscriber::*;
-// // mod pull_subscriber;
-// // pub use crate::pull_subscriber::*;
 mod publisher;
 pub use crate::publisher::*;
 mod closures;
 pub use closures::*;
-mod liveliness;
-pub use liveliness::*;
-mod publication_cache;
-pub use publication_cache::*;
-mod querying_subscriber;
+pub mod platform;
 pub use platform::*;
+#[cfg(feature = "unstable")]
+mod liveliness;
+#[cfg(feature = "unstable")]
+pub use liveliness::*;
+#[cfg(feature = "unstable")]
+mod publication_cache;
+#[cfg(feature = "unstable")]
+pub use publication_cache::*;
+#[cfg(feature = "unstable")]
+mod querying_subscriber;
+#[cfg(feature = "unstable")]
 pub use querying_subscriber::*;
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
 pub mod context;
-pub mod platform;
+
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
 pub mod shm;
 

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -27,12 +27,13 @@ use zenoh::{
 
 use crate::{
     errors,
-    transmute::{IntoCType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
-    z_congestion_control_t, z_entity_global_id_t, z_loaned_keyexpr_t, z_loaned_session_t,
-    z_owned_bytes_t, z_owned_encoding_t, z_owned_source_info_t, z_priority_t, z_timestamp_t,
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    z_congestion_control_t, z_loaned_keyexpr_t, z_loaned_session_t, z_owned_bytes_t,
+    z_owned_encoding_t, z_priority_t, z_timestamp_t,
 };
 #[cfg(feature = "unstable")]
 use crate::{
+    transmute::IntoCType, z_entity_global_id_t, z_owned_source_info_t,
     zc_closure_matching_status_call, zc_closure_matching_status_loan, zc_locality_default,
     zc_locality_t, zc_owned_closure_matching_status_t,
 };
@@ -166,6 +167,7 @@ pub struct z_publisher_put_options_t {
     pub encoding: *mut z_owned_encoding_t,
     /// The timestamp of the publication.
     pub timestamp: *mut z_timestamp_t,
+    #[cfg(feature = "unstable")]
     /// The source info for the publication.
     pub source_info: *mut z_owned_source_info_t,
     /// The attachment to attach to the publication.
@@ -179,6 +181,7 @@ pub extern "C" fn z_publisher_put_options_default(this: &mut z_publisher_put_opt
     *this = z_publisher_put_options_t {
         encoding: ptr::null_mut(),
         timestamp: ptr::null_mut(),
+        #[cfg(feature = "unstable")]
         source_info: ptr::null_mut(),
         attachment: ptr::null_mut(),
     }
@@ -211,6 +214,7 @@ pub unsafe extern "C" fn z_publisher_put(
             let encoding = std::mem::take(encoding.as_rust_type_mut());
             put = put.encoding(encoding);
         };
+        #[cfg(feature = "unstable")]
         if let Some(source_info) = unsafe { options.source_info.as_mut() } {
             let source_info = std::mem::take(source_info.as_rust_type_mut());
             put = put.source_info(source_info);
@@ -277,7 +281,7 @@ pub extern "C" fn z_publisher_delete(
         errors::Z_OK
     }
 }
-
+#[cfg(feature = "unstable")]
 /// Returns the ID of the publisher.
 #[no_mangle]
 pub extern "C" fn z_publisher_id(publisher: &z_loaned_publisher_t) -> z_entity_global_id_t {

--- a/src/put.rs
+++ b/src/put.rs
@@ -40,6 +40,7 @@ pub struct z_put_options_t {
     #[cfg(feature = "unstable")]
     /// The allowed destination of this message.
     pub allowed_destination: zc_locality_t,
+    #[cfg(feature = "unstable")]
     /// The source info for the message.
     pub source_info: *mut z_owned_source_info_t,
     /// The attachment to this message.
@@ -58,6 +59,7 @@ pub extern "C" fn z_put_options_default(this: &mut z_put_options_t) {
         timestamp: null_mut(),
         #[cfg(feature = "unstable")]
         allowed_destination: zc_locality_default(),
+        #[cfg(feature = "unstable")]
         source_info: null_mut(),
         attachment: null_mut(),
     };
@@ -89,6 +91,7 @@ pub extern "C" fn z_put(
             let encoding = std::mem::take(encoding.as_rust_type_mut());
             put = put.encoding(encoding);
         };
+        #[cfg(feature = "unstable")]
         if let Some(source_info) = unsafe { options.source_info.as_mut() } {
             let source_info = std::mem::take(source_info.as_rust_type_mut());
             put = put.source_info(source_info);

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -21,13 +21,15 @@ use zenoh::{
 };
 
 pub use crate::opaque_types::{z_loaned_queryable_t, z_owned_queryable_t};
+#[cfg(feature = "unstable")]
+use crate::z_owned_source_info_t;
 use crate::{
     errors,
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
     z_closure_query_call, z_closure_query_loan, z_congestion_control_t, z_loaned_bytes_t,
     z_loaned_encoding_t, z_loaned_keyexpr_t, z_loaned_session_t, z_owned_bytes_t,
-    z_owned_closure_query_t, z_owned_encoding_t, z_owned_source_info_t, z_priority_t,
-    z_timestamp_t, z_view_string_from_substr, z_view_string_t,
+    z_owned_closure_query_t, z_owned_encoding_t, z_priority_t, z_timestamp_t,
+    z_view_string_from_substr, z_view_string_t,
 };
 decl_c_type!(
     owned(z_owned_queryable_t, Option<Queryable<'static, ()>>),
@@ -118,6 +120,7 @@ pub struct z_query_reply_options_t {
     pub is_express: bool,
     /// The timestamp of the reply.
     pub timestamp: *mut z_timestamp_t,
+    #[cfg(feature = "unstable")]
     /// The source info for the reply.
     pub source_info: *mut z_owned_source_info_t,
     /// The attachment to this reply.
@@ -134,6 +137,7 @@ pub extern "C" fn z_query_reply_options_default(this: &mut z_query_reply_options
         priority: Priority::default().into(),
         is_express: false,
         timestamp: null_mut(),
+        #[cfg(feature = "unstable")]
         source_info: null_mut(),
         attachment: null_mut(),
     };
@@ -170,6 +174,7 @@ pub struct z_query_reply_del_options_t {
     pub is_express: bool,
     /// The timestamp of the reply.
     pub timestamp: *mut z_timestamp_t,
+    #[cfg(feature = "unstable")]
     /// The source info for the reply.
     pub source_info: *mut z_owned_source_info_t,
     /// The attachment to this reply.
@@ -185,6 +190,7 @@ pub extern "C" fn z_query_reply_del_options_default(this: &mut z_query_reply_del
         priority: Priority::default().into(),
         is_express: false,
         timestamp: null_mut(),
+        #[cfg(feature = "unstable")]
         source_info: null_mut(),
         attachment: null_mut(),
     };
@@ -294,6 +300,7 @@ pub extern "C" fn z_query_reply(
             let encoding = std::mem::take(encoding.as_rust_type_mut());
             reply = reply.encoding(encoding);
         };
+        #[cfg(feature = "unstable")]
         if let Some(source_info) = unsafe { options.source_info.as_mut() } {
             let source_info = std::mem::take(source_info.as_rust_type_mut());
             reply = reply.source_info(source_info);
@@ -383,6 +390,7 @@ pub unsafe extern "C" fn z_query_reply_del(
 
     let mut reply = query.reply_del(key_expr);
     if let Some(options) = options {
+        #[cfg(feature = "unstable")]
         if let Some(source_info) = unsafe { options.source_info.as_mut() } {
             let source_info = std::mem::take(source_info.as_rust_type_mut());
             reply = reply.source_info(source_info);

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -179,6 +179,7 @@ pub unsafe extern "C" fn ze_querying_subscriber_get(
                         let encoding = std::mem::take(encoding.as_rust_type_mut());
                         get = get.encoding(encoding);
                     }
+                    #[cfg(feature = "unstable")]
                     if let Some(source_info) = unsafe { options.source_info.as_mut() } {
                         let source_info = std::mem::take(source_info.as_rust_type_mut());
                         get = get.source_info(source_info);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,13 @@ foreach(file ${files})
         endif()
     endif()
 
+    # Exclude Liveliness and zenoh-ext tests if unstable api feature is disabled
+    if(NOT(ZENOHC_BUILD_WITH_UNSTABLE_API))
+	    if((${target} MATCHES "^.*_liveliness.*$") OR (${target} MATCHES "^.*_query_sub_test.*$"))
+            continue()
+        endif()
+    endif()
+
     # Check the filename prefix to determine the test type
     if (${file} MATCHES "^.*z_api_.*$")
         set(test_type "unit")

--- a/tests/z_api_keyexpr_test.c
+++ b/tests/z_api_keyexpr_test.c
@@ -97,6 +97,7 @@ void undeclare() {
     assert(!z_keyexpr_check(&ke));
 }
 
+#if defined(UNSTABLE)
 void relation_to() {
     z_view_keyexpr_t foobar, foostar, barstar;
     z_view_keyexpr_from_str(&foobar, "foo/bar");
@@ -108,11 +109,14 @@ void relation_to() {
     assert(z_keyexpr_relation_to(z_loan(foostar), z_loan(foostar)) == Z_KEYEXPR_INTERSECTION_LEVEL_EQUALS);
     assert(z_keyexpr_relation_to(z_loan(barstar), z_loan(foobar)) == Z_KEYEXPR_INTERSECTION_LEVEL_DISJOINT);
 }
+#endif
 
 int main(int argc, char **argv) {
     canonize();
     includes();
     intersects();
     undeclare();
+#if defined(UNSTABLE)
     relation_to();
+#endif
 }

--- a/tests/z_int_pub_sub_test.c
+++ b/tests/z_int_pub_sub_test.c
@@ -103,12 +103,13 @@ void data_handler(const z_loaned_sample_t *sample, void *arg) {
         perror("Unexpected QoS values");
         exit(-1);
     }
-
+#if defined(UNSTABLE)
     const z_loaned_source_info_t *source_info = z_sample_source_info(sample);
     if (source_info == NULL) {
         perror("Unexpected null source_info");
         exit(-1);
     }
+#endif
     // See https://github.com/eclipse-zenoh/zenoh/issues/1203
     // const uint64_t sn = z_source_info_sn(source_info);
     // if (sn != TEST_SN) {

--- a/tests/z_int_queryable_test.c
+++ b/tests/z_int_queryable_test.c
@@ -121,11 +121,13 @@ int run_get() {
                 exit(-1);
             }
 
+#if defined(UNSTABLE)
             const z_loaned_source_info_t *source_info = z_sample_source_info(sample);
             if (source_info == NULL) {
                 perror("Unexpected null source_info");
                 exit(-1);
             }
+#endif
             // See https://github.com/eclipse-zenoh/zenoh/issues/1203
             // const uint64_t sn = z_source_info_sn(source_info);
             // if (sn != TEST_SN) {


### PR DESCRIPTION
move SourceInfo, liveliness, KeyExpr::relation_to and zenoh-ext functionality under UNSTABLE feature