### PR TITLE
Remove legacy slice methods

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,9 +39,7 @@ Functions
 
 .. doxygenfunction:: z_slice_empty
 .. doxygenfunction:: z_view_slice_empty
-.. doxygenfunction:: z_slice_wrap
 .. doxygenfunction:: z_view_slice_wrap
-.. doxygenfunction:: z_slice_from_str
 .. doxygenfunction:: z_slice_data
 .. doxygenfunction:: z_slice_len
 .. doxygenfunction:: z_slice_is_empty

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -3641,14 +3641,6 @@ ZENOHC_API void z_slice_drop(struct z_owned_slice_t *this_);
  */
 ZENOHC_API void z_slice_empty(struct z_owned_slice_t *this_);
 /**
- * Copies a string into `z_owned_slice_t` using `strlen` (this should therefore not be used with untrusted inputs).
- *
- * @return -1 if `str == NULL` (and creates an empty slice), 0 otherwise.
- */
-ZENOHC_API
-z_result_t z_slice_from_str(struct z_owned_slice_t *this_,
-                            const char *str);
-/**
  * @return ``true`` if slice is empty, ``false`` otherwise.
  */
 ZENOHC_API bool z_slice_is_empty(const struct z_loaned_slice_t *this_);
@@ -3664,12 +3656,6 @@ ZENOHC_API const struct z_loaned_slice_t *z_slice_loan(const struct z_owned_slic
  * Constructs an empty `z_owned_slice_t`.
  */
 ZENOHC_API void z_slice_null(struct z_owned_slice_t *this_);
-/**
- * Constructs a slice by copying a `len` bytes long sequence starting at `start`.
- *
- * @return -1 if `start == NULL` and `len > 0` (creating an empty slice), 0 otherwise.
- */
-ZENOHC_API z_result_t z_slice_wrap(struct z_owned_slice_t *this_, const uint8_t *start, size_t len);
 /**
  * Returns ``true`` if source info is valid, ``false`` if it is in gravestone state.
  */

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -288,47 +288,6 @@ pub extern "C" fn z_slice_null(this: &mut MaybeUninit<z_owned_slice_t>) {
     z_slice_empty(this);
 }
 
-/// Copies a string into `z_owned_slice_t` using `strlen` (this should therefore not be used with untrusted inputs).
-///
-/// @return -1 if `str == NULL` (and creates an empty slice), 0 otherwise.
-#[no_mangle]
-#[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_slice_from_str(
-    this: &mut MaybeUninit<z_owned_slice_t>,
-    str: *const c_char,
-) -> z_result_t {
-    if str.is_null() {
-        z_slice_empty(this);
-        result::Z_EINVAL
-    } else {
-        z_slice_wrap(this, str as *const u8, libc::strlen(str));
-        result::Z_OK
-    }
-}
-
-/// Constructs a slice by copying a `len` bytes long sequence starting at `start`.
-///
-/// @return -1 if `start == NULL` and `len > 0` (creating an empty slice), 0 otherwise.
-#[no_mangle]
-#[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_slice_wrap(
-    this: &mut MaybeUninit<z_owned_slice_t>,
-    start: *const u8,
-    len: usize,
-) -> z_result_t {
-    let this = this.as_rust_type_mut_uninit();
-    match CSliceOwned::new(start, len) {
-        Ok(slice) => {
-            this.write(slice);
-            result::Z_OK
-        }
-        Err(e) => {
-            this.write(CSliceOwned::default());
-            e
-        }
-    }
-}
-
 /// Frees the memory and invalidates the slice.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]


### PR DESCRIPTION
Methods `z_slice_wrap`, `z_slice_from_str` are legacy and we don't need them 

Closes: https://github.com/eclipse-zenoh/zenoh-c/issues/475