### PR TITLE
generate panic messages only if explicitly asked

### DIFF
--- a/build-resources/opaque-types/Cargo.toml
+++ b/build-resources/opaque-types/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [features]
 shared-memory = ["zenoh/shared-memory", "dep:zenoh-ext", "zenoh-ext/shared-memory", "zenoh-protocol/shared-memory"]
 unstable = ["zenoh/unstable", "zenoh-ext/unstable", "dep:zenoh-ext"]
+panic = [] # The whole purpose of this project is to generate set of compilation panic messages with calculated structure sizes. To do it the "panic" feature should be set. By default we just want to check if build is successful.
 default = ["zenoh/default"]
 
 [dependencies]

--- a/build-resources/opaque-types/src/lib.rs
+++ b/build-resources/opaque-types/src/lib.rs
@@ -1,7 +1,5 @@
-#[cfg(all(feature = "shared-memory", feature = "unstable"))]
 use core::ffi::c_void;
 use std::{
-    collections::HashMap,
     sync::{Arc, Condvar, Mutex, MutexGuard},
     thread::JoinHandle,
 };
@@ -9,7 +7,7 @@ use std::{
 use zenoh::{
     bytes::{Encoding, ZBytes, ZBytesIterator, ZBytesReader, ZBytesWriter},
     config::Config,
-    handlers::{DefaultHandler, RingChannelHandler},
+    handlers::RingChannelHandler,
     key_expr::KeyExpr,
     pubsub::{Publisher, Subscriber},
     query::{Query, Queryable, Reply, ReplyError},
@@ -44,185 +42,191 @@ macro_rules! get_opaque_type_data {
             const SIZE: usize = std::mem::size_of::<$src_type>();
             const INFO_MESSAGE: &str =
                 concatcp!("type: ", DST_NAME, ", align: ", ALIGN, ", size: ", SIZE);
+            #[cfg(feature = "panic")]
             panic!("{}", INFO_MESSAGE);
         };
     };
 }
 
-/// A serialized Zenoh data.
-///
-/// To minimize copies and reallocations, Zenoh may provide data in several separate buffers.
+// A serialized Zenoh data.
+//
+// To minimize copies and reallocations, Zenoh may provide data in several separate buffers.
 get_opaque_type_data!(ZBytes, z_owned_bytes_t);
-/// A loaned serialized Zenoh data.
+// A loaned serialized Zenoh data.
 get_opaque_type_data!(ZBytes, z_loaned_bytes_t);
 
-type CSlice = (usize, usize, usize, usize);
+pub struct CSlice {
+    _data: *const u8,
+    _len: usize,
+    _drop: Option<extern "C" fn(data: *mut c_void, context: *mut c_void)>,
+    _context: *mut c_void,
+}
 
-/// A contiguous owned sequence of bytes allocated by Zenoh.
+// A contiguous owned sequence of bytes allocated by Zenoh.
 get_opaque_type_data!(CSlice, z_owned_slice_t);
-/// A contiguous sequence of bytes owned by some other entity.
+// A contiguous sequence of bytes owned by some other entity.
 get_opaque_type_data!(CSlice, z_view_slice_t);
-/// A loaned sequence of bytes.
+// A loaned sequence of bytes.
 get_opaque_type_data!(CSlice, z_loaned_slice_t);
 
-/// The wrapper type for strings allocated by Zenoh.
+// The wrapper type for strings allocated by Zenoh.
 get_opaque_type_data!(CSlice, z_owned_string_t);
-/// The view over a string.
+// The view over a string.
 get_opaque_type_data!(CSlice, z_view_string_t);
-/// A loaned string.
+// A loaned string.
 get_opaque_type_data!(CSlice, z_loaned_string_t);
 
-/// An array of maybe-owned non-null terminated strings.
-///
+// An array of maybe-owned non-null terminated strings.
+//
 get_opaque_type_data!(Option<Vec<CSlice>>, z_owned_string_array_t);
-/// A loaned string array.
+// A loaned string array.
 get_opaque_type_data!(Vec<CSlice>, z_loaned_string_array_t);
 
-/// An owned Zenoh sample.
-///
-/// This is a read only type that can only be constructed by cloning a `z_loaned_sample_t`.
-/// Like all owned types, it should be freed using z_drop or z_sample_drop.
+// An owned Zenoh sample.
+//
+// This is a read only type that can only be constructed by cloning a `z_loaned_sample_t`.
+// Like all owned types, it should be freed using z_drop or z_sample_drop.
 get_opaque_type_data!(Option<Sample>, z_owned_sample_t);
-/// A loaned Zenoh sample.
+// A loaned Zenoh sample.
 get_opaque_type_data!(Sample, z_loaned_sample_t);
 
-/// A reader for serialized data.
+// A reader for serialized data.
 get_opaque_type_data!(ZBytesReader<'static>, z_bytes_reader_t);
 
-/// A writer for serialized data.
+// A writer for serialized data.
 get_opaque_type_data!(Option<ZBytesWriter<'static>>, z_owned_bytes_writer_t);
 
-/// A loaned writer for serialized data.
+// A loaned writer for serialized data.
 get_opaque_type_data!(ZBytesWriter<'static>, z_loaned_bytes_writer_t);
 
-/// An iterator over multi-element serialized data
+// An iterator over multi-element serialized data
 get_opaque_type_data!(ZBytesIterator<'static, ZBytes>, z_bytes_iterator_t);
 
-/// The <a href="https://zenoh.io/docs/manual/abstractions/#encoding"> encoding </a> of Zenoh data.
+// The <a href="https://zenoh.io/docs/manual/abstractions/#encoding"> encoding </a> of Zenoh data.
 get_opaque_type_data!(Encoding, z_owned_encoding_t);
-/// A loaned Zenoh encoding.
+// A loaned Zenoh encoding.
 get_opaque_type_data!(Encoding, z_loaned_encoding_t);
 
-/// An owned reply from a Queryable to a `z_get()`.
+// An owned reply from a Queryable to a `z_get()`.
 get_opaque_type_data!(Option<Reply>, z_owned_reply_t);
-/// A loaned reply.
+// A loaned reply.
 get_opaque_type_data!(Reply, z_loaned_reply_t);
 
-/// A Zenoh reply error a compination of reply error payload and its encoding.
+// A Zenoh reply error a compination of reply error payload and its encoding.
 get_opaque_type_data!(ReplyError, z_owned_reply_err_t);
-/// A loaned Zenoh reply error.
+// A loaned Zenoh reply error.
 get_opaque_type_data!(ReplyError, z_loaned_reply_err_t);
 
-/// An owned Zenoh query received by a queryable.
-///
-/// Queries are atomically reference-counted, letting you extract them from the callback that handed them to you by cloning.
+// An owned Zenoh query received by a queryable.
+//
+// Queries are atomically reference-counted, letting you extract them from the callback that handed them to you by cloning.
 get_opaque_type_data!(Option<Query>, z_owned_query_t);
-/// A loaned Zenoh query.
+// A loaned Zenoh query.
 get_opaque_type_data!(Query, z_loaned_query_t);
 
-/// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#queryable"> queryable </a>.
-///
-/// Responds to queries sent via `z_get()` with intersecting key expression.
+// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#queryable"> queryable </a>.
+//
+// Responds to queries sent via `z_get()` with intersecting key expression.
 get_opaque_type_data!(Option<Queryable<'static, ()>>, z_owned_queryable_t);
-/// A loaned Zenoh queryable.
+// A loaned Zenoh queryable.
 get_opaque_type_data!(Queryable<'static, ()>, z_loaned_queryable_t);
 #[cfg(feature = "unstable")]
-/// An owned Zenoh querying subscriber.
-///
-/// In addition to receiving the data it is subscribed to,
-/// it also will fetch data from a Queryable at startup and peridodically (using  `ze_querying_subscriber_get()`).
+// An owned Zenoh querying subscriber.
+//
+// In addition to receiving the data it is subscribed to,
+// it also will fetch data from a Queryable at startup and peridodically (using  `ze_querying_subscriber_get()`).
 get_opaque_type_data!(
     Option<(zenoh_ext::FetchingSubscriber<'static, ()>, &'static Session)>,
     ze_owned_querying_subscriber_t
 );
 #[cfg(feature = "unstable")]
-/// A loaned Zenoh querying subscriber.
+// A loaned Zenoh querying subscriber.
 get_opaque_type_data!(
     (zenoh_ext::FetchingSubscriber<'static, ()>, &'static Session),
     ze_loaned_querying_subscriber_t
 );
 
-/// A Zenoh-allocated <a href="https://zenoh.io/docs/manual/abstractions/#key-expression"> key expression </a>.
-///
-/// Key expressions can identify a single key or a set of keys.
-///
-/// Examples :
-///    - ``"key/expression"``.
-///    - ``"key/ex*"``.
-///
-/// Key expressions can be mapped to numerical ids through `z_declare_keyexpr`
-/// for wire and computation efficiency.
-///
-/// Internally key expressiobn can be either:
-///   - A plain string expression.
-///   - A pure numerical id.
-///   - The combination of a numerical prefix and a string suffix.
+// A Zenoh-allocated <a href="https://zenoh.io/docs/manual/abstractions/#key-expression"> key expression </a>.
+//
+// Key expressions can identify a single key or a set of keys.
+//
+// Examples :
+//    - ``"key/expression"``.
+//    - ``"key/ex*"``.
+//
+// Key expressions can be mapped to numerical ids through `z_declare_keyexpr`
+// for wire and computation efficiency.
+//
+// Internally key expressiobn can be either:
+//   - A plain string expression.
+//   - A pure numerical id.
+//   - The combination of a numerical prefix and a string suffix.
 get_opaque_type_data!(Option<KeyExpr<'static>>, z_owned_keyexpr_t);
-/// A user allocated string, viewed as a key expression.
+// A user allocated string, viewed as a key expression.
 get_opaque_type_data!(Option<KeyExpr<'static>>, z_view_keyexpr_t);
 
-/// A loaned key expression.
-///
-/// Key expressions can identify a single key or a set of keys.
-///
-/// Examples :
-///    - ``"key/expression"``.
-///    - ``"key/ex*"``.
-///
-/// Using `z_declare_keyexpr` allows Zenoh to optimize a key expression,
-/// both for local processing and network-wise.
+// A loaned key expression.
+//
+// Key expressions can identify a single key or a set of keys.
+//
+// Examples :
+//    - ``"key/expression"``.
+//    - ``"key/ex*"``.
+//
+// Using `z_declare_keyexpr` allows Zenoh to optimize a key expression,
+// both for local processing and network-wise.
 get_opaque_type_data!(KeyExpr<'static>, z_loaned_keyexpr_t);
 
-/// An owned Zenoh session.
+// An owned Zenoh session.
 get_opaque_type_data!(Option<Arc<Session>>, z_owned_session_t);
-/// A loaned Zenoh session.
+// A loaned Zenoh session.
 get_opaque_type_data!(Arc<Session>, z_loaned_session_t);
 
-/// An owned Zenoh configuration.
+// An owned Zenoh configuration.
 get_opaque_type_data!(Option<Config>, z_owned_config_t);
-/// A loaned Zenoh configuration.
+// A loaned Zenoh configuration.
 get_opaque_type_data!(Config, z_loaned_config_t);
 
 #[cfg(feature = "unstable")]
-/// A Zenoh ID.
-///
-/// In general, valid Zenoh IDs are LSB-first 128bit unsigned and non-zero integers.
+// A Zenoh ID.
+//
+// In general, valid Zenoh IDs are LSB-first 128bit unsigned and non-zero integers.
 get_opaque_type_data!(ZenohId, z_id_t);
 
-/// A Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#timestamp"> timestamp </a>.
-///
-/// It consists of a time generated by a Hybrid Logical Clock (HLC) in NPT64 format and a unique zenoh identifier.
+// A Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#timestamp"> timestamp </a>.
+//
+// It consists of a time generated by a Hybrid Logical Clock (HLC) in NPT64 format and a unique zenoh identifier.
 get_opaque_type_data!(Timestamp, z_timestamp_t);
 
-/// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#publisher"> publisher </a>.
+// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#publisher"> publisher </a>.
 get_opaque_type_data!(Option<Publisher<'static>>, z_owned_publisher_t);
-/// A loaned Zenoh publisher.
+// A loaned Zenoh publisher.
 get_opaque_type_data!(Publisher<'static>, z_loaned_publisher_t);
 
 #[cfg(feature = "unstable")]
-/// An owned Zenoh matching listener.
-///
-/// A listener that sends notifications when the [`MatchingStatus`] of a publisher changes.
-/// Dropping the corresponding publisher, also drops matching listener.
+// An owned Zenoh matching listener.
+//
+// A listener that sends notifications when the [`MatchingStatus`] of a publisher changes.
+// Dropping the corresponding publisher, also drops matching listener.
 get_opaque_type_data!(
     Option<MatchingListener<'static, ()>>,
     zc_owned_matching_listener_t
 );
 
-/// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#subscriber"> subscriber </a>.
-///
-/// Receives data from publication on intersecting key expressions.
-/// Destroying the subscriber cancels the subscription.
+// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#subscriber"> subscriber </a>.
+//
+// Receives data from publication on intersecting key expressions.
+// Destroying the subscriber cancels the subscription.
 get_opaque_type_data!(Option<Subscriber<'static, ()>>, z_owned_subscriber_t);
-/// A loaned Zenoh subscriber.
+// A loaned Zenoh subscriber.
 get_opaque_type_data!(Subscriber<'static, ()>, z_loaned_subscriber_t);
 
 #[cfg(feature = "unstable")]
-/// A liveliness token that can be used to provide the network with information about connectivity to its
-/// declarer: when constructed, a PUT sample will be received by liveliness subscribers on intersecting key
-/// expressions.
-///
-/// A DELETE on the token's key expression will be received by subscribers if the token is destroyed, or if connectivity between the subscriber and the token's creator is lost.
+// A liveliness token that can be used to provide the network with information about connectivity to its
+// declarer: when constructed, a PUT sample will be received by liveliness subscribers on intersecting key
+// expressions.
+//
+// A DELETE on the token's key expression will be received by subscribers if the token is destroyed, or if connectivity between the subscriber and the token's creator is lost.
 get_opaque_type_data!(
     Option<LivelinessToken<'static>>,
     zc_owned_liveliness_token_t
@@ -230,96 +234,96 @@ get_opaque_type_data!(
 #[cfg(feature = "unstable")]
 get_opaque_type_data!(LivelinessToken<'static>, zc_loaned_liveliness_token_t);
 #[cfg(feature = "unstable")]
-/// An owned Zenoh publication cache.
-///
-/// Used to store publications on intersecting key expressions. Can be queried later via `z_get()` to retrieve this data
-/// (for example by `ze_owned_querying_subscriber_t`).
+// An owned Zenoh publication cache.
+//
+// Used to store publications on intersecting key expressions. Can be queried later via `z_get()` to retrieve this data
+// (for example by `ze_owned_querying_subscriber_t`).
 get_opaque_type_data!(
     Option<zenoh_ext::PublicationCache<'static>>,
     ze_owned_publication_cache_t
 );
 #[cfg(feature = "unstable")]
-/// A loaned Zenoh publication cache.
+// A loaned Zenoh publication cache.
 get_opaque_type_data!(
     zenoh_ext::PublicationCache<'static>,
     ze_loaned_publication_cache_t
 );
 
-/// An owned mutex.
+// An owned mutex.
 get_opaque_type_data!(
     Option<(Mutex<()>, Option<MutexGuard<'static, ()>>)>,
     z_owned_mutex_t
 );
-/// A loaned mutex.
+// A loaned mutex.
 get_opaque_type_data!(
     (Mutex<()>, Option<MutexGuard<'static, ()>>),
     z_loaned_mutex_t
 );
 
-/// An owned conditional variable.
-///
-/// Used in combination with `z_owned_mutex_t` to wake up thread when certain conditions are met.
+// An owned conditional variable.
+//
+// Used in combination with `z_owned_mutex_t` to wake up thread when certain conditions are met.
 get_opaque_type_data!(Option<Condvar>, z_owned_condvar_t);
-/// A loaned conditional variable.
+// A loaned conditional variable.
 get_opaque_type_data!(Condvar, z_loaned_condvar_t);
 
-/// An owned Zenoh task.
+// An owned Zenoh task.
 get_opaque_type_data!(Option<JoinHandle<()>>, z_owned_task_t);
 
-/// An owned Zenoh-allocated hello message returned by a Zenoh entity to a scout message sent with `z_scout()`.
+// An owned Zenoh-allocated hello message returned by a Zenoh entity to a scout message sent with `z_scout()`.
 get_opaque_type_data!(Option<Hello>, z_owned_hello_t);
-/// A loaned hello message.
+// A loaned hello message.
 get_opaque_type_data!(Hello, z_loaned_hello_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// An owned SHM Client
+// An owned SHM Client
 get_opaque_type_data!(Option<Arc<dyn ShmClient>>, z_owned_shm_client_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// An owned list of SHM Clients
+// An owned list of SHM Clients
 get_opaque_type_data!(
     Option<Vec<(ProtocolID, Arc<dyn ShmClient>)>>,
     zc_owned_shm_client_list_t
 );
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// A loaned list of SHM Clients
+// A loaned list of SHM Clients
 get_opaque_type_data!(
     Vec<(ProtocolID, Arc<dyn ShmClient>)>,
     zc_loaned_shm_client_list_t
 );
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// An owned SHM Client Storage
+// An owned SHM Client Storage
 get_opaque_type_data!(Option<Arc<ShmClientStorage>>, z_owned_shm_client_storage_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// A loaned SHM Client Storage
+// A loaned SHM Client Storage
 get_opaque_type_data!(Arc<ShmClientStorage>, z_loaned_shm_client_storage_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// An owned MemoryLayout
+// An owned MemoryLayout
 get_opaque_type_data!(Option<MemoryLayout>, z_owned_memory_layout_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// A loaned MemoryLayout
+// A loaned MemoryLayout
 get_opaque_type_data!(MemoryLayout, z_loaned_memory_layout_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// An owned ChunkAllocResult
+// An owned ChunkAllocResult
 get_opaque_type_data!(Option<ChunkAllocResult>, z_owned_chunk_alloc_result_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// A loaned ChunkAllocResult
+// A loaned ChunkAllocResult
 get_opaque_type_data!(ChunkAllocResult, z_loaned_chunk_alloc_result_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// An owned ZShm slice
+// An owned ZShm slice
 get_opaque_type_data!(Option<ZShm>, z_owned_shm_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// A loaned ZShm slice
+// A loaned ZShm slice
 get_opaque_type_data!(zshm, z_loaned_shm_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// An owned ZShmMut slice
+// An owned ZShmMut slice
 get_opaque_type_data!(Option<ZShmMut>, z_owned_shm_mut_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// A loaned ZShmMut slice
+// A loaned ZShmMut slice
 get_opaque_type_data!(zshmmut, z_loaned_shm_mut_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
@@ -384,10 +388,10 @@ enum CDummySHMProvider {
 }
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// An owned ShmProvider
+// An owned ShmProvider
 get_opaque_type_data!(Option<CDummySHMProvider>, z_owned_shm_provider_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// A loaned ShmProvider
+// A loaned ShmProvider
 get_opaque_type_data!(CDummySHMProvider, z_loaned_shm_provider_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
@@ -404,60 +408,60 @@ enum CSHMLayout {
 }
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// An owned ShmProvider's AllocLayout
+// An owned ShmProvider's AllocLayout
 get_opaque_type_data!(Option<CSHMLayout>, z_owned_alloc_layout_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-/// A loaned ShmProvider's AllocLayout
+// A loaned ShmProvider's AllocLayout
 get_opaque_type_data!(CSHMLayout, z_loaned_alloc_layout_t);
 
-/// An owned Zenoh fifo sample handler.
+// An owned Zenoh fifo sample handler.
 get_opaque_type_data!(
     Option<flume::Receiver<Sample>>,
     z_owned_fifo_handler_sample_t
 );
-/// An loaned Zenoh fifo sample handler.
+// An loaned Zenoh fifo sample handler.
 get_opaque_type_data!(flume::Receiver<Sample>, z_loaned_fifo_handler_sample_t);
 
-/// An owned Zenoh ring sample handler.
+// An owned Zenoh ring sample handler.
 get_opaque_type_data!(
     Option<RingChannelHandler<Sample>>,
     z_owned_ring_handler_sample_t
 );
-/// An loaned Zenoh ring sample handler.
+// An loaned Zenoh ring sample handler.
 get_opaque_type_data!(RingChannelHandler<Sample>, z_loaned_ring_handler_sample_t);
 
-/// An owned Zenoh fifo query handler.
+// An owned Zenoh fifo query handler.
 get_opaque_type_data!(Option<flume::Receiver<Query>>, z_owned_fifo_handler_query_t);
-/// An loaned Zenoh fifo query handler.
+// An loaned Zenoh fifo query handler.
 get_opaque_type_data!(flume::Receiver<Query>, z_loaned_fifo_handler_query_t);
 
-/// An owned Zenoh ring query handler.
+// An owned Zenoh ring query handler.
 get_opaque_type_data!(
     Option<RingChannelHandler<Query>>,
     z_owned_ring_handler_query_t
 );
-/// An loaned Zenoh ring query handler.
+// An loaned Zenoh ring query handler.
 get_opaque_type_data!(RingChannelHandler<Query>, z_loaned_ring_handler_query_t);
 
-/// An owned Zenoh fifo reply handler.
+// An owned Zenoh fifo reply handler.
 get_opaque_type_data!(Option<flume::Receiver<Reply>>, z_owned_fifo_handler_reply_t);
-/// An loaned Zenoh fifo reply handler.
+// An loaned Zenoh fifo reply handler.
 get_opaque_type_data!(flume::Receiver<Reply>, z_loaned_fifo_handler_reply_t);
 
-/// An owned Zenoh ring reply handler.
+// An owned Zenoh ring reply handler.
 get_opaque_type_data!(
     Option<RingChannelHandler<Reply>>,
     z_owned_ring_handler_reply_t
 );
-/// An loaned Zenoh ring reply handler.
+// An loaned Zenoh ring reply handler.
 get_opaque_type_data!(RingChannelHandler<Reply>, z_loaned_ring_handler_reply_t);
 
 #[cfg(feature = "unstable")]
-/// An owned Zenoh-allocated source info`.
+// An owned Zenoh-allocated source info`.
 get_opaque_type_data!(SourceInfo, z_owned_source_info_t);
 #[cfg(feature = "unstable")]
-/// A loaned source info.
+// A loaned source info.
 get_opaque_type_data!(SourceInfo, z_loaned_source_info_t);
 #[cfg(feature = "unstable")]
-/// An entity gloabal id.
+// An entity gloabal id.
 get_opaque_type_data!(EntityGlobalId, z_entity_global_id_t);

--- a/build-resources/opaque-types/src/lib.rs
+++ b/build-resources/opaque-types/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unused_doc_comments)]
 use core::ffi::c_void;
 use std::{
     sync::{Arc, Condvar, Mutex, MutexGuard},
@@ -48,11 +49,11 @@ macro_rules! get_opaque_type_data {
     };
 }
 
-// A serialized Zenoh data.
-//
-// To minimize copies and reallocations, Zenoh may provide data in several separate buffers.
+/// A serialized Zenoh data.
+///
+/// To minimize copies and reallocations, Zenoh may provide data in several separate buffers.
 get_opaque_type_data!(ZBytes, z_owned_bytes_t);
-// A loaned serialized Zenoh data.
+/// A loaned serialized Zenoh data.
 get_opaque_type_data!(ZBytes, z_loaned_bytes_t);
 
 pub struct CSlice {
@@ -62,171 +63,171 @@ pub struct CSlice {
     _context: *mut c_void,
 }
 
-// A contiguous owned sequence of bytes allocated by Zenoh.
+
 get_opaque_type_data!(CSlice, z_owned_slice_t);
-// A contiguous sequence of bytes owned by some other entity.
+/// A contiguous sequence of bytes owned by some other entity.
 get_opaque_type_data!(CSlice, z_view_slice_t);
-// A loaned sequence of bytes.
+/// A loaned sequence of bytes.
 get_opaque_type_data!(CSlice, z_loaned_slice_t);
 
-// The wrapper type for strings allocated by Zenoh.
+/// The wrapper type for strings allocated by Zenoh.
 get_opaque_type_data!(CSlice, z_owned_string_t);
-// The view over a string.
+/// The view over a string.
 get_opaque_type_data!(CSlice, z_view_string_t);
-// A loaned string.
+/// A loaned string.
 get_opaque_type_data!(CSlice, z_loaned_string_t);
 
-// An array of maybe-owned non-null terminated strings.
-//
+/// An array of maybe-owned non-null terminated strings.
+///
 get_opaque_type_data!(Option<Vec<CSlice>>, z_owned_string_array_t);
-// A loaned string array.
+/// A loaned string array.
 get_opaque_type_data!(Vec<CSlice>, z_loaned_string_array_t);
 
-// An owned Zenoh sample.
-//
-// This is a read only type that can only be constructed by cloning a `z_loaned_sample_t`.
-// Like all owned types, it should be freed using z_drop or z_sample_drop.
+/// An owned Zenoh sample.
+///
+/// This is a read only type that can only be constructed by cloning a `z_loaned_sample_t`.
+/// Like all owned types, it should be freed using z_drop or z_sample_drop.
 get_opaque_type_data!(Option<Sample>, z_owned_sample_t);
-// A loaned Zenoh sample.
+/// A loaned Zenoh sample.
 get_opaque_type_data!(Sample, z_loaned_sample_t);
 
-// A reader for serialized data.
+/// A reader for serialized data.
 get_opaque_type_data!(ZBytesReader<'static>, z_bytes_reader_t);
 
-// A writer for serialized data.
+/// A writer for serialized data.
 get_opaque_type_data!(Option<ZBytesWriter<'static>>, z_owned_bytes_writer_t);
 
-// A loaned writer for serialized data.
+/// A loaned writer for serialized data.
 get_opaque_type_data!(ZBytesWriter<'static>, z_loaned_bytes_writer_t);
 
-// An iterator over multi-element serialized data
+/// An iterator over multi-element serialized data
 get_opaque_type_data!(ZBytesIterator<'static, ZBytes>, z_bytes_iterator_t);
 
-// The <a href="https://zenoh.io/docs/manual/abstractions/#encoding"> encoding </a> of Zenoh data.
+/// The <a href="https://zenoh.io/docs/manual/abstractions/#encoding"> encoding </a> of Zenoh data.
 get_opaque_type_data!(Encoding, z_owned_encoding_t);
-// A loaned Zenoh encoding.
+/// A loaned Zenoh encoding.
 get_opaque_type_data!(Encoding, z_loaned_encoding_t);
 
-// An owned reply from a Queryable to a `z_get()`.
+/// An owned reply from a Queryable to a `z_get()`.
 get_opaque_type_data!(Option<Reply>, z_owned_reply_t);
-// A loaned reply.
+/// A loaned reply.
 get_opaque_type_data!(Reply, z_loaned_reply_t);
 
-// A Zenoh reply error a compination of reply error payload and its encoding.
+/// A Zenoh reply error a compination of reply error payload and its encoding.
 get_opaque_type_data!(ReplyError, z_owned_reply_err_t);
-// A loaned Zenoh reply error.
+/// A loaned Zenoh reply error.
 get_opaque_type_data!(ReplyError, z_loaned_reply_err_t);
 
-// An owned Zenoh query received by a queryable.
-//
-// Queries are atomically reference-counted, letting you extract them from the callback that handed them to you by cloning.
+/// An owned Zenoh query received by a queryable.
+///
+/// Queries are atomically reference-counted, letting you extract them from the callback that handed them to you by cloning.
 get_opaque_type_data!(Option<Query>, z_owned_query_t);
-// A loaned Zenoh query.
+/// A loaned Zenoh query.
 get_opaque_type_data!(Query, z_loaned_query_t);
 
-// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#queryable"> queryable </a>.
-//
-// Responds to queries sent via `z_get()` with intersecting key expression.
+/// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#queryable"> queryable </a>.
+///
+/// Responds to queries sent via `z_get()` with intersecting key expression.
 get_opaque_type_data!(Option<Queryable<'static, ()>>, z_owned_queryable_t);
-// A loaned Zenoh queryable.
+/// A loaned Zenoh queryable.
 get_opaque_type_data!(Queryable<'static, ()>, z_loaned_queryable_t);
 #[cfg(feature = "unstable")]
-// An owned Zenoh querying subscriber.
-//
-// In addition to receiving the data it is subscribed to,
-// it also will fetch data from a Queryable at startup and peridodically (using  `ze_querying_subscriber_get()`).
+/// An owned Zenoh querying subscriber.
+///
+/// In addition to receiving the data it is subscribed to,
+/// it also will fetch data from a Queryable at startup and peridodically (using  `ze_querying_subscriber_get()`).
 get_opaque_type_data!(
     Option<(zenoh_ext::FetchingSubscriber<'static, ()>, &'static Session)>,
     ze_owned_querying_subscriber_t
 );
 #[cfg(feature = "unstable")]
-// A loaned Zenoh querying subscriber.
+/// A loaned Zenoh querying subscriber.
 get_opaque_type_data!(
     (zenoh_ext::FetchingSubscriber<'static, ()>, &'static Session),
     ze_loaned_querying_subscriber_t
 );
 
-// A Zenoh-allocated <a href="https://zenoh.io/docs/manual/abstractions/#key-expression"> key expression </a>.
-//
-// Key expressions can identify a single key or a set of keys.
-//
-// Examples :
-//    - ``"key/expression"``.
-//    - ``"key/ex*"``.
-//
-// Key expressions can be mapped to numerical ids through `z_declare_keyexpr`
-// for wire and computation efficiency.
-//
-// Internally key expressiobn can be either:
-//   - A plain string expression.
-//   - A pure numerical id.
-//   - The combination of a numerical prefix and a string suffix.
+/// A Zenoh-allocated <a href="https://zenoh.io/docs/manual/abstractions/#key-expression"> key expression </a>.
+///
+/// Key expressions can identify a single key or a set of keys.
+///
+/// Examples :
+///    - ``"key/expression"``.
+///    - ``"key/ex*"``.
+///
+/// Key expressions can be mapped to numerical ids through `z_declare_keyexpr`
+/// for wire and computation efficiency.
+///
+/// Internally key expressiobn can be either:
+///   - A plain string expression.
+///   - A pure numerical id.
+///   - The combination of a numerical prefix and a string suffix.
 get_opaque_type_data!(Option<KeyExpr<'static>>, z_owned_keyexpr_t);
-// A user allocated string, viewed as a key expression.
+/// A user allocated string, viewed as a key expression.
 get_opaque_type_data!(Option<KeyExpr<'static>>, z_view_keyexpr_t);
 
-// A loaned key expression.
-//
-// Key expressions can identify a single key or a set of keys.
-//
-// Examples :
-//    - ``"key/expression"``.
-//    - ``"key/ex*"``.
-//
-// Using `z_declare_keyexpr` allows Zenoh to optimize a key expression,
-// both for local processing and network-wise.
+/// A loaned key expression.
+///
+/// Key expressions can identify a single key or a set of keys.
+///
+/// Examples :
+///    - ``"key/expression"``.
+///    - ``"key/ex*"``.
+///
+/// Using `z_declare_keyexpr` allows Zenoh to optimize a key expression,
+/// both for local processing and network-wise.
 get_opaque_type_data!(KeyExpr<'static>, z_loaned_keyexpr_t);
 
-// An owned Zenoh session.
+/// An owned Zenoh session.
 get_opaque_type_data!(Option<Arc<Session>>, z_owned_session_t);
-// A loaned Zenoh session.
+/// A loaned Zenoh session.
 get_opaque_type_data!(Arc<Session>, z_loaned_session_t);
 
-// An owned Zenoh configuration.
+/// An owned Zenoh configuration.
 get_opaque_type_data!(Option<Config>, z_owned_config_t);
-// A loaned Zenoh configuration.
+/// A loaned Zenoh configuration.
 get_opaque_type_data!(Config, z_loaned_config_t);
 
 #[cfg(feature = "unstable")]
-// A Zenoh ID.
-//
-// In general, valid Zenoh IDs are LSB-first 128bit unsigned and non-zero integers.
+/// A Zenoh ID.
+///
+/// In general, valid Zenoh IDs are LSB-first 128bit unsigned and non-zero integers.
 get_opaque_type_data!(ZenohId, z_id_t);
 
-// A Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#timestamp"> timestamp </a>.
-//
-// It consists of a time generated by a Hybrid Logical Clock (HLC) in NPT64 format and a unique zenoh identifier.
+/// A Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#timestamp"> timestamp </a>.
+///
+/// It consists of a time generated by a Hybrid Logical Clock (HLC) in NPT64 format and a unique zenoh identifier.
 get_opaque_type_data!(Timestamp, z_timestamp_t);
 
-// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#publisher"> publisher </a>.
+/// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#publisher"> publisher </a>.
 get_opaque_type_data!(Option<Publisher<'static>>, z_owned_publisher_t);
-// A loaned Zenoh publisher.
+/// A loaned Zenoh publisher.
 get_opaque_type_data!(Publisher<'static>, z_loaned_publisher_t);
 
 #[cfg(feature = "unstable")]
-// An owned Zenoh matching listener.
-//
-// A listener that sends notifications when the [`MatchingStatus`] of a publisher changes.
-// Dropping the corresponding publisher, also drops matching listener.
+/// An owned Zenoh matching listener.
+///
+/// A listener that sends notifications when the [`MatchingStatus`] of a publisher changes.
+/// Dropping the corresponding publisher, also drops matching listener.
 get_opaque_type_data!(
     Option<MatchingListener<'static, ()>>,
     zc_owned_matching_listener_t
 );
 
-// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#subscriber"> subscriber </a>.
-//
-// Receives data from publication on intersecting key expressions.
-// Destroying the subscriber cancels the subscription.
+/// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#subscriber"> subscriber </a>.
+///
+/// Receives data from publication on intersecting key expressions.
+/// Destroying the subscriber cancels the subscription.
 get_opaque_type_data!(Option<Subscriber<'static, ()>>, z_owned_subscriber_t);
-// A loaned Zenoh subscriber.
+/// A loaned Zenoh subscriber.
 get_opaque_type_data!(Subscriber<'static, ()>, z_loaned_subscriber_t);
 
 #[cfg(feature = "unstable")]
-// A liveliness token that can be used to provide the network with information about connectivity to its
-// declarer: when constructed, a PUT sample will be received by liveliness subscribers on intersecting key
-// expressions.
-//
-// A DELETE on the token's key expression will be received by subscribers if the token is destroyed, or if connectivity between the subscriber and the token's creator is lost.
+/// A liveliness token that can be used to provide the network with information about connectivity to its
+/// declarer: when constructed, a PUT sample will be received by liveliness subscribers on intersecting key
+/// expressions.
+///
+/// A DELETE on the token's key expression will be received by subscribers if the token is destroyed, or if connectivity between the subscriber and the token's creator is lost.
 get_opaque_type_data!(
     Option<LivelinessToken<'static>>,
     zc_owned_liveliness_token_t
@@ -234,96 +235,96 @@ get_opaque_type_data!(
 #[cfg(feature = "unstable")]
 get_opaque_type_data!(LivelinessToken<'static>, zc_loaned_liveliness_token_t);
 #[cfg(feature = "unstable")]
-// An owned Zenoh publication cache.
-//
-// Used to store publications on intersecting key expressions. Can be queried later via `z_get()` to retrieve this data
-// (for example by `ze_owned_querying_subscriber_t`).
+/// An owned Zenoh publication cache.
+///
+/// Used to store publications on intersecting key expressions. Can be queried later via `z_get()` to retrieve this data
+/// (for example by `ze_owned_querying_subscriber_t`).
 get_opaque_type_data!(
     Option<zenoh_ext::PublicationCache<'static>>,
     ze_owned_publication_cache_t
 );
 #[cfg(feature = "unstable")]
-// A loaned Zenoh publication cache.
+/// A loaned Zenoh publication cache.
 get_opaque_type_data!(
     zenoh_ext::PublicationCache<'static>,
     ze_loaned_publication_cache_t
 );
 
-// An owned mutex.
+/// An owned mutex.
 get_opaque_type_data!(
     Option<(Mutex<()>, Option<MutexGuard<'static, ()>>)>,
     z_owned_mutex_t
 );
-// A loaned mutex.
+/// A loaned mutex.
 get_opaque_type_data!(
     (Mutex<()>, Option<MutexGuard<'static, ()>>),
     z_loaned_mutex_t
 );
 
-// An owned conditional variable.
-//
-// Used in combination with `z_owned_mutex_t` to wake up thread when certain conditions are met.
+/// An owned conditional variable.
+///
+/// Used in combination with `z_owned_mutex_t` to wake up thread when certain conditions are met.
 get_opaque_type_data!(Option<Condvar>, z_owned_condvar_t);
-// A loaned conditional variable.
+/// A loaned conditional variable.
 get_opaque_type_data!(Condvar, z_loaned_condvar_t);
 
-// An owned Zenoh task.
+/// An owned Zenoh task.
 get_opaque_type_data!(Option<JoinHandle<()>>, z_owned_task_t);
 
-// An owned Zenoh-allocated hello message returned by a Zenoh entity to a scout message sent with `z_scout()`.
+/// An owned Zenoh-allocated hello message returned by a Zenoh entity to a scout message sent with `z_scout()`.
 get_opaque_type_data!(Option<Hello>, z_owned_hello_t);
-// A loaned hello message.
+/// A loaned hello message.
 get_opaque_type_data!(Hello, z_loaned_hello_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// An owned SHM Client
+/// An owned SHM Client
 get_opaque_type_data!(Option<Arc<dyn ShmClient>>, z_owned_shm_client_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// An owned list of SHM Clients
+/// An owned list of SHM Clients
 get_opaque_type_data!(
     Option<Vec<(ProtocolID, Arc<dyn ShmClient>)>>,
     zc_owned_shm_client_list_t
 );
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// A loaned list of SHM Clients
+/// A loaned list of SHM Clients
 get_opaque_type_data!(
     Vec<(ProtocolID, Arc<dyn ShmClient>)>,
     zc_loaned_shm_client_list_t
 );
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// An owned SHM Client Storage
+/// An owned SHM Client Storage
 get_opaque_type_data!(Option<Arc<ShmClientStorage>>, z_owned_shm_client_storage_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// A loaned SHM Client Storage
+/// A loaned SHM Client Storage
 get_opaque_type_data!(Arc<ShmClientStorage>, z_loaned_shm_client_storage_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// An owned MemoryLayout
+/// An owned MemoryLayout
 get_opaque_type_data!(Option<MemoryLayout>, z_owned_memory_layout_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// A loaned MemoryLayout
+/// A loaned MemoryLayout
 get_opaque_type_data!(MemoryLayout, z_loaned_memory_layout_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// An owned ChunkAllocResult
+/// An owned ChunkAllocResult
 get_opaque_type_data!(Option<ChunkAllocResult>, z_owned_chunk_alloc_result_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// A loaned ChunkAllocResult
+/// A loaned ChunkAllocResult
 get_opaque_type_data!(ChunkAllocResult, z_loaned_chunk_alloc_result_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// An owned ZShm slice
+/// An owned ZShm slice
 get_opaque_type_data!(Option<ZShm>, z_owned_shm_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// A loaned ZShm slice
+/// A loaned ZShm slice
 get_opaque_type_data!(zshm, z_loaned_shm_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// An owned ZShmMut slice
+/// An owned ZShmMut slice
 get_opaque_type_data!(Option<ZShmMut>, z_owned_shm_mut_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// A loaned ZShmMut slice
+/// A loaned ZShmMut slice
 get_opaque_type_data!(zshmmut, z_loaned_shm_mut_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
@@ -388,10 +389,10 @@ enum CDummySHMProvider {
 }
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// An owned ShmProvider
+/// An owned ShmProvider
 get_opaque_type_data!(Option<CDummySHMProvider>, z_owned_shm_provider_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// A loaned ShmProvider
+/// A loaned ShmProvider
 get_opaque_type_data!(CDummySHMProvider, z_loaned_shm_provider_t);
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
@@ -408,60 +409,60 @@ enum CSHMLayout {
 }
 
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// An owned ShmProvider's AllocLayout
+/// An owned ShmProvider's AllocLayout
 get_opaque_type_data!(Option<CSHMLayout>, z_owned_alloc_layout_t);
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-// A loaned ShmProvider's AllocLayout
+/// A loaned ShmProvider's AllocLayout
 get_opaque_type_data!(CSHMLayout, z_loaned_alloc_layout_t);
 
-// An owned Zenoh fifo sample handler.
+/// An owned Zenoh fifo sample handler.
 get_opaque_type_data!(
     Option<flume::Receiver<Sample>>,
     z_owned_fifo_handler_sample_t
 );
-// An loaned Zenoh fifo sample handler.
+/// An loaned Zenoh fifo sample handler.
 get_opaque_type_data!(flume::Receiver<Sample>, z_loaned_fifo_handler_sample_t);
 
-// An owned Zenoh ring sample handler.
+/// An owned Zenoh ring sample handler.
 get_opaque_type_data!(
     Option<RingChannelHandler<Sample>>,
     z_owned_ring_handler_sample_t
 );
-// An loaned Zenoh ring sample handler.
+/// An loaned Zenoh ring sample handler.
 get_opaque_type_data!(RingChannelHandler<Sample>, z_loaned_ring_handler_sample_t);
 
-// An owned Zenoh fifo query handler.
+/// An owned Zenoh fifo query handler.
 get_opaque_type_data!(Option<flume::Receiver<Query>>, z_owned_fifo_handler_query_t);
-// An loaned Zenoh fifo query handler.
+/// An loaned Zenoh fifo query handler.
 get_opaque_type_data!(flume::Receiver<Query>, z_loaned_fifo_handler_query_t);
 
-// An owned Zenoh ring query handler.
+/// An owned Zenoh ring query handler.
 get_opaque_type_data!(
     Option<RingChannelHandler<Query>>,
     z_owned_ring_handler_query_t
 );
-// An loaned Zenoh ring query handler.
+/// An loaned Zenoh ring query handler.
 get_opaque_type_data!(RingChannelHandler<Query>, z_loaned_ring_handler_query_t);
 
-// An owned Zenoh fifo reply handler.
+/// An owned Zenoh fifo reply handler.
 get_opaque_type_data!(Option<flume::Receiver<Reply>>, z_owned_fifo_handler_reply_t);
-// An loaned Zenoh fifo reply handler.
+/// An loaned Zenoh fifo reply handler.
 get_opaque_type_data!(flume::Receiver<Reply>, z_loaned_fifo_handler_reply_t);
 
-// An owned Zenoh ring reply handler.
+/// An owned Zenoh ring reply handler.
 get_opaque_type_data!(
     Option<RingChannelHandler<Reply>>,
     z_owned_ring_handler_reply_t
 );
-// An loaned Zenoh ring reply handler.
+/// An loaned Zenoh ring reply handler.
 get_opaque_type_data!(RingChannelHandler<Reply>, z_loaned_ring_handler_reply_t);
 
 #[cfg(feature = "unstable")]
-// An owned Zenoh-allocated source info`.
+/// An owned Zenoh-allocated source info`.
 get_opaque_type_data!(SourceInfo, z_owned_source_info_t);
 #[cfg(feature = "unstable")]
-// A loaned source info.
+/// A loaned source info.
 get_opaque_type_data!(SourceInfo, z_loaned_source_info_t);
 #[cfg(feature = "unstable")]
-// An entity gloabal id.
+/// An entity gloabal id.
 get_opaque_type_data!(EntityGlobalId, z_entity_global_id_t);

--- a/build.rs
+++ b/build.rs
@@ -104,7 +104,7 @@ fn produce_opaque_types_data() -> PathBuf {
     let stdio = Stdio::from(out_file);
 
     #[allow(unused_mut)]
-    let mut feature_args: Vec<&str> = vec![];
+    let mut feature_args: Vec<&str> = vec!["-F", "panic"]; // enable output structure sizes in panic messages during build
     for (rust_feature, _c_feature) in RUST_TO_C_FEATURES.entries() {
         if test_feature(rust_feature) {
             feature_args.push("-F");


### PR DESCRIPTION
by default do not generate panic messages in opaque-types subprobject for making easier to check if it compiles or not