### PR TITLE
fix queryable examples to account for an empty payload

### DIFF
--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -28,7 +28,7 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     z_query_parameters(query, &params);
 
     const z_loaned_bytes_t *payload = z_query_payload(query);
-    if (z_bytes_len(payload) > 0) {
+    if (payload != NULL && z_bytes_len(payload) > 0) {
         z_owned_string_t payload_string;
         z_bytes_deserialize_into_string(payload, &payload_string);
 

--- a/examples/z_queryable_shm.c
+++ b/examples/z_queryable_shm.c
@@ -30,7 +30,7 @@ void query_handler(const z_loaned_query_t *query, void *context) {
     z_query_parameters(query, &params);
 
     const z_loaned_bytes_t *payload = z_query_payload(query);
-    if (z_bytes_len(payload) > 0) {
+    if (payload != NULL && z_bytes_len(payload) > 0) {
         const z_loaned_shm_t *shm = NULL;
         char *payload_type = z_bytes_deserialize_into_loaned_shm(payload, &shm) == Z_OK ? "SHM" : "RAW";
 

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
         z_query_parameters(query, &params);
 
         const z_loaned_bytes_t *payload = z_query_payload(query);
-        if (z_bytes_len(payload) > 0) {
+        if (payload != NULL && z_bytes_len(payload) > 0) {
             z_owned_string_t payload_string;
             z_bytes_deserialize_into_string(payload, &payload_string);
 

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -2871,7 +2871,7 @@ ZENOHC_API void z_query_drop(struct z_owned_query_t *this_);
 /**
  * Gets query <a href="https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Query%20Payload.md">payload encoding</a>.
  *
- * Returns NULL if query does not hame an encoding.
+ * Returns NULL if query does not contain an encoding.
  */
 ZENOHC_API
 const struct z_loaned_encoding_t *z_query_encoding(const struct z_loaned_query_t *this_);

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -448,7 +448,7 @@ pub extern "C" fn z_query_payload(this: &z_loaned_query_t) -> Option<&z_loaned_b
 
 /// Gets query <a href="https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Query%20Payload.md">payload encoding</a>.
 ///
-/// Returns NULL if query does not hame an encoding.
+/// Returns NULL if query does not contain an encoding.
 #[no_mangle]
 pub extern "C" fn z_query_encoding(this: &z_loaned_query_t) -> Option<&z_loaned_encoding_t> {
     this.as_rust_type_ref()


### PR DESCRIPTION
fix queryable examples to account for missing payload