### PR TITLE
Cargo build before docs generation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,14 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+    rust: "1.75"
+  apt_packages:
+    - cargo
+  jobs:
+    # Run cargo build to build git ignored files that are platform specific (e.g. include/zenoh_opaque.h)
+    pre_build:
+      - cargo build --release --manifest-path=./Cargo.toml --features=logger-autoinit --features=unstable --features=shared-memory
+
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Some auto generated files (e.g. include/zenoh_opaque.h) are platform specific so they are git ignored. They contain documentation that should be published as well, so this step makes sure all the files are in the checkout before publishing them to readthedocs.io