### PR TITLE
Allow providing custom delete function when serializing from pointers

### DIFF
--- a/build-resources/opaque-types/src/lib.rs
+++ b/build-resources/opaque-types/src/lib.rs
@@ -6,13 +6,6 @@ use std::{
     thread::JoinHandle,
 };
 
-#[cfg(feature = "unstable")]
-use zenoh::{
-    pubsub::MatchingListener,
-    liveliness::LivelinessToken,
-    session::{EntityGlobalId, ZenohId},
-    sample::SourceInfo,
-};
 use zenoh::{
     bytes::{Encoding, ZBytes, ZBytesIterator, ZBytesReader, ZBytesWriter},
     config::Config,
@@ -25,13 +18,20 @@ use zenoh::{
     session::Session,
     time::Timestamp,
 };
+#[cfg(feature = "unstable")]
+use zenoh::{
+    liveliness::LivelinessToken,
+    pubsub::MatchingListener,
+    sample::SourceInfo,
+    session::{EntityGlobalId, ZenohId},
+};
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
 use zenoh::{
     shm::zshm, shm::zshmmut, shm::AllocLayout, shm::BufAllocResult, shm::ChunkAllocResult,
     shm::ChunkDescriptor, shm::DynamicProtocolID, shm::MemoryLayout, shm::PosixShmProviderBackend,
     shm::ProtocolID, shm::ShmClient, shm::ShmClientStorage, shm::ShmProvider,
-    shm::ShmProviderBackend, shm::StaticProtocolID, shm::ZShm, shm::ZShmMut,
-    shm::POSIX_PROTOCOL_ID, shm::ZLayoutError,
+    shm::ShmProviderBackend, shm::StaticProtocolID, shm::ZLayoutError, shm::ZShm, shm::ZShmMut,
+    shm::POSIX_PROTOCOL_ID,
 };
 
 #[macro_export]
@@ -56,7 +56,7 @@ get_opaque_type_data!(ZBytes, z_owned_bytes_t);
 /// A loaned serialized Zenoh data.
 get_opaque_type_data!(ZBytes, z_loaned_bytes_t);
 
-type CSlice = (usize, isize);
+type CSlice = (usize, usize, usize, usize);
 
 /// A contiguous owned sequence of bytes allocated by Zenoh.
 get_opaque_type_data!(CSlice, z_owned_slice_t);

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,6 +38,7 @@ Functions
 .. doxygenfunction:: z_slice_drop
 
 .. doxygenfunction:: z_slice_empty
+.. doxygenfunction:: z_slice_from_buf
 .. doxygenfunction:: z_view_slice_empty
 .. doxygenfunction:: z_view_slice_wrap
 .. doxygenfunction:: z_slice_data
@@ -108,6 +109,8 @@ Functions
 ^^^^^^^^^
 .. doxygenfunction:: z_bytes_len
 .. doxygenfunction:: z_bytes_serialize_from_slice
+.. doxygenfunction:: z_bytes_serialize_from_buf
+.. doxygenfunction:: z_bytes_serialize_from_string
 .. doxygenfunction:: z_bytes_serialize_from_str
 .. doxygenfunction:: z_bytes_serialize_from_iter
 .. doxygenfunction:: z_bytes_serialize_from_pair

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -34,7 +34,7 @@ Publish
       }
       
       z_owned_bytes_t payload;
-      z_bytes_serialize_from_str(&payload, "value");
+      z_bytes_serialize_from_str(&payload, "value", NULL, NULL);
       z_view_keyexpr_t key_expr;
       z_view_keyexpr_from_string(&key_expr, "key/expression");
 
@@ -171,7 +171,7 @@ Queryable
       }
 
       z_owned_bytes_t reply_payload;
-      z_bytes_serialize_from_str(&reply_payload, "reply");
+      z_bytes_serialize_from_str(&reply_payload, "reply", NULL, NULL);
 
       z_view_keyexpr_t reply_keyexpr;
       z_view_keyexpr_from_string(&reply_keyexpr, (const char *)context);

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
 
     z_owned_bytes_t payload;
     if (value != NULL) {
-        z_bytes_serialize_from_str(&payload, value);
+        z_bytes_serialize_from_str(&payload, value, NULL, NULL);
         opts.payload = &payload;
     }
     z_get(z_loan(s), z_loan(keyexpr), "", z_move(closure),

--- a/examples/z_ping.c
+++ b/examples/z_ping.c
@@ -78,7 +78,7 @@ int main(int argc, char** argv) {
 
         unsigned long elapsed_us = 0;
         while (elapsed_us < args.warmup_ms * 1000) {
-            z_bytes_serialize_from_slice(&payload, data, args.size);
+            z_bytes_serialize_from_buf(&payload, data, args.size, NULL, NULL);
             z_publisher_put(z_loan(pub), z_move(payload), NULL);
             int s = z_condvar_wait(z_loan(cond), z_loan_mut(mutex));
             if (s != 0) {
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
     }
     unsigned long* results = z_malloc(sizeof(unsigned long) * args.number_of_pings);
     for (int i = 0; i < args.number_of_pings; i++) {
-        z_bytes_serialize_from_slice(&payload, data, args.size);
+        z_bytes_serialize_from_buf(&payload, data, args.size, NULL, NULL);
         z_clock_t measure_start = z_clock_now();
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
         int s = z_condvar_wait(z_loan(cond), z_loan_mut(mutex));

--- a/examples/z_pong.c
+++ b/examples/z_pong.c
@@ -5,11 +5,9 @@
 
 void callback(const z_loaned_sample_t* sample, void* context) {
     const z_loaned_publisher_t* pub = z_loan(*(z_owned_publisher_t*)context);
-#ifdef ZENOH_C  // The z_owned_bytes_t API is exclusive to zenoh-c, but allows avoiding some copies.
     z_owned_bytes_t payload;
     z_bytes_clone(&payload, z_sample_payload(sample));
     z_publisher_put(pub, z_move(payload), NULL);
-#endif
 }
 void drop(void* context) {
     z_owned_publisher_t* pub = (z_owned_publisher_t*)context;

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
         z_publisher_put_options_default(&options);
 
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_str(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf, NULL, NULL);
 
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -32,8 +32,8 @@ bool create_attachment_iter(z_owned_bytes_t* kv_pair, void* context) {
         return false;
     }
     z_owned_bytes_t k, v;
-    z_bytes_serialize_from_str(&k, it->current->key);
-    z_bytes_serialize_from_str(&v, it->current->value);
+    z_bytes_serialize_from_str(&k, it->current->key, NULL, NULL);
+    z_bytes_serialize_from_str(&v, it->current->value, NULL, NULL);
     z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
     it->current++;
     return true;
@@ -99,7 +99,7 @@ int main(int argc, char** argv) {
         sprintf(buf, "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
 
-        z_bytes_serialize_from_str(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf, NULL, NULL);
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
 

--- a/examples/z_pub_cache.c
+++ b/examples/z_pub_cache.c
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
         sprintf(buf, "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_str(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf, NULL, NULL);
 
         z_put(z_loan(s), z_loan(ke), z_move(payload), NULL);
     }

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
 
     z_owned_bytes_t payload;
     while (1) {
-        z_bytes_serialize_from_slice(&payload, value, len);
+        z_bytes_serialize_from_buf(&payload, value, len, NULL, NULL);
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
     }
 

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -49,11 +49,11 @@ int main(int argc, char **argv) {
     z_view_keyexpr_from_str(&ke, keyexpr);
 
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_str(&payload, value);
+    z_bytes_serialize_from_str(&payload, value, NULL, NULL);
 
     z_owned_bytes_t attachment, key, val;
-    z_bytes_serialize_from_str(&key, "hello");
-    z_bytes_serialize_from_str(&val, "there");
+    z_bytes_serialize_from_str(&key, "hello", NULL, NULL);
+    z_bytes_serialize_from_str(&val, "there", NULL, NULL);
     z_bytes_serialize_from_pair(&attachment, z_move(key), z_move(val));
 
     z_put_options_t options;

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -44,7 +44,7 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     z_query_reply_options_default(&options);
 
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_str(&reply_payload, value);
+    z_bytes_serialize_from_str(&reply_payload, value, NULL, NULL);
 
     z_view_keyexpr_t reply_keyexpr;
     z_view_keyexpr_from_str(&reply_keyexpr, (const char *)context);

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         z_query_reply_options_default(&options);
 
         z_owned_bytes_t reply_payload;
-        z_bytes_serialize_from_str(&reply_payload, value);
+        z_bytes_serialize_from_str(&reply_payload, value, NULL, NULL);
         z_query_reply(query, z_loan(ke), z_move(reply_payload), &options);
         z_drop(z_move(oquery));
     }

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -66,7 +66,7 @@ void query_handler(const z_loaned_query_t *query, void *arg) {
     z_query_reply_options_default(&_ret_qreply_opt);
 
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_str(&payload, value);
+    z_bytes_serialize_from_str(&payload, value, NULL, NULL);
     z_query_reply(query, query_ke, z_move(payload), &_ret_qreply_opt);
 }
 
@@ -289,7 +289,7 @@ int main(int argc, char **argv) {
     // TODO: set encoding option
 
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_str(&payload, value);
+    z_bytes_serialize_from_str(&payload, value, NULL, NULL);
     _ret_int8 = z_put(z_loan(s1), z_loan(_ret_expr), z_move(payload), &_ret_put_opt);
     assert(_ret_int8 == 0);
 

--- a/tests/z_int_pub_cache_query_sub_test.c
+++ b/tests/z_int_pub_cache_query_sub_test.c
@@ -66,7 +66,7 @@ int run_publisher() {
     // values for cache
     for (int i = 0; i < values_count / 2; ++i) {
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_str(&payload, values[i]);
+        z_bytes_serialize_from_str(&payload, values[i], NULL, NULL);
         z_put(z_loan(s), z_loan(ke), z_move(payload), NULL);
     }
 
@@ -77,7 +77,7 @@ int run_publisher() {
     // values for subscribe
     for (int i = values_count / 2; i < values_count; ++i) {
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_str(&payload, values[i]);
+        z_bytes_serialize_from_str(&payload, values[i], NULL, NULL);
         z_put(z_loan(s), z_loan(ke), z_move(payload), NULL);
     }
 

--- a/tests/z_int_pub_sub_attachment_test.c
+++ b/tests/z_int_pub_sub_attachment_test.c
@@ -47,8 +47,8 @@ bool create_attachment_iter(z_owned_bytes_t *kv_pair, void *context) {
         return false;
     }
     z_owned_bytes_t k, v;
-    z_bytes_serialize_from_str(&k, it->current->key);
-    z_bytes_serialize_from_str(&v, it->current->value);
+    z_bytes_serialize_from_str(&k, it->current->key, NULL, NULL);
+    z_bytes_serialize_from_str(&v, it->current->value, NULL, NULL);
     z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
     it->current++;
     return true;
@@ -124,7 +124,7 @@ int run_publisher() {
         z_view_slice_t v_var;
         z_view_slice_from_str(&v_var, values[i]);
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_slice(&payload, z_slice_data(z_loan(v_var)), z_slice_len(z_loan(v_var)));
+        z_bytes_serialize_from_buf(&payload, z_slice_data(z_loan(v_var)), z_slice_len(z_loan(v_var)), NULL, NULL);
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
 

--- a/tests/z_int_pub_sub_test.c
+++ b/tests/z_int_pub_sub_test.c
@@ -71,7 +71,7 @@ int run_publisher() {
         options.timestamp = &ts;
 
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_str(&payload, values[i]);
+        z_bytes_serialize_from_str(&payload, values[i], NULL, NULL);
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
 

--- a/tests/z_int_queryable_attachment_test.c
+++ b/tests/z_int_queryable_attachment_test.c
@@ -45,8 +45,8 @@ bool create_attachment_iter(z_owned_bytes_t *kv_pair, void *context) {
         return false;
     }
     z_owned_bytes_t k, v;
-    z_bytes_serialize_from_str(&k, it->current->key);
-    z_bytes_serialize_from_str(&v, it->current->value);
+    z_bytes_serialize_from_str(&k, it->current->key, NULL, NULL);
+    z_bytes_serialize_from_str(&v, it->current->value, NULL, NULL);
     z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
     it->current++;
     return true;
@@ -116,7 +116,7 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     options.attachment = &reply_attachment;
 
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_str(&payload, values[value_num]);
+    z_bytes_serialize_from_str(&payload, values[value_num], NULL, NULL);
 
     z_view_keyexpr_t reply_ke;
     z_view_keyexpr_from_str(&reply_ke, (const char *)context);

--- a/tests/z_int_queryable_test.c
+++ b/tests/z_int_queryable_test.c
@@ -48,7 +48,7 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     // options.source_info = &source_info;
 
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_str(&payload, values[value_num]);
+    z_bytes_serialize_from_str(&payload, values[value_num], NULL, NULL);
 
     z_view_keyexpr_t reply_ke;
     z_view_keyexpr_from_str(&reply_ke, (const char *)context);


### PR DESCRIPTION
remove z_serialize_xxx_copy;
z_serialize_from_slice now consumes z_owned_slice_t; z_serialize_from_str is renamed into z_serialize_from_string and is now consuming z_owned_string_t introduce z_serialize_from_buf/from_str allowing to consume raw pointers by taking custom delete function;