### PR TITLE
fix: use `z_move` in shm examples

### DIFF
--- a/examples/z_get_shm.c
+++ b/examples/z_get_shm.c
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
             printf("Unexpected failure during SHM buffer serialization...\n");
             return -1;
         }
-        opts.payload = &payload;
+        opts.payload = z_move(payload);
     }
     z_get(z_loan(s), z_loan(keyexpr), "", z_move(closure),
           &opts);  // here, the send is moved and will be dropped by zenoh when adequate

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
             z_publisher_put_options_default(&options);
 
             z_owned_bytes_t payload;
-            z_bytes_serialize_from_shm_mut(&payload, &alloc.buf);
+            z_bytes_serialize_from_shm_mut(&payload, z_move(alloc.buf));
 
             z_publisher_put(z_loan(pub), z_move(payload), &options);
         } else {

--- a/examples/z_queryable_shm.c
+++ b/examples/z_queryable_shm.c
@@ -62,7 +62,7 @@ void query_handler(const z_loaned_query_t *query, void *context) {
         z_query_reply_options_default(&options);
 
         z_owned_bytes_t reply_payload;
-        z_bytes_serialize_from_shm_mut(&reply_payload, &alloc.buf);
+        z_bytes_serialize_from_shm_mut(&reply_payload, z_move(alloc.buf));
 
         z_view_keyexpr_t reply_keyexpr;
         z_view_keyexpr_from_str(&reply_keyexpr, (const char *)context);


### PR DESCRIPTION
Closes #588.