### PR TITLE
z_recv/z_try_recv without the need of z_check

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -123,7 +123,7 @@ Query
 
       z_get(z_loan(s), z_loan(key_expr), "", z_move(closure), NULL);
       z_owned_reply_t reply;
-      for (z_recv(z_loan(handler), &reply); z_check(reply); z_recv(z_loan(handler), &reply)) {
+      for (z_result_t res = z_recv(z_loan(handler), &reply); res == Z_OK; res = z_recv(z_loan(handler), &reply)) {
           if (z_reply_is_ok(&reply)) {
               const z_loaned_sample_t* sample = z_reply_ok(&reply);
               z_view_string_t key_string;

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
           z_move(opts));  // here, the send is moved and will be dropped by zenoh when adequate
     z_owned_reply_t reply;
 
-    for (z_recv(z_loan(handler), &reply); z_check(reply); z_recv(z_loan(handler), &reply)) {
+    for (z_result_t res = z_recv(z_loan(handler), &reply); res == Z_OK; res = z_recv(z_loan(handler), &reply)) {
         if (z_reply_is_ok(z_loan(reply))) {
             const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));
 

--- a/examples/z_get_liveliness.c
+++ b/examples/z_get_liveliness.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
     z_fifo_channel_reply_new(&closure, &handler, 16);
     zc_liveliness_get(z_loan(s), z_loan(keyexpr), z_move(closure), NULL);
     z_owned_reply_t reply;
-    for (z_recv(z_loan(handler), &reply); z_check(reply); z_recv(z_loan(handler), &reply)) {
+    for (z_result_t res = z_recv(z_loan(handler), &reply); res == Z_OK; res = z_recv(z_loan(handler), &reply)) {
         if (z_reply_is_ok(z_loan(reply))) {
             const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));
             z_view_string_t key_str;

--- a/examples/z_get_shm.c
+++ b/examples/z_get_shm.c
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
           z_move(opts));  // here, the send is moved and will be dropped by zenoh when adequate
     z_owned_reply_t reply;
 
-    for (z_recv(z_loan(handler), &reply); z_check(reply); z_recv(z_loan(handler), &reply)) {
+    for (z_result_t res = z_recv(z_loan(handler), &reply); res == Z_OK; res = z_recv(z_loan(handler), &reply)) {
         if (z_reply_is_ok(z_loan(reply))) {
             const z_loaned_sample_t* sample = z_reply_ok(z_loan(reply));
 

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -55,7 +55,8 @@ int main(int argc, char **argv) {
     z_get(z_loan(s), z_loan(keyexpr), "", z_move(closure),
           z_move(opts));  // here, the closure is moved and will be dropped by zenoh when adequate
     z_owned_reply_t reply;
-    for (z_result_t res = z_try_recv(z_loan(handler), &reply); res != Z_CHANNEL_DISCONNECTED; res = z_try_recv(z_loan(handler), &reply)) {
+    for (z_result_t res = z_try_recv(z_loan(handler), &reply); res != Z_CHANNEL_DISCONNECTED;
+         res = z_try_recv(z_loan(handler), &reply)) {
         if (res != Z_OK) {
             z_sleep_ms(50);
             continue;

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -55,9 +55,8 @@ int main(int argc, char **argv) {
     z_get(z_loan(s), z_loan(keyexpr), "", z_move(closure),
           z_move(opts));  // here, the closure is moved and will be dropped by zenoh when adequate
     z_owned_reply_t reply;
-    for (bool has_more = z_try_recv(z_loan(handler), &reply); has_more;
-         has_more = z_try_recv(z_loan(handler), &reply)) {
-        if (!z_check(reply)) {
+    for (z_result_t res = z_try_recv(z_loan(handler), &reply); res != Z_CHANNEL_DISCONNECTED; res = z_try_recv(z_loan(handler), &reply)) {
+        if (res != Z_OK) {
             z_sleep_ms(50);
             continue;
         }

--- a/examples/z_pub_cache.c
+++ b/examples/z_pub_cache.c
@@ -56,8 +56,8 @@ int main(int argc, char **argv) {
     ze_owned_publication_cache_t pub_cache;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    ze_declare_publication_cache(&pub_cache, z_loan(s), z_loan(ke), &pub_cache_opts);
-    if (!z_check(pub_cache)) {
+
+    if (ze_declare_publication_cache(&pub_cache, z_loan(s), z_loan(ke), &pub_cache_opts) != Z_OK) {
         printf("Unable to declare publication cache for key expression!\n");
         exit(-1);
     }

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -85,8 +85,8 @@ int main(int argc, char **argv) {
         if (c == -1) {
             z_sleep_s(1);
         } else {
-            z_try_recv(z_loan(handler), &sample);
-            if (z_check(sample)) {
+            z_result_t res = z_try_recv(z_loan(handler), &sample);
+            if (res == Z_OK) {
                 handle_sample(z_loan(sample));
                 z_drop(z_move(sample));
             }

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
 
     printf("^C to quit...\n");
     z_owned_query_t oquery;
-    for (z_recv(z_loan(handler), &oquery); z_check(oquery); z_recv(z_loan(handler), &oquery)) {
+    for (z_result_t res = z_recv(z_loan(handler), &oquery); res == Z_OK; res = z_recv(z_loan(handler), &oquery)) {
         const z_loaned_query_t *query = z_loan(oquery);
         z_view_string_t key_string;
         z_keyexpr_as_view_string(z_query_keyexpr(query), &key_string);

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -2364,19 +2364,21 @@ const struct z_loaned_fifo_handler_query_t *z_fifo_handler_query_loan(const stru
 ZENOHC_API void z_fifo_handler_query_null(struct z_owned_fifo_handler_query_t *this_);
 /**
  * Returns query from the fifo buffer. If there are no more pending queries will block until next query is received, or until
- * the channel is dropped (normally when Queryable is dropped). In the later case will return ``false`` and query will be
- * in the gravestone state.
+ * the channel is dropped (normally when Queryable is dropped).
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the query will be in the gravestone state),
+ * `Z_CHANNEL_NODATA` if the channel is still alive, but its buffer is empty (the query will be in the gravestone state).
  */
 ZENOHC_API
-bool z_fifo_handler_query_recv(const struct z_loaned_fifo_handler_query_t *this_,
-                               struct z_owned_query_t *query);
+z_result_t z_fifo_handler_query_recv(const struct z_loaned_fifo_handler_query_t *this_,
+                                     struct z_owned_query_t *query);
 /**
  * Returns query from the fifo buffer. If there are no more pending queries will return immediately (with query set to its gravestone state).
- * Will return false if the channel is dropped (normally when Queryable is dropped) and there are no more queries in the fifo.
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the query will be in the gravestone state),
+ * `Z_CHANNEL_NODATA` if the channel is still alive, but its buffer is empty (the query will be in the gravestone state).
  */
 ZENOHC_API
-bool z_fifo_handler_query_try_recv(const struct z_loaned_fifo_handler_query_t *this_,
-                                   struct z_owned_query_t *query);
+z_result_t z_fifo_handler_query_try_recv(const struct z_loaned_fifo_handler_query_t *this_,
+                                         struct z_owned_query_t *query);
 /**
  * Returns ``true`` if handler is valid, ``false`` if it is in gravestone state.
  */
@@ -2396,19 +2398,20 @@ const struct z_loaned_fifo_handler_reply_t *z_fifo_handler_reply_loan(const stru
 ZENOHC_API void z_fifo_handler_reply_null(struct z_owned_fifo_handler_reply_t *this_);
 /**
  * Returns reply from the fifo buffer. If there are no more pending replies will block until next reply is received, or until
- * the channel is dropped (normally when all replies are received). In the later case will return ``false`` and reply will be
- * in the gravestone state.
+ * the channel is dropped (normally when all replies are received).
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the reply will be in the gravestone state).
  */
 ZENOHC_API
-bool z_fifo_handler_reply_recv(const struct z_loaned_fifo_handler_reply_t *this_,
-                               struct z_owned_reply_t *reply);
+z_result_t z_fifo_handler_reply_recv(const struct z_loaned_fifo_handler_reply_t *this_,
+                                     struct z_owned_reply_t *reply);
 /**
  * Returns reply from the fifo buffer. If there are no more pending replies will return immediately (with reply set to its gravestone state).
- * Will return false if the channel is dropped (normally when all replies are received) and there are no more replies in the fifo.
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the reply will be in the gravestone state),
+ * `Z_CHANNEL_NODATA` if the channel is still alive, but its buffer is empty (the reply will be in the gravestone state).
  */
 ZENOHC_API
-bool z_fifo_handler_reply_try_recv(const struct z_loaned_fifo_handler_reply_t *this_,
-                                   struct z_owned_reply_t *reply);
+z_result_t z_fifo_handler_reply_try_recv(const struct z_loaned_fifo_handler_reply_t *this_,
+                                         struct z_owned_reply_t *reply);
 /**
  * Returns ``true`` if handler is valid, ``false`` if it is in gravestone state.
  */
@@ -2428,19 +2431,21 @@ const struct z_loaned_fifo_handler_sample_t *z_fifo_handler_sample_loan(const st
 ZENOHC_API void z_fifo_handler_sample_null(struct z_owned_fifo_handler_sample_t *this_);
 /**
  * Returns sample from the fifo buffer. If there are no more pending replies will block until next sample is received, or until
- * the channel is dropped (normally when there are no more samples to receive). In the later case will return ``false`` and sample will be
- * in the gravestone state.
+ * the channel is dropped (normally when there are no more samples to receive).
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the sample will be in the gravestone state).
  */
 ZENOHC_API
-bool z_fifo_handler_sample_recv(const struct z_loaned_fifo_handler_sample_t *this_,
-                                struct z_owned_sample_t *sample);
+z_result_t z_fifo_handler_sample_recv(const struct z_loaned_fifo_handler_sample_t *this_,
+                                      struct z_owned_sample_t *sample);
 /**
- * Returns sample from the fifo buffer. If there are no more pending replies will return immediately (with sample set to its gravestone state).
- * Will return false if the channel is dropped (normally when there are no more samples to receive) and there are no more replies in the fifo.
+ * Returns sample from the fifo buffer.
+ * If there are no more pending replies will return immediately (with sample set to its gravestone state).
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the sample will be in the gravestone state),
+ * `Z_CHANNEL_NODATA` if the channel is still alive, but its buffer is empty (the sample will be in the gravestone state).
  */
 ZENOHC_API
-bool z_fifo_handler_sample_try_recv(const struct z_loaned_fifo_handler_sample_t *this_,
-                                    struct z_owned_sample_t *sample);
+z_result_t z_fifo_handler_sample_try_recv(const struct z_loaned_fifo_handler_sample_t *this_,
+                                          struct z_owned_sample_t *sample);
 /**
  * Query data from the matching queryables in the system.
  * Replies are provided through a callback function.
@@ -3187,19 +3192,20 @@ const struct z_loaned_ring_handler_query_t *z_ring_handler_query_loan(const stru
 ZENOHC_API void z_ring_handler_query_null(struct z_owned_ring_handler_query_t *this_);
 /**
  * Returns query from the ring buffer. If there are no more pending queries will block until next query is received, or until
- * the channel is dropped (normally when Queryable is dropped). In the later case will return ``false`` and query will be
- * in the gravestone state.
+ * the channel is dropped (normally when Queryable is dropped).
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the query will be in the gravestone state).
  */
 ZENOHC_API
-bool z_ring_handler_query_recv(const struct z_loaned_ring_handler_query_t *this_,
-                               struct z_owned_query_t *query);
+z_result_t z_ring_handler_query_recv(const struct z_loaned_ring_handler_query_t *this_,
+                                     struct z_owned_query_t *query);
 /**
  * Returns query from the ring buffer. If there are no more pending queries will return immediately (with query set to its gravestone state).
- * Will return false if the channel is dropped (normally when Queryable is dropped) and there are no more queries in the fifo.
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the query will be in the gravestone state),
+ * Z_CHANNEL_NODATA if the channel is still alive, but its buffer is empty (the query will be in the gravestone state).
  */
 ZENOHC_API
-bool z_ring_handler_query_try_recv(const struct z_loaned_ring_handler_query_t *this_,
-                                   struct z_owned_query_t *query);
+z_result_t z_ring_handler_query_try_recv(const struct z_loaned_ring_handler_query_t *this_,
+                                         struct z_owned_query_t *query);
 /**
  * Returns ``true`` if handler is valid, ``false`` if it is in gravestone state.
  */
@@ -3219,19 +3225,20 @@ const struct z_loaned_ring_handler_reply_t *z_ring_handler_reply_loan(const stru
 ZENOHC_API void z_ring_handler_reply_null(struct z_owned_ring_handler_reply_t *this_);
 /**
  * Returns reply from the ring buffer. If there are no more pending replies will block until next reply is received, or until
- * the channel is dropped (normally when all replies are received). In the later case will return ``false`` and reply will be
- * in the gravestone state.
+ * the channel is dropped (normally when all replies are received).
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the reply will be in the gravestone state).
  */
 ZENOHC_API
-bool z_ring_handler_reply_recv(const struct z_loaned_ring_handler_reply_t *this_,
-                               struct z_owned_reply_t *reply);
+z_result_t z_ring_handler_reply_recv(const struct z_loaned_ring_handler_reply_t *this_,
+                                     struct z_owned_reply_t *reply);
 /**
  * Returns reply from the ring buffer. If there are no more pending replies will return immediately (with reply set to its gravestone state).
- * Will return false if the channel is dropped (normally when all replies are received) and there are no more replies in the fifo.
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the reply will be in the gravestone state),
+ * `Z_CHANNEL_NODATA` if the channel is still alive, but its buffer is empty (the reply will be in the gravestone state).
  */
 ZENOHC_API
-bool z_ring_handler_reply_try_recv(const struct z_loaned_ring_handler_reply_t *this_,
-                                   struct z_owned_reply_t *reply);
+z_result_t z_ring_handler_reply_try_recv(const struct z_loaned_ring_handler_reply_t *this_,
+                                         struct z_owned_reply_t *reply);
 /**
  * Returns ``true`` if handler is valid, ``false`` if it is in gravestone state.
  */
@@ -3251,19 +3258,20 @@ const struct z_loaned_ring_handler_sample_t *z_ring_handler_sample_loan(const st
 ZENOHC_API void z_ring_handler_sample_null(struct z_owned_ring_handler_sample_t *this_);
 /**
  * Returns sample from the ring buffer. If there are no more pending replies will block until next sample is received, or until
- * the channel is dropped (normally when there are no more samples to receive). In the later case will return ``false`` and sample will be
- * in the gravestone state.
+ * the channel is dropped (normally when there are no more replies to receive).
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the sample will be in the gravestone state).
  */
 ZENOHC_API
-bool z_ring_handler_sample_recv(const struct z_loaned_ring_handler_sample_t *this_,
-                                struct z_owned_sample_t *sample);
+z_result_t z_ring_handler_sample_recv(const struct z_loaned_ring_handler_sample_t *this_,
+                                      struct z_owned_sample_t *sample);
 /**
  * Returns sample from the ring buffer. If there are no more pending replies will return immediately (with sample set to its gravestone state).
- * Will return false if the channel is dropped (normally when there are no more samples to receive) and there are no more replies in the fifo.
+ * @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the sample will be in the gravestone state),
+ * `Z_CHANNEL_NODATA` if the channel is still alive, but its buffer is empty (the sample will be in the gravestone state).
  */
 ZENOHC_API
-bool z_ring_handler_sample_try_recv(const struct z_loaned_ring_handler_sample_t *this_,
-                                    struct z_owned_sample_t *sample);
+z_result_t z_ring_handler_sample_try_recv(const struct z_loaned_ring_handler_sample_t *this_,
+                                          struct z_owned_sample_t *sample);
 /**
  * Returns sample attachment.
  *

--- a/include/zenoh_concrete.h
+++ b/include/zenoh_concrete.h
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #define DEFAULT_SCOUTING_TIMEOUT 1000
+#define Z_CHANNEL_DISCONNECTED 1
+#define Z_CHANNEL_NODATA 2
 #define Z_OK 0
 #define Z_EINVAL -1
 #define Z_EPARSE -2

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -421,42 +421,42 @@ inline void z_closure(
 };
 
 
-inline bool z_try_recv(const z_loaned_fifo_handler_query_t* this_, z_owned_query_t* query) {
+inline z_result_t z_try_recv(const z_loaned_fifo_handler_query_t* this_, z_owned_query_t* query) {
     return z_fifo_handler_query_try_recv(this_, query);
 };
-inline bool z_try_recv(const z_loaned_fifo_handler_reply_t* this_, z_owned_reply_t* reply) {
+inline z_result_t z_try_recv(const z_loaned_fifo_handler_reply_t* this_, z_owned_reply_t* reply) {
     return z_fifo_handler_reply_try_recv(this_, reply);
 };
-inline bool z_try_recv(const z_loaned_fifo_handler_sample_t* this_, z_owned_sample_t* sample) {
+inline z_result_t z_try_recv(const z_loaned_fifo_handler_sample_t* this_, z_owned_sample_t* sample) {
     return z_fifo_handler_sample_try_recv(this_, sample);
 };
-inline bool z_try_recv(const z_loaned_ring_handler_query_t* this_, z_owned_query_t* query) {
+inline z_result_t z_try_recv(const z_loaned_ring_handler_query_t* this_, z_owned_query_t* query) {
     return z_ring_handler_query_try_recv(this_, query);
 };
-inline bool z_try_recv(const z_loaned_ring_handler_reply_t* this_, z_owned_reply_t* reply) {
+inline z_result_t z_try_recv(const z_loaned_ring_handler_reply_t* this_, z_owned_reply_t* reply) {
     return z_ring_handler_reply_try_recv(this_, reply);
 };
-inline bool z_try_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sample_t* sample) {
+inline z_result_t z_try_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sample_t* sample) {
     return z_ring_handler_sample_try_recv(this_, sample);
 };
 
 
-inline bool z_recv(const z_loaned_fifo_handler_query_t* this_, z_owned_query_t* query) {
+inline z_result_t z_recv(const z_loaned_fifo_handler_query_t* this_, z_owned_query_t* query) {
     return z_fifo_handler_query_recv(this_, query);
 };
-inline bool z_recv(const z_loaned_fifo_handler_reply_t* this_, z_owned_reply_t* reply) {
+inline z_result_t z_recv(const z_loaned_fifo_handler_reply_t* this_, z_owned_reply_t* reply) {
     return z_fifo_handler_reply_recv(this_, reply);
 };
-inline bool z_recv(const z_loaned_fifo_handler_sample_t* this_, z_owned_sample_t* sample) {
+inline z_result_t z_recv(const z_loaned_fifo_handler_sample_t* this_, z_owned_sample_t* sample) {
     return z_fifo_handler_sample_recv(this_, sample);
 };
-inline bool z_recv(const z_loaned_ring_handler_query_t* this_, z_owned_query_t* query) {
+inline z_result_t z_recv(const z_loaned_ring_handler_query_t* this_, z_owned_query_t* query) {
     return z_ring_handler_query_recv(this_, query);
 };
-inline bool z_recv(const z_loaned_ring_handler_reply_t* this_, z_owned_reply_t* reply) {
+inline z_result_t z_recv(const z_loaned_ring_handler_reply_t* this_, z_owned_reply_t* reply) {
     return z_ring_handler_reply_recv(this_, reply);
 };
-inline bool z_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sample_t* sample) {
+inline z_result_t z_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sample_t* sample) {
     return z_ring_handler_sample_recv(this_, sample);
 };
 

--- a/src/closures/response_channel.rs
+++ b/src/closures/response_channel.rs
@@ -23,6 +23,7 @@ use zenoh::{
 
 pub use crate::opaque_types::{z_loaned_fifo_handler_reply_t, z_owned_fifo_handler_reply_t};
 use crate::{
+    result::{self, z_result_t},
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
     z_loaned_reply_t, z_owned_closure_reply_t, z_owned_reply_t,
 };
@@ -97,42 +98,43 @@ pub unsafe extern "C" fn z_fifo_handler_reply_loan(
 }
 
 /// Returns reply from the fifo buffer. If there are no more pending replies will block until next reply is received, or until
-/// the channel is dropped (normally when all replies are received). In the later case will return ``false`` and reply will be
-/// in the gravestone state.
+/// the channel is dropped (normally when all replies are received).
+/// @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the reply will be in the gravestone state).
 #[no_mangle]
 pub extern "C" fn z_fifo_handler_reply_recv(
     this: &z_loaned_fifo_handler_reply_t,
     reply: &mut MaybeUninit<z_owned_reply_t>,
-) -> bool {
+) -> z_result_t {
     match this.as_rust_type_ref().recv() {
         Ok(q) => {
             reply.as_rust_type_mut_uninit().write(Some(q));
-            true
+            result::Z_OK
         }
         Err(_) => {
             reply.as_rust_type_mut_uninit().write(None);
-            false
+            result::Z_CHANNEL_DISCONNECTED
         }
     }
 }
 
 /// Returns reply from the fifo buffer. If there are no more pending replies will return immediately (with reply set to its gravestone state).
-/// Will return false if the channel is dropped (normally when all replies are received) and there are no more replies in the fifo.
+/// @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the reply will be in the gravestone state),
+/// `Z_CHANNEL_NODATA` if the channel is still alive, but its buffer is empty (the reply will be in the gravestone state).
 #[no_mangle]
 pub extern "C" fn z_fifo_handler_reply_try_recv(
     this: &z_loaned_fifo_handler_reply_t,
     reply: &mut MaybeUninit<z_owned_reply_t>,
-) -> bool {
+) -> z_result_t {
     match this.as_rust_type_ref().try_recv() {
         Ok(q) => {
             reply.as_rust_type_mut_uninit().write(Some(q));
-            true
+            result::Z_OK
         }
         Err(e) => {
             reply.as_rust_type_mut_uninit().write(None);
             match e {
-                flume::TryRecvError::Empty => true,
-                flume::TryRecvError::Disconnected => false,
+                flume::TryRecvError::Empty => result::Z_CHANNEL_NODATA,
+                flume::TryRecvError::Disconnected => result::Z_CHANNEL_DISCONNECTED,
             }
         }
     }
@@ -194,40 +196,46 @@ pub unsafe extern "C" fn z_ring_handler_reply_loan(
 }
 
 /// Returns reply from the ring buffer. If there are no more pending replies will block until next reply is received, or until
-/// the channel is dropped (normally when all replies are received). In the later case will return ``false`` and reply will be
-/// in the gravestone state.
+/// the channel is dropped (normally when all replies are received).
+/// @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the reply will be in the gravestone state).
 #[no_mangle]
 pub extern "C" fn z_ring_handler_reply_recv(
     this: &z_loaned_ring_handler_reply_t,
     reply: &mut MaybeUninit<z_owned_reply_t>,
-) -> bool {
+) -> z_result_t {
     match this.as_rust_type_ref().recv() {
         Ok(q) => {
             reply.as_rust_type_mut_uninit().write(Some(q));
-            true
+            result::Z_OK
         }
         Err(_) => {
             reply.as_rust_type_mut_uninit().write(None);
-            false
+            result::Z_CHANNEL_DISCONNECTED
         }
     }
 }
 
 /// Returns reply from the ring buffer. If there are no more pending replies will return immediately (with reply set to its gravestone state).
-/// Will return false if the channel is dropped (normally when all replies are received) and there are no more replies in the fifo.
+/// @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the reply will be in the gravestone state),
+/// `Z_CHANNEL_NODATA` if the channel is still alive, but its buffer is empty (the reply will be in the gravestone state).
 #[no_mangle]
 pub extern "C" fn z_ring_handler_reply_try_recv(
     this: &z_loaned_ring_handler_reply_t,
     reply: &mut MaybeUninit<z_owned_reply_t>,
-) -> bool {
+) -> z_result_t {
     match this.as_rust_type_ref().try_recv() {
         Ok(q) => {
+            let r = if q.is_some() {
+                result::Z_OK
+            } else {
+                result::Z_CHANNEL_NODATA
+            };
             reply.as_rust_type_mut_uninit().write(q);
-            true
+            r
         }
         Err(_) => {
             reply.as_rust_type_mut_uninit().write(None);
-            false
+            result::Z_CHANNEL_DISCONNECTED
         }
     }
 }

--- a/src/closures/sample_channel.rs
+++ b/src/closures/sample_channel.rs
@@ -23,6 +23,7 @@ use zenoh::{
 
 pub use crate::opaque_types::{z_loaned_fifo_handler_sample_t, z_owned_fifo_handler_sample_t};
 use crate::{
+    result::{self, z_result_t},
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
     z_loaned_sample_t, z_owned_closure_sample_t, z_owned_sample_t,
 };
@@ -99,42 +100,44 @@ pub unsafe extern "C" fn z_fifo_handler_sample_loan(
 }
 
 /// Returns sample from the fifo buffer. If there are no more pending replies will block until next sample is received, or until
-/// the channel is dropped (normally when there are no more samples to receive). In the later case will return ``false`` and sample will be
-/// in the gravestone state.
+/// the channel is dropped (normally when there are no more samples to receive).
+/// @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the sample will be in the gravestone state).
 #[no_mangle]
 pub extern "C" fn z_fifo_handler_sample_recv(
     this: &z_loaned_fifo_handler_sample_t,
     sample: &mut MaybeUninit<z_owned_sample_t>,
-) -> bool {
+) -> z_result_t {
     match this.as_rust_type_ref().recv() {
         Ok(q) => {
             sample.as_rust_type_mut_uninit().write(Some(q));
-            true
+            result::Z_OK
         }
         Err(_) => {
             sample.as_rust_type_mut_uninit().write(None);
-            false
+            result::Z_CHANNEL_DISCONNECTED
         }
     }
 }
 
-/// Returns sample from the fifo buffer. If there are no more pending replies will return immediately (with sample set to its gravestone state).
-/// Will return false if the channel is dropped (normally when there are no more samples to receive) and there are no more replies in the fifo.
+/// Returns sample from the fifo buffer.
+/// If there are no more pending replies will return immediately (with sample set to its gravestone state).
+/// @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the sample will be in the gravestone state),
+/// `Z_CHANNEL_NODATA` if the channel is still alive, but its buffer is empty (the sample will be in the gravestone state).
 #[no_mangle]
 pub extern "C" fn z_fifo_handler_sample_try_recv(
     this: &z_loaned_fifo_handler_sample_t,
     sample: &mut MaybeUninit<z_owned_sample_t>,
-) -> bool {
+) -> z_result_t {
     match this.as_rust_type_ref().try_recv() {
         Ok(q) => {
             sample.as_rust_type_mut_uninit().write(Some(q));
-            true
+            result::Z_OK
         }
         Err(e) => {
             sample.as_rust_type_mut_uninit().write(None);
             match e {
-                flume::TryRecvError::Empty => true,
-                flume::TryRecvError::Disconnected => false,
+                flume::TryRecvError::Empty => result::Z_CHANNEL_NODATA,
+                flume::TryRecvError::Disconnected => result::Z_CHANNEL_DISCONNECTED,
             }
         }
     }
@@ -198,40 +201,46 @@ pub unsafe extern "C" fn z_ring_handler_sample_loan(
 }
 
 /// Returns sample from the ring buffer. If there are no more pending replies will block until next sample is received, or until
-/// the channel is dropped (normally when there are no more samples to receive). In the later case will return ``false`` and sample will be
-/// in the gravestone state.
+/// the channel is dropped (normally when there are no more replies to receive).
+/// @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the sample will be in the gravestone state).
 #[no_mangle]
 pub extern "C" fn z_ring_handler_sample_recv(
     this: &z_loaned_ring_handler_sample_t,
     sample: &mut MaybeUninit<z_owned_sample_t>,
-) -> bool {
+) -> z_result_t {
     match this.as_rust_type_ref().recv() {
         Ok(q) => {
             sample.as_rust_type_mut_uninit().write(Some(q));
-            true
+            result::Z_OK
         }
         Err(_) => {
             sample.as_rust_type_mut_uninit().write(None);
-            false
+            result::Z_CHANNEL_DISCONNECTED
         }
     }
 }
 
 /// Returns sample from the ring buffer. If there are no more pending replies will return immediately (with sample set to its gravestone state).
-/// Will return false if the channel is dropped (normally when there are no more samples to receive) and there are no more replies in the fifo.
+/// @return 0 in case of success, `Z_CHANNEL_DISCONNECTED` if channel was dropped (the sample will be in the gravestone state),
+/// `Z_CHANNEL_NODATA` if the channel is still alive, but its buffer is empty (the sample will be in the gravestone state).
 #[no_mangle]
 pub extern "C" fn z_ring_handler_sample_try_recv(
     this: &z_loaned_ring_handler_sample_t,
     sample: &mut MaybeUninit<z_owned_sample_t>,
-) -> bool {
+) -> z_result_t {
     match this.as_rust_type_ref().try_recv() {
         Ok(q) => {
+            let r = if q.is_some() {
+                result::Z_OK
+            } else {
+                result::Z_CHANNEL_NODATA
+            };
             sample.as_rust_type_mut_uninit().write(q);
-            true
+            r
         }
         Err(_) => {
             sample.as_rust_type_mut_uninit().write(None);
-            false
+            result::Z_CHANNEL_DISCONNECTED
         }
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -15,6 +15,8 @@
 #[allow(non_camel_case_types)]
 pub type z_result_t = i8;
 
+pub const Z_CHANNEL_DISCONNECTED: z_result_t = 1;
+pub const Z_CHANNEL_NODATA: z_result_t = 2;
 pub const Z_OK: z_result_t = 0;
 pub const Z_EINVAL: z_result_t = -1;
 pub const Z_EPARSE: z_result_t = -2;

--- a/tests/z_api_liveliness.c
+++ b/tests/z_api_liveliness.c
@@ -119,8 +119,7 @@ void test_liveliness_get() {
 
     zc_liveliness_get(z_loan(s2), z_loan(k), z_move(cb), NULL);
     z_owned_reply_t reply;
-    assert(z_recv(z_loan(handler), &reply));
-    assert(z_check(reply));
+    assert(z_recv(z_loan(handler), &reply) == Z_OK);
     assert(z_reply_is_ok(z_loan(reply)));
     const z_loaned_keyexpr_t* reply_keyexpr = z_sample_keyexpr(z_reply_ok(z_loan(reply)));
     z_view_string_t reply_keyexpr_s;
@@ -128,7 +127,7 @@ void test_liveliness_get() {
     assert(strncmp(token1_expr, z_string_data(z_loan(reply_keyexpr_s)), z_string_len(z_loan(reply_keyexpr_s))) == 0);
 
     z_drop(z_move(reply));
-    assert(!z_recv(z_loan(handler), &reply));
+    assert(z_recv(z_loan(handler), &reply) == Z_CHANNEL_DISCONNECTED);
 
     z_drop(z_move(t1));
     z_drop(z_move(handler));
@@ -136,7 +135,7 @@ void test_liveliness_get() {
     z_fifo_channel_reply_new(&cb, &handler, 3);
 
     zc_liveliness_get(z_loan(s2), z_loan(k), z_move(cb), NULL);
-    assert(!z_recv(z_loan(handler), &reply));
+    assert(z_recv(z_loan(handler), &reply) == Z_CHANNEL_DISCONNECTED);
 
     z_drop(z_move(handler));
     z_drop(z_move(s1));

--- a/tests/z_api_payload_test.c
+++ b/tests/z_api_payload_test.c
@@ -139,14 +139,14 @@ void test_slice(void) {
     z_owned_slice_t s;
     z_slice_copy_from_buf(&s, data, 10);
     z_bytes_serialize_from_slice(&payload2, z_loan(s));
-    assert(z_check(s));
+    assert(!z_slice_is_empty(z_loan(s)));
     z_drop(z_move(s));
     assert(z_check_and_drop_payload(&payload2, data, 10));
 
     z_owned_bytes_t payload3;
     z_slice_copy_from_buf(&s, data, 10);
     z_bytes_from_slice(&payload3, z_move(s));
-    assert(!z_check(s));
+    assert(z_slice_is_empty(z_loan(s)));
     assert(z_check_and_drop_payload(&payload3, data, 10));
 
     z_owned_bytes_t payload4;

--- a/tests/z_api_shm_test.c
+++ b/tests/z_api_shm_test.c
@@ -81,12 +81,11 @@ int test_shm_buffer(z_owned_shm_mut_t* buf) {
 
 bool test_layouted_allocation(const z_loaned_alloc_layout_t* alloc_layout) {
     z_buf_alloc_result_t alloc;
-    z_alloc_layout_alloc_gc(&alloc, alloc_layout);
 
     z_owned_shm_mut_t shm_buf;
     z_alloc_error_t shm_error;
 
-    if (z_check(alloc.buf)) {
+    if (z_alloc_layout_alloc_gc(&alloc, alloc_layout) == Z_OK) {
         ASSERT_OK(test_shm_buffer(z_move(alloc.buf)));
         ASSERT_CHECK_ERR(alloc.buf);
         return true;
@@ -96,12 +95,11 @@ bool test_layouted_allocation(const z_loaned_alloc_layout_t* alloc_layout) {
 
 bool test_allocation(const z_loaned_shm_provider_t* provider, size_t size, z_alloc_alignment_t alignment) {
     z_buf_layout_alloc_result_t alloc;
-    z_shm_provider_alloc_gc(&alloc, provider, size, alignment);
 
     z_owned_shm_mut_t shm_buf;
     z_alloc_error_t shm_error;
 
-    if (z_check(alloc.buf)) {
+    if (z_shm_provider_alloc_gc(&alloc, provider, size, alignment) == Z_OK) {
         ASSERT_OK(test_shm_buffer(z_move(alloc.buf)));
         ASSERT_CHECK_ERR(alloc.buf);
         return true;

--- a/tests/z_int_pub_cache_query_sub_test.c
+++ b/tests/z_int_pub_cache_query_sub_test.c
@@ -134,8 +134,8 @@ int run_subscriber() {
     z_owned_closure_sample_t callback;
     z_closure(&callback, data_handler, NULL, NULL);
     ze_owned_querying_subscriber_t sub;
-    ze_declare_querying_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL);
-    if (!z_check(sub)) {
+    ;
+    if (ze_declare_querying_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) != Z_OK) {
         perror("Unable to declare subscriber!");
         return -1;
     }

--- a/tests/z_int_pub_sub_test.c
+++ b/tests/z_int_pub_sub_test.c
@@ -49,8 +49,8 @@ int run_publisher() {
     publisher_options.priority = Z_PRIORITY_DATA;
     publisher_options.congestion_control = Z_CONGESTION_CONTROL_BLOCK;
     z_owned_publisher_t pub;
-    z_declare_publisher(&pub, z_loan(s), z_loan(ke), &publisher_options);
-    if (!z_check(pub)) {
+
+    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), &publisher_options) != Z_OK) {
         perror("Unable to declare Publisher for key expression!");
         return -1;
     }

--- a/tests/z_int_queryable_attachment_test.c
+++ b/tests/z_int_queryable_attachment_test.c
@@ -190,7 +190,7 @@ int run_get() {
         opts.attachment = &attachment;
         z_get(z_loan(s), z_loan(ke), "", z_move(closure), &opts);
         z_owned_reply_t reply;
-        for (z_recv(z_loan(handler), &reply); z_check(reply); z_recv(z_loan(handler), &reply)) {
+        for (z_result_t res = z_recv(z_loan(handler), &reply); res == Z_OK; res = z_recv(z_loan(handler), &reply)) {
             assert(z_reply_is_ok(z_loan(reply)));
 
             const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));

--- a/tests/z_int_queryable_test.c
+++ b/tests/z_int_queryable_test.c
@@ -73,8 +73,8 @@ int run_queryable() {
     z_owned_closure_query_t callback;
     z_closure(&callback, query_handler, NULL, keyexpr);
     z_owned_queryable_t qable;
-    z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL);
-    if (!z_check(qable)) {
+    ;
+    if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) != Z_OK) {
         printf("Unable to create queryable.\n");
         return -1;
     }
@@ -109,7 +109,7 @@ int run_get() {
         z_get_options_default(&opts);
         z_get(z_loan(s), z_loan(ke), "", z_move(closure), &opts);
         z_owned_reply_t reply;
-        for (z_recv(z_loan(handler), &reply); z_check(reply); z_recv(z_loan(handler), &reply)) {
+        for (z_result_t res = z_recv(z_loan(handler), &reply); res == Z_OK; res = z_recv(z_loan(handler), &reply)) {
             assert(z_reply_is_ok(z_loan(reply)));
 
             const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));


### PR DESCRIPTION
make z_recv/z_try_recv return z_result_t to allow differentiating between different cases without the need to call z_check on constructed object.
Closes #568.