### PR TITLE
Moved as ptr

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1023,7 +1023,7 @@ pub fn create_generics_header(path_in: &str, path_out: &str) {
     }
 
     if !msgs.is_empty() {
-        // panic!("Some functions are missing:\n{}", msgs.join("\n"));
+        panic!("Some functions are missing:\n{}", msgs.join("\n"));
     }
 
     let out = generate_move_functions_c(&move_funcs);

--- a/build.rs
+++ b/build.rs
@@ -1141,7 +1141,7 @@ pub fn make_move_take_signatures(
     path_in: &str,
 ) -> (Vec<FunctionSignature>, Vec<FunctionSignature>) {
     let bindings = std::fs::read_to_string(path_in).unwrap();
-    let re = Regex::new(r"(\w+)_drop\(struct (\w+) (\w+)\);").unwrap();
+    let re = Regex::new(r"(\w+)_drop\(struct (\w+) \*(\w+)\);").unwrap();
     let mut move_funcs = Vec::<FunctionSignature>::new();
     let mut take_funcs = Vec::<FunctionSignature>::new();
 
@@ -1217,7 +1217,7 @@ pub fn find_loan_mut_functions(path_in: &str) -> Vec<FunctionSignature> {
 
 pub fn find_drop_functions(path_in: &str) -> Vec<FunctionSignature> {
     let bindings = std::fs::read_to_string(path_in).unwrap();
-    let re = Regex::new(r"(.+?) +(\w+_drop)\(struct (\w+) (\w+)\);").unwrap();
+    let re = Regex::new(r"(.+?) +(\w+_drop)\(struct (\w+) \*(\w+)\);").unwrap();
     let mut res = Vec::<FunctionSignature>::new();
 
     for (_, [return_type, func_name, arg_type, arg_name]) in
@@ -1344,7 +1344,9 @@ pub fn generate_generic_c(
     let va_args = macro_func
         .iter()
         .any(|f| f.args.len() != macro_func[0].args.len());
-    let mut args = macro_func[0]
+    let mut args = macro_func
+        .first()
+        .unwrap_or_else(|| panic!("no sigatures found for building generic {generic_name}"))
         .args
         .iter()
         .map(|a| a.name.to_string())

--- a/build.rs
+++ b/build.rs
@@ -1230,11 +1230,12 @@ pub fn find_drop_functions(path_in: &str) -> Vec<FunctionSignature> {
             .collect::<Vec<_>>()
             .join(" ");
         let (_, _, semantic, _) = split_type_name(arg_type);
+        let arg_type = arg_type.to_string() + "*";
         let f = FunctionSignature::new(
             semantic,
             return_type.as_str(),
             func_name.to_string(),
-            vec![FuncArg::new(arg_type, arg_name)],
+            vec![FuncArg::new(&arg_type, arg_name)],
         );
         res.push(f);
     }

--- a/build.rs
+++ b/build.rs
@@ -180,7 +180,7 @@ pub struct {type_name} {{
                 "#[repr(C)]
 #[derive(Default)]
 pub struct {moved_type_name} {{
-    _this: {type_name}
+    _this: {type_name},
 }}
 
 impl crate::transmute::TakeCType for {moved_type_name} {{

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -16,26 +16,6 @@
 #define ALIGN(n)
 #define ZENOHC_API
 #endif
-/**
- * Allocation errors
- *
- *     - **NEED_DEFRAGMENT**: defragmentation needed
- *     - **OUT_OF_MEMORY**: the provider is out of memory
- *     - **OTHER**: other error
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef enum z_alloc_error_t {
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  Z_ALLOC_ERROR_NEED_DEFRAGMENT,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  Z_ALLOC_ERROR_OUT_OF_MEMORY,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  Z_ALLOC_ERROR_OTHER,
-#endif
-} z_alloc_error_t;
-#endif
 typedef enum z_congestion_control_t {
   /**
    * Messages are not dropped in case of congestion.
@@ -95,22 +75,6 @@ typedef enum z_keyexpr_intersection_level_t {
    */
   Z_KEYEXPR_INTERSECTION_LEVEL_EQUALS = 3,
 } z_keyexpr_intersection_level_t;
-#endif
-/**
- * Layouting errors
- *
- * INCORRECT_LAYOUT_ARGS: layout arguments are incorrect
- * PROVIDER_INCOMPATIBLE_LAYOUT: layout incompatible with provider
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef enum z_layout_error_t {
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  Z_LAYOUT_ERROR_INCORRECT_LAYOUT_ARGS,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  Z_LAYOUT_ERROR_PROVIDER_INCOMPATIBLE_LAYOUT,
-#endif
-} z_layout_error_t;
 #endif
 /**
  * The priority of zenoh messages.
@@ -266,47 +230,10 @@ typedef enum zc_reply_keyexpr_t {
   ZC_REPLY_KEYEXPR_MATCHING_QUERY = 1,
 } zc_reply_keyexpr_t;
 #endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_buf_alloc_result_t {
-  z_owned_shm_mut_t buf;
-  enum z_alloc_error_t error;
-} z_buf_alloc_result_t;
-#endif
+typedef struct z_moved_alloc_layout_t {
+  struct z_owned_alloc_layout_t _this;
+} z_moved_alloc_layout_t;
 typedef int8_t z_result_t;
-/**
- * An AllocAlignment.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_alloc_alignment_t {
-  uint8_t pow;
-} z_alloc_alignment_t;
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_threadsafe_context_data_t {
-  void *ptr;
-} zc_threadsafe_context_data_t;
-#endif
-/**
- * A tread-safe droppable context.
- * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
- * information to each callback.
- *
- * This is a thread-safe context - the associated callbacks may be executed concurrently with the same
- * zc_context_t instance. In other words, all the callbacks associated with this context data MUST be
- * thread-safe.
- *
- * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted.The
- * delete_fn is guaranteed to be executed only once at some point of time after the last associated
- * callback call returns.
- * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
- * be executed.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_threadsafe_context_t {
-  struct zc_threadsafe_context_data_t context;
-  void (*delete_fn)(void*);
-} zc_threadsafe_context_t;
-#endif
 typedef struct z_moved_bytes_t {
   struct z_owned_bytes_t _this;
 } z_moved_bytes_t;
@@ -316,37 +243,15 @@ typedef struct z_moved_slice_t {
 typedef struct z_moved_string_t {
   struct z_owned_string_t _this;
 } z_moved_string_t;
-/**
- * Unique segment identifier
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef uint32_t z_segment_id_t;
-#endif
-/**
- * Chunk id within it's segment
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef uint32_t z_chunk_id_t;
-#endif
-/**
- * A ChunkDescriptor
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_chunk_descriptor_t {
-  z_segment_id_t segment;
-  z_chunk_id_t chunk;
-  size_t len;
-} z_chunk_descriptor_t;
-#endif
-/**
- * An AllocatedChunk
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_allocated_chunk_t {
-  struct z_chunk_descriptor_t descriptpr;
-  void *data;
-} z_allocated_chunk_t;
-#endif
+typedef struct z_moved_shm_t {
+  struct z_owned_shm_t _this;
+} z_moved_shm_t;
+typedef struct z_moved_shm_mut_t {
+  struct z_owned_shm_mut_t _this;
+} z_moved_shm_mut_t;
+typedef struct z_moved_chunk_alloc_result_t {
+  struct z_owned_chunk_alloc_result_t _this;
+} z_moved_chunk_alloc_result_t;
 /**
  * Monotonic clock
  */
@@ -497,7 +402,7 @@ typedef struct z_owned_closure_zid_t {
   /**
    * A callback function.
    */
-  void (*call)(const z_id_t *z_id, void *context);
+  void (*call)(const struct z_id_t *z_id, void *context);
   /**
    * An optional function that will be called upon closure drop.
    */
@@ -608,6 +513,9 @@ typedef struct z_moved_fifo_handler_sample_t {
 typedef struct z_query_consolidation_t {
   enum z_consolidation_mode_t mode;
 } z_query_consolidation_t;
+typedef struct z_moved_source_info_t {
+  struct z_owned_source_info_t _this;
+} z_moved_source_info_t;
 /**
  * Options passed to the `z_get()` function.
  */
@@ -656,7 +564,7 @@ typedef struct z_get_options_t {
   /**
    * The source info for the query.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * An optional attachment to attach to the query.
@@ -673,6 +581,9 @@ typedef struct z_moved_hello_t {
 typedef struct z_moved_keyexpr_t {
   struct z_owned_keyexpr_t _this;
 } z_moved_keyexpr_t;
+typedef struct z_moved_memory_layout_t {
+  struct z_owned_memory_layout_t _this;
+} z_moved_memory_layout_t;
 typedef struct z_moved_mutex_t {
   struct z_owned_mutex_t _this;
 } z_moved_mutex_t;
@@ -705,7 +616,7 @@ typedef struct z_publisher_put_options_t {
   /**
    * The source info for the publication.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to attach to the publication.
@@ -746,7 +657,7 @@ typedef struct z_put_options_t {
   /**
    * The source info for the message.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this message.
@@ -785,7 +696,7 @@ typedef struct z_query_reply_options_t {
   /**
    * The source info for the reply.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
@@ -817,7 +728,7 @@ typedef struct z_query_reply_del_options_t {
   /**
    * The source info for the reply.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
@@ -868,39 +779,15 @@ typedef struct z_scout_options_t {
    */
   enum z_what_t what;
 } z_scout_options_t;
-/**
- * A callbacks for ShmSegment
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_shm_segment_callbacks_t {
-  uint8_t *(*map_fn)(z_chunk_id_t chunk_id, void *context);
-} zc_shm_segment_callbacks_t;
-#endif
-/**
- * A ShmSegment
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_shm_segment_t {
-  struct zc_threadsafe_context_t context;
-  struct zc_shm_segment_callbacks_t callbacks;
-} z_shm_segment_t;
-#endif
-/**
- * A callbacks for ShmClient
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_shm_client_callbacks_t {
-  bool (*attach_fn)(struct z_shm_segment_t *out_segment, z_segment_id_t segment_id, void *context);
-} zc_shm_client_callbacks_t;
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_buf_layout_alloc_result_t {
-  z_owned_shm_mut_t buf;
-  bool error_is_alloc;
-  enum z_alloc_error_t alloc_error;
-  enum z_layout_error_t layout_error;
-} z_buf_layout_alloc_result_t;
-#endif
+typedef struct z_moved_shm_client_t {
+  struct z_owned_shm_client_t _this;
+} z_moved_shm_client_t;
+typedef struct z_moved_shm_client_storage_t {
+  struct z_owned_shm_client_storage_t _this;
+} z_moved_shm_client_storage_t;
+typedef struct z_moved_shm_provider_t {
+  struct z_owned_shm_provider_t _this;
+} z_moved_shm_provider_t;
 /**
  * Unique protocol identifier.
  * Here is a contract: it is up to user to make sure that incompatible ShmClient
@@ -908,46 +795,6 @@ typedef struct z_buf_layout_alloc_result_t {
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 typedef uint32_t z_protocol_id_t;
-#endif
-/**
- * A non-tread-safe droppable context.
- * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
- * information to each callback.
- *
- * This is a non-thread-safe context - zenoh-c guarantees that associated callbacks that share the same
- * zc_context_t instance will never be executed concurrently. In other words, all the callbacks associated
- * with this context data are not required to be thread-safe.
- *
- * NOTE: Remember that the same callback interfaces associated with different zc_context_t instances can
- * still be executed concurrently. The exact behavior depends on user's application, but we strongly
- * discourage our users from pinning to some specific behavior unless they _really_ understand what they
- * are doing.
- *
- * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted. The
- * delete_fn is guaranteed to be executed only once at some point of time after the last associated
- * callback call returns.
- * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
- * be executed.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_context_t {
-  void *context;
-  void (*delete_fn)(void*);
-} zc_context_t;
-#endif
-/**
- * A callbacks for ShmProviderBackend
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_shm_provider_backend_callbacks_t {
-  void (*alloc_fn)(z_owned_chunk_alloc_result_t *out_result,
-                   const z_loaned_memory_layout_t *layout,
-                   void *context);
-  void (*free_fn)(const struct z_chunk_descriptor_t *chunk, void *context);
-  size_t (*defragment_fn)(void *context);
-  size_t (*available_fn)(void *context);
-  void (*layout_for_fn)(z_owned_memory_layout_t *layout, void *context);
-} zc_shm_provider_backend_callbacks_t;
 #endif
 typedef struct z_moved_string_array_t {
   struct z_owned_string_array_t _this;
@@ -997,14 +844,6 @@ typedef struct zc_owned_closure_log_t {
 typedef struct zc_moved_closure_log_t {
   struct zc_owned_closure_log_t _this;
 } zc_moved_closure_log_t;
-/**
- * Loaned closure.
- */
-#if defined(UNSTABLE)
-typedef struct zc_loaned_closure_matching_status_t {
-  size_t _0[3];
-} zc_loaned_closure_matching_status_t;
-#endif
 /**
  * A struct that indicates if there exist Subscribers matching the Publisher's key expression.
  */
@@ -1074,6 +913,15 @@ typedef struct zc_liveliness_get_options_t {
   uint32_t timeout_ms;
 } zc_liveliness_get_options_t;
 #endif
+typedef struct zc_moved_liveliness_token_t {
+  struct zc_owned_liveliness_token_t _this;
+} zc_moved_liveliness_token_t;
+typedef struct zc_moved_matching_listener_t {
+  struct zc_owned_matching_listener_t _this;
+} zc_moved_matching_listener_t;
+typedef struct zc_moved_shm_client_list_t {
+  struct zc_owned_shm_client_list_t _this;
+} zc_moved_shm_client_list_t;
 /**
  * Options passed to the `ze_declare_publication_cache()` function.
  */
@@ -1144,6 +992,12 @@ typedef struct ze_querying_subscriber_options_t {
   uint64_t query_timeout_ms;
 } ze_querying_subscriber_options_t;
 #endif
+typedef struct ze_moved_publication_cache_t {
+  struct ze_owned_publication_cache_t _this;
+} ze_moved_publication_cache_t;
+typedef struct ze_moved_querying_subscriber_t {
+  struct ze_owned_querying_subscriber_t _this;
+} ze_moved_querying_subscriber_t;
 ZENOHC_API extern const unsigned int Z_ROUTER;
 ZENOHC_API extern const unsigned int Z_PEER;
 ZENOHC_API extern const unsigned int Z_CLIENT;
@@ -1163,53 +1017,54 @@ ZENOHC_API extern const unsigned int Z_SHM_POSIX_PROTOCOL_ID;
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc(struct z_buf_alloc_result_t *out_result,
-                          const z_loaned_alloc_layout_t *layout);
+                          const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc(struct z_buf_alloc_result_t *out_result,
-                             const z_loaned_alloc_layout_t *layout);
+                             const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag(struct z_buf_alloc_result_t *out_result,
-                                    const z_loaned_alloc_layout_t *layout);
+                                    const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_blocking(struct z_buf_alloc_result_t *out_result,
-                                             const z_loaned_alloc_layout_t *layout);
+                                             const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_dealloc(struct z_buf_alloc_result_t *out_result,
-                                            const z_loaned_alloc_layout_t *layout);
+                                            const struct z_loaned_alloc_layout_t *layout);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_alloc_layout_check(const z_owned_alloc_layout_t *this_);
+ZENOHC_API bool z_alloc_layout_check(const struct z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Deletes Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_drop(z_moved_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_drop(struct z_moved_alloc_layout_t *this_);
 #endif
 /**
  * Borrows Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_alloc_layout_t *z_alloc_layout_loan(const z_owned_alloc_layout_t *this_);
+ZENOHC_API
+const struct z_loaned_alloc_layout_t *z_alloc_layout_loan(const struct z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Creates a new Alloc Layout for SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_alloc_layout_new(z_owned_alloc_layout_t *this_,
-                              const z_loaned_shm_provider_t *provider,
+z_result_t z_alloc_layout_new(struct z_owned_alloc_layout_t *this_,
+                              const struct z_loaned_shm_provider_t *provider,
                               size_t size,
                               struct z_alloc_alignment_t alignment);
 #endif
@@ -1217,12 +1072,12 @@ z_result_t z_alloc_layout_new(z_owned_alloc_layout_t *this_,
  * Constructs Alloc Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_null(z_owned_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_null(struct z_owned_alloc_layout_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_alloc_layout_threadsafe_alloc_gc_defrag_async(struct z_buf_alloc_result_t *out_result,
-                                                           const z_loaned_alloc_layout_t *layout,
+                                                           const struct z_loaned_alloc_layout_t *layout,
                                                            struct zc_threadsafe_context_t result_context,
                                                            void (*result_callback)(void*,
                                                                                    struct z_buf_alloc_result_t*));
@@ -1286,7 +1141,7 @@ z_result_t z_bytes_deserialize_into_int8(const struct z_loaned_bytes_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *this_,
-                                               const z_loaned_shm_t **dst);
+                                               const struct z_loaned_shm_t **dst);
 #endif
 /**
  * Deserializes data into a mutably loaned SHM buffer
@@ -1297,7 +1152,7 @@ z_result_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *th
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this_,
-                                                   z_loaned_shm_t **dst);
+                                                   struct z_loaned_shm_t **dst);
 #endif
 /**
  * Deserializes data into an owned SHM buffer by copying it's shared reference
@@ -1308,7 +1163,7 @@ z_result_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_owned_shm(const struct z_loaned_bytes_t *this_,
-                                              z_owned_shm_t *dst);
+                                              struct z_owned_shm_t *dst);
 #endif
 /**
  * Deserializes into a pair of `z_owned_bytes_t` objects.
@@ -1567,7 +1422,9 @@ ZENOHC_API void z_bytes_serialize_from_int8(struct z_owned_bytes_t *this_, int8_
  * Serializes from an immutable SHM buffer consuming it
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_, z_moved_shm_t *shm);
+ZENOHC_API
+z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_,
+                                      struct z_moved_shm_t *shm);
 #endif
 /**
  * Serializes from a mutable SHM buffer consuming it
@@ -1575,7 +1432,7 @@ ZENOHC_API z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_, 
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_serialize_from_shm_mut(struct z_owned_bytes_t *this_,
-                                          z_moved_shm_mut_t *shm);
+                                          struct z_moved_shm_mut_t *shm);
 #endif
 /**
  * Serializes a slice by copying.
@@ -1643,27 +1500,27 @@ z_result_t z_bytes_writer_write_all(struct z_bytes_writer_t *this_,
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_chunk_alloc_result_check(const z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API bool z_chunk_alloc_result_check(const struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Deletes Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_drop(z_moved_chunk_alloc_result_t *this_);
+ZENOHC_API void z_chunk_alloc_result_drop(struct z_moved_chunk_alloc_result_t *this_);
 #endif
 /**
  * Borrows Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const z_owned_chunk_alloc_result_t *this_);
+const struct z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Creates a new Chunk Alloc Result with Error value
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
+void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
                                     enum z_alloc_error_t alloc_error);
 #endif
 /**
@@ -1671,14 +1528,14 @@ void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_chunk_alloc_result_new_ok(z_owned_chunk_alloc_result_t *this_,
+z_result_t z_chunk_alloc_result_new_ok(struct z_owned_chunk_alloc_result_t *this_,
                                        struct z_allocated_chunk_t allocated_chunk);
 #endif
 /**
  * Constructs Chunk Alloc Result in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_null(z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API void z_chunk_alloc_result_null(struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Get number of milliseconds passed since creation of `time`.
@@ -1803,7 +1660,7 @@ ZENOHC_API void z_closure_sample_null(struct z_owned_closure_sample_t *this_);
 #if defined(UNSTABLE)
 ZENOHC_API
 void z_closure_zid_call(const struct z_loaned_closure_zid_t *closure,
-                        const z_id_t *z_id);
+                        const struct z_id_t *z_id);
 #endif
 /**
  * Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
@@ -2498,13 +2355,13 @@ ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint8(void);
  * Returns the entity id of the entity global id.
  */
 #if defined(UNSTABLE)
-ZENOHC_API uint32_t z_entity_global_id_eid(const z_entity_global_id_t *this_);
+ZENOHC_API uint32_t z_entity_global_id_eid(const struct z_entity_global_id_t *this_);
 #endif
 /**
  * Returns the zenoh id of entity global id.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_id_t z_entity_global_id_zid(const z_entity_global_id_t *this_);
+ZENOHC_API struct z_id_t z_entity_global_id_zid(const struct z_entity_global_id_t *this_);
 #endif
 /**
  * Constructs send and recieve ends of the fifo channel
@@ -2682,7 +2539,7 @@ ZENOHC_API enum z_whatami_t z_hello_whatami(const struct z_loaned_hello_t *this_
  * Returns id of Zenoh entity that transmitted hello message.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
+ZENOHC_API struct z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
 #endif
 /**
  * Fetches the Zenoh IDs of all connected peers.
@@ -2718,7 +2575,7 @@ z_result_t z_info_routers_zid(const struct z_loaned_session_t *session,
  * to pass it a valid session.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_id_t z_info_zid(const struct z_loaned_session_t *session);
+ZENOHC_API struct z_id_t z_info_zid(const struct z_loaned_session_t *session);
 #endif
 /**
  * Constructs a non-owned non-null-terminated string from key expression.
@@ -2862,13 +2719,13 @@ enum z_keyexpr_intersection_level_t z_keyexpr_relation_to(const struct z_loaned_
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_memory_layout_check(const z_owned_memory_layout_t *this_);
+ZENOHC_API bool z_memory_layout_check(const struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * Deletes Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_drop(z_moved_memory_layout_t *this_);
+ZENOHC_API void z_memory_layout_drop(struct z_moved_memory_layout_t *this_);
 #endif
 /**
  * Extract data from Memory Layout
@@ -2877,21 +2734,21 @@ ZENOHC_API void z_memory_layout_drop(z_moved_memory_layout_t *this_);
 ZENOHC_API
 void z_memory_layout_get_data(size_t *out_size,
                               struct z_alloc_alignment_t *out_alignment,
-                              const z_loaned_memory_layout_t *this_);
+                              const struct z_loaned_memory_layout_t *this_);
 #endif
 /**
  * Borrows Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_memory_layout_t *z_memory_layout_loan(const z_owned_memory_layout_t *this_);
+const struct z_loaned_memory_layout_t *z_memory_layout_loan(const struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * Creates a new Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_memory_layout_new(z_owned_memory_layout_t *this_,
+z_result_t z_memory_layout_new(struct z_owned_memory_layout_t *this_,
                                size_t size,
                                struct z_alloc_alignment_t alignment);
 #endif
@@ -2899,7 +2756,7 @@ z_result_t z_memory_layout_new(z_owned_memory_layout_t *this_,
  * Constructs Memory Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_null(z_owned_memory_layout_t *this_);
+ZENOHC_API void z_memory_layout_null(struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * Returns ``true`` if mutex is valid, ``false`` otherwise.
@@ -2955,21 +2812,21 @@ z_result_t z_open(struct z_owned_session_t *this_,
 ZENOHC_API
 z_result_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
                                           struct z_moved_config_t *config,
-                                          const z_loaned_shm_client_storage_t *shm_clients);
+                                          const struct z_loaned_shm_client_storage_t *shm_clients);
 #endif
 /**
  * Creates a new POSIX SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_posix_shm_client_new(z_owned_shm_client_t *this_);
+ZENOHC_API void z_posix_shm_client_new(struct z_owned_shm_client_t *this_);
 #endif
 /**
  * Creates a new POSIX SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_posix_shm_provider_new(z_owned_shm_provider_t *this_,
-                                    const z_loaned_memory_layout_t *layout);
+z_result_t z_posix_shm_provider_new(struct z_owned_shm_provider_t *this_,
+                                    const struct z_loaned_memory_layout_t *layout);
 #endif
 /**
  * Returns the default value of #z_priority_t.
@@ -2999,7 +2856,7 @@ ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t *this_);
  * Returns the ID of the publisher.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
+ZENOHC_API struct z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
 #endif
 /**
  * Returns the key expression of the publisher.
@@ -3261,7 +3118,7 @@ ZENOHC_API uint64_t z_random_u64(void);
  */
 ZENOHC_API uint8_t z_random_u8(void);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_ref_shm_client_storage_global(z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_ref_shm_client_storage_global(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Returns ``true`` if `reply` is valid, ``false`` otherwise.
@@ -3332,7 +3189,7 @@ ZENOHC_API const struct z_loaned_sample_t *z_reply_ok(const struct z_loaned_repl
  * Returns `true` if id is present.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool z_reply_replier_id(const struct z_loaned_reply_t *this_, z_id_t *out_id);
+ZENOHC_API bool z_reply_replier_id(const struct z_loaned_reply_t *this_, struct z_id_t *out_id);
 #endif
 /**
  * Constructs send and recieve ends of the ring channel
@@ -3518,7 +3375,7 @@ ZENOHC_API enum z_priority_t z_sample_priority(const struct z_loaned_sample_t *t
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
+const struct z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
 #endif
 /**
  * Returns the sample timestamp.
@@ -3571,26 +3428,26 @@ ZENOHC_API void z_session_null(struct z_owned_session_t *this_);
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_check(const z_owned_shm_t *this_);
+ZENOHC_API bool z_shm_check(const struct z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_check(const z_owned_shm_client_t *this_);
+ZENOHC_API bool z_shm_client_check(const struct z_owned_shm_client_t *this_);
 #endif
 /**
  * Deletes SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_drop(z_moved_shm_client_t *this_);
+ZENOHC_API void z_shm_client_drop(struct z_moved_shm_client_t *this_);
 #endif
 /**
  * Creates a new SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_new(z_owned_shm_client_t *this_,
+void z_shm_client_new(struct z_owned_shm_client_t *this_,
                       struct zc_threadsafe_context_t context,
                       struct zc_shm_client_callbacks_t callbacks);
 #endif
@@ -3598,177 +3455,179 @@ void z_shm_client_new(z_owned_shm_client_t *this_,
  * Constructs SHM client in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_null(z_owned_shm_client_t *this_);
+ZENOHC_API void z_shm_client_null(struct z_owned_shm_client_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_storage_check(const z_owned_shm_client_storage_t *this_);
+ZENOHC_API bool z_shm_client_storage_check(const struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Performs a shallow copy of SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_storage_clone(z_owned_shm_client_storage_t *this_,
-                                const z_loaned_shm_client_storage_t *from);
+void z_shm_client_storage_clone(struct z_owned_shm_client_storage_t *this_,
+                                const struct z_loaned_shm_client_storage_t *from);
 #endif
 /**
  * Derefs SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_drop(z_moved_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_drop(struct z_moved_shm_client_storage_t *this_);
 #endif
 /**
  * Borrows SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const z_owned_shm_client_storage_t *this_);
+const struct z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const struct z_owned_shm_client_storage_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_shm_client_storage_new(z_owned_shm_client_storage_t *this_,
-                                    const zc_loaned_shm_client_list_t *clients,
+z_result_t z_shm_client_storage_new(struct z_owned_shm_client_storage_t *this_,
+                                    const struct zc_loaned_shm_client_list_t *clients,
                                     bool add_default_client_set);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_new_default(z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_new_default(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Constructs SHM Client Storage in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_null(z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_null(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Converts borrowed ZShm slice to owned ZShm slice by performing a shallow SHM reference copy
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_clone(z_owned_shm_t *out, const z_loaned_shm_t *this_);
+ZENOHC_API void z_shm_clone(struct z_owned_shm_t *out, const struct z_loaned_shm_t *this_);
 #endif
 /**
  * @return the pointer of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const unsigned char *z_shm_data(const z_loaned_shm_t *this_);
+ZENOHC_API const unsigned char *z_shm_data(const struct z_loaned_shm_t *this_);
 #endif
 /**
  * Deletes ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_drop(z_moved_shm_t *this_);
+ZENOHC_API void z_shm_drop(struct z_moved_shm_t *this_);
 #endif
 /**
  * Constructs ZShm slice from ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_from_mut(z_owned_shm_t *this_, z_moved_shm_mut_t *that);
+ZENOHC_API void z_shm_from_mut(struct z_owned_shm_t *this_, struct z_moved_shm_mut_t *that);
 #endif
 /**
  * @return the length of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_len(const z_loaned_shm_t *this_);
+ZENOHC_API size_t z_shm_len(const struct z_loaned_shm_t *this_);
 #endif
 /**
  * Borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_shm_t *z_shm_loan(const z_owned_shm_t *this_);
+ZENOHC_API const struct z_loaned_shm_t *z_shm_loan(const struct z_owned_shm_t *this_);
 #endif
 /**
  * Mutably borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_t *z_shm_loan_mut(z_owned_shm_t *this_);
+ZENOHC_API struct z_loaned_shm_t *z_shm_loan_mut(struct z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_mut_check(const z_owned_shm_mut_t *this_);
+ZENOHC_API bool z_shm_mut_check(const struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * @return the immutable pointer to the underlying data
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const unsigned char *z_shm_mut_data(const z_loaned_shm_mut_t *this_);
+ZENOHC_API const unsigned char *z_shm_mut_data(const struct z_loaned_shm_mut_t *this_);
 #endif
 /**
  * @return the mutable pointer to the underlying data
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API unsigned char *z_shm_mut_data_mut(z_loaned_shm_mut_t *this_);
+ZENOHC_API unsigned char *z_shm_mut_data_mut(struct z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Deletes ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_drop(z_moved_shm_mut_t *this_);
+ZENOHC_API void z_shm_mut_drop(struct z_moved_shm_mut_t *this_);
 #endif
 /**
  * @return the length of the ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_mut_len(const z_loaned_shm_mut_t *this_);
+ZENOHC_API size_t z_shm_mut_len(const struct z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Borrows ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_shm_mut_t *z_shm_mut_loan(const z_owned_shm_mut_t *this_);
+ZENOHC_API const struct z_loaned_shm_mut_t *z_shm_mut_loan(const struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * Mutably borrows ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_mut_t *z_shm_mut_loan_mut(z_owned_shm_mut_t *this_);
+ZENOHC_API struct z_loaned_shm_mut_t *z_shm_mut_loan_mut(struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * Constructs ZShmMut slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_null(z_owned_shm_mut_t *this_);
+ZENOHC_API void z_shm_mut_null(struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * Tries to construct ZShmMut slice from ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_try_from_immut(z_owned_shm_mut_t *this_, z_moved_shm_t *that);
+ZENOHC_API
+void z_shm_mut_try_from_immut(struct z_owned_shm_mut_t *this_,
+                              struct z_moved_shm_t *that);
 #endif
 /**
  * Constructs ZShm slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_null(z_owned_shm_t *this_);
+ZENOHC_API void z_shm_null(struct z_owned_shm_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc(struct z_buf_layout_alloc_result_t *out_result,
-                          const z_loaned_shm_provider_t *provider,
+                          const struct z_loaned_shm_provider_t *provider,
                           size_t size,
                           struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc(struct z_buf_layout_alloc_result_t *out_result,
-                             const z_loaned_shm_provider_t *provider,
+                             const struct z_loaned_shm_provider_t *provider,
                              size_t size,
                              struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag(struct z_buf_layout_alloc_result_t *out_result,
-                                    const z_loaned_shm_provider_t *provider,
+                                    const struct z_loaned_shm_provider_t *provider,
                                     size_t size,
                                     struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result_t *out_result,
-                                                const z_loaned_shm_provider_t *provider,
+                                                const struct z_loaned_shm_provider_t *provider,
                                                 size_t size,
                                                 struct z_alloc_alignment_t alignment,
                                                 struct zc_threadsafe_context_t result_context,
@@ -3778,48 +3637,49 @@ z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_blocking(struct z_buf_layout_alloc_result_t *out_result,
-                                             const z_loaned_shm_provider_t *provider,
+                                             const struct z_loaned_shm_provider_t *provider,
                                              size_t size,
                                              struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_dealloc(struct z_buf_layout_alloc_result_t *out_result,
-                                            const z_loaned_shm_provider_t *provider,
+                                            const struct z_loaned_shm_provider_t *provider,
                                             size_t size,
                                             struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_available(const z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_available(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_provider_check(const z_owned_shm_provider_t *this_);
+ZENOHC_API bool z_shm_provider_check(const struct z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_defragment(const z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_defragment(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Deletes SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_drop(z_moved_shm_provider_t *this_);
+ZENOHC_API void z_shm_provider_drop(struct z_moved_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_garbage_collect(const z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_garbage_collect(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Borrows SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_shm_provider_t *z_shm_provider_loan(const z_owned_shm_provider_t *this_);
+ZENOHC_API
+const struct z_loaned_shm_provider_t *z_shm_provider_loan(const struct z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_shm_provider_map(z_owned_shm_mut_t *out_result,
-                              const z_loaned_shm_provider_t *provider,
+z_result_t z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
+                              const struct z_loaned_shm_provider_t *provider,
                               struct z_allocated_chunk_t allocated_chunk,
                               size_t len);
 #endif
@@ -3828,7 +3688,7 @@ z_result_t z_shm_provider_map(z_owned_shm_mut_t *out_result,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_new(z_owned_shm_provider_t *this_,
+void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
                         z_protocol_id_t id,
                         struct zc_context_t context,
                         struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3837,14 +3697,14 @@ void z_shm_provider_new(z_owned_shm_provider_t *this_,
  * Constructs SHM Provider in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_null(z_owned_shm_provider_t *this_);
+ZENOHC_API void z_shm_provider_null(struct z_owned_shm_provider_t *this_);
 #endif
 /**
  * Creates a new threadsafe SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
+void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
                                    z_protocol_id_t id,
                                    struct zc_threadsafe_context_t context,
                                    struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3853,13 +3713,13 @@ void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
  * Mutably borrows ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_mut_t *z_shm_try_mut(z_owned_shm_t *this_);
+ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_mut(struct z_owned_shm_t *this_);
 #endif
 /**
  * Tries to reborrow mutably-borrowed ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_mut_t *z_shm_try_reloan_mut(z_loaned_shm_t *this_);
+ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_reloan_mut(struct z_loaned_shm_t *this_);
 #endif
 /**
  * Puts current thread to sleep for specified amount of milliseconds.
@@ -3938,46 +3798,47 @@ ZENOHC_API void z_slice_null(struct z_owned_slice_t *this_);
  * Returns ``true`` if source info is valid, ``false`` if it is in gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool z_source_info_check(const z_owned_source_info_t *this_);
+ZENOHC_API bool z_source_info_check(const struct z_owned_source_info_t *this_);
 #endif
 /**
  * Frees the memory and invalidates the source info, resetting it to a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void z_source_info_drop(z_moved_source_info_t *this_);
+ZENOHC_API void z_source_info_drop(struct z_moved_source_info_t *this_);
 #endif
 /**
  * Returns the source_id of the source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_entity_global_id_t z_source_info_id(const z_loaned_source_info_t *this_);
+ZENOHC_API struct z_entity_global_id_t z_source_info_id(const struct z_loaned_source_info_t *this_);
 #endif
 /**
  * Borrows source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API const z_loaned_source_info_t *z_source_info_loan(const z_owned_source_info_t *this_);
+ZENOHC_API
+const struct z_loaned_source_info_t *z_source_info_loan(const struct z_owned_source_info_t *this_);
 #endif
 /**
  * Create source info
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t z_source_info_new(z_owned_source_info_t *this_,
-                             const z_entity_global_id_t *source_id,
+z_result_t z_source_info_new(struct z_owned_source_info_t *this_,
+                             const struct z_entity_global_id_t *source_id,
                              uint64_t source_sn);
 #endif
 /**
  * Constructs source info in its gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void z_source_info_null(z_owned_source_info_t *this_);
+ZENOHC_API void z_source_info_null(struct z_owned_source_info_t *this_);
 #endif
 /**
  * Returns the source_sn of the source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API uint64_t z_source_info_sn(const z_loaned_source_info_t *this_);
+ZENOHC_API uint64_t z_source_info_sn(const struct z_loaned_source_info_t *this_);
 #endif
 /**
  * @return ``true`` if the string array is valid, ``false`` if it is in a gravestone state.
@@ -4193,7 +4054,7 @@ const char *z_time_now_as_str(const char *buf,
  * Returns id associated with this timestamp.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
+ZENOHC_API struct z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
 #endif
 /**
  * Create uhlc timestamp from session id.
@@ -4561,7 +4422,7 @@ z_result_t zc_liveliness_declare_subscriber(struct z_owned_subscriber_t *this_,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_liveliness_declare_token(zc_owned_liveliness_token_t *this_,
+z_result_t zc_liveliness_declare_token(struct zc_owned_liveliness_token_t *this_,
                                        const struct z_loaned_session_t *session,
                                        const struct z_loaned_keyexpr_t *key_expr,
                                        const struct zc_liveliness_declaration_options_t *_options);
@@ -4598,32 +4459,32 @@ void zc_liveliness_subscriber_options_default(struct zc_liveliness_subscriber_op
  * Returns ``true`` if liveliness token is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool zc_liveliness_token_check(const zc_owned_liveliness_token_t *this_);
+ZENOHC_API bool zc_liveliness_token_check(const struct zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Undeclares liveliness token, frees memory and resets it to a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_liveliness_token_drop(zc_moved_liveliness_token_t *this_);
+ZENOHC_API void zc_liveliness_token_drop(struct zc_moved_liveliness_token_t *this_);
 #endif
 /**
  * Borrows token.
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const zc_owned_liveliness_token_t *this_);
+const struct zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const struct zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Constructs liveliness token in its gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_liveliness_token_null(zc_owned_liveliness_token_t *this_);
+ZENOHC_API void zc_liveliness_token_null(struct zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Destroys a liveliness token, notifying subscribers of its destruction.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t zc_liveliness_undeclare_token(zc_moved_liveliness_token_t *this_);
+ZENOHC_API z_result_t zc_liveliness_undeclare_token(struct zc_moved_liveliness_token_t *this_);
 #endif
 /**
  * Returns default value of `zc_locality_t`
@@ -4635,13 +4496,13 @@ ZENOHC_API enum zc_locality_t zc_locality_default(void);
  * Checks the matching listener is for the gravestone state
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool zc_matching_listener_check(const zc_owned_matching_listener_t *this_);
+ZENOHC_API bool zc_matching_listener_check(const struct zc_owned_matching_listener_t *this_);
 #endif
 /**
  * Constructs an empty matching listener
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_matching_listener_null(zc_owned_matching_listener_t *this_);
+ZENOHC_API void zc_matching_listener_null(struct zc_owned_matching_listener_t *this_);
 #endif
 /**
  * Gets publisher matching status - i.e. if there are any subscribers matching its key expression.
@@ -4664,7 +4525,7 @@ z_result_t zc_publisher_get_matching_status(const struct z_loaned_publisher_t *t
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_publisher_matching_listener_declare(zc_owned_matching_listener_t *this_,
+z_result_t zc_publisher_matching_listener_declare(struct zc_owned_matching_listener_t *this_,
                                                   const struct z_loaned_publisher_t *publisher,
                                                   struct zc_moved_closure_matching_status_t *callback);
 #endif
@@ -4674,7 +4535,8 @@ z_result_t zc_publisher_matching_listener_declare(zc_owned_matching_listener_t *
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t zc_publisher_matching_listener_drop(zc_moved_matching_listener_t *this_);
+ZENOHC_API
+z_result_t zc_publisher_matching_listener_drop(struct zc_moved_matching_listener_t *this_);
 #endif
 /**
  * Undeclares the given matching listener, droping and invalidating it.
@@ -4682,7 +4544,8 @@ ZENOHC_API z_result_t zc_publisher_matching_listener_drop(zc_moved_matching_list
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t zc_publisher_matching_listener_undeclare(zc_moved_matching_listener_t *this_);
+ZENOHC_API
+z_result_t zc_publisher_matching_listener_undeclare(struct zc_moved_matching_listener_t *this_);
 #endif
 /**
  * Returns the default value of #zc_reply_keyexpr_t.
@@ -4693,46 +4556,46 @@ ZENOHC_API enum zc_reply_keyexpr_t zc_reply_keyexpr_default(void);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t zc_shm_client_list_add_client(z_protocol_id_t id,
-                                         z_moved_shm_client_t *client,
-                                         zc_loaned_shm_client_list_t *list);
+                                         struct z_moved_shm_client_t *client,
+                                         struct zc_loaned_shm_client_list_t *list);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool zc_shm_client_list_check(const zc_owned_shm_client_list_t *this_);
+ZENOHC_API bool zc_shm_client_list_check(const struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Deletes list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_drop(zc_moved_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_drop(struct zc_moved_shm_client_list_t *this_);
 #endif
 /**
  * Borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const zc_owned_shm_client_list_t *this_);
+const struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Mutably borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(zc_owned_shm_client_list_t *this_);
+struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Creates a new empty list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_new(zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_new(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Constructs SHM client list in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_null(zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_null(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Stops all Zenoh tasks and drops all related static variables.
@@ -4754,7 +4617,7 @@ void zc_stop_z_runtime(void);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_declare_publication_cache(ze_owned_publication_cache_t *this_,
+z_result_t ze_declare_publication_cache(struct ze_owned_publication_cache_t *this_,
                                         const struct z_loaned_session_t *session,
                                         const struct z_loaned_keyexpr_t *key_expr,
                                         struct ze_publication_cache_options_t *options);
@@ -4772,7 +4635,7 @@ z_result_t ze_declare_publication_cache(ze_owned_publication_cache_t *this_,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_declare_querying_subscriber(ze_owned_querying_subscriber_t *this_,
+z_result_t ze_declare_querying_subscriber(struct ze_owned_querying_subscriber_t *this_,
                                           const struct z_loaned_session_t *session,
                                           const struct z_loaned_keyexpr_t *key_expr,
                                           struct z_moved_closure_sample_t *callback,
@@ -4782,19 +4645,19 @@ z_result_t ze_declare_querying_subscriber(ze_owned_querying_subscriber_t *this_,
  * Returns ``true`` if publication cache is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool ze_publication_cache_check(const ze_owned_publication_cache_t *this_);
+ZENOHC_API bool ze_publication_cache_check(const struct ze_owned_publication_cache_t *this_);
 #endif
 /**
  * Drops publication cache. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_publication_cache_drop(ze_moved_publication_cache_t *this_);
+ZENOHC_API void ze_publication_cache_drop(struct ze_moved_publication_cache_t *this_);
 #endif
 /**
  * Constructs a publication cache in a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_publication_cache_null(ze_owned_publication_cache_t *this_);
+ZENOHC_API void ze_publication_cache_null(struct ze_owned_publication_cache_t *this_);
 #endif
 /**
  * Constructs the default value for `ze_publication_cache_options_t`.
@@ -4806,13 +4669,13 @@ ZENOHC_API void ze_publication_cache_options_default(struct ze_publication_cache
  * Returns ``true`` if querying subscriber is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool ze_querying_subscriber_check(const ze_owned_querying_subscriber_t *this_);
+ZENOHC_API bool ze_querying_subscriber_check(const struct ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Drops querying subscriber. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_querying_subscriber_drop(ze_moved_querying_subscriber_t *this_);
+ZENOHC_API void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_t *this_);
 #endif
 /**
  * Make querying subscriber perform an additional query on a specified selector.
@@ -4821,7 +4684,7 @@ ZENOHC_API void ze_querying_subscriber_drop(ze_moved_querying_subscriber_t *this
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_querying_subscriber_get(const ze_loaned_querying_subscriber_t *this_,
+z_result_t ze_querying_subscriber_get(const struct ze_loaned_querying_subscriber_t *this_,
                                       const struct z_loaned_keyexpr_t *selector,
                                       struct z_get_options_t *options);
 #endif
@@ -4830,13 +4693,13 @@ z_result_t ze_querying_subscriber_get(const ze_loaned_querying_subscriber_t *thi
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const ze_owned_querying_subscriber_t *this_);
+const struct ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const struct ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Constructs a querying subscriber in a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_querying_subscriber_null(ze_owned_querying_subscriber_t *this_);
+ZENOHC_API void ze_querying_subscriber_null(struct ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Constructs the default value for `ze_querying_subscriber_options_t`.
@@ -4850,7 +4713,7 @@ void ze_querying_subscriber_options_default(struct ze_querying_subscriber_option
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t ze_undeclare_publication_cache(ze_moved_publication_cache_t *this_);
+ZENOHC_API z_result_t ze_undeclare_publication_cache(struct ze_moved_publication_cache_t *this_);
 #endif
 /**
  * Undeclares the given querying subscriber, drops it and resets to a gravestone state.
@@ -4858,5 +4721,6 @@ ZENOHC_API z_result_t ze_undeclare_publication_cache(ze_moved_publication_cache_
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t ze_undeclare_querying_subscriber(ze_moved_querying_subscriber_t *_this);
+ZENOHC_API
+z_result_t ze_undeclare_querying_subscriber(struct ze_moved_querying_subscriber_t *_this);
 #endif

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -16,6 +16,26 @@
 #define ALIGN(n)
 #define ZENOHC_API
 #endif
+/**
+ * Allocation errors
+ *
+ *     - **NEED_DEFRAGMENT**: defragmentation needed
+ *     - **OUT_OF_MEMORY**: the provider is out of memory
+ *     - **OTHER**: other error
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef enum z_alloc_error_t {
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+  Z_ALLOC_ERROR_NEED_DEFRAGMENT,
+#endif
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+  Z_ALLOC_ERROR_OUT_OF_MEMORY,
+#endif
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+  Z_ALLOC_ERROR_OTHER,
+#endif
+} z_alloc_error_t;
+#endif
 typedef enum z_congestion_control_t {
   /**
    * Messages are not dropped in case of congestion.
@@ -75,6 +95,22 @@ typedef enum z_keyexpr_intersection_level_t {
    */
   Z_KEYEXPR_INTERSECTION_LEVEL_EQUALS = 3,
 } z_keyexpr_intersection_level_t;
+#endif
+/**
+ * Layouting errors
+ *
+ * INCORRECT_LAYOUT_ARGS: layout arguments are incorrect
+ * PROVIDER_INCOMPATIBLE_LAYOUT: layout incompatible with provider
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef enum z_layout_error_t {
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+  Z_LAYOUT_ERROR_INCORRECT_LAYOUT_ARGS,
+#endif
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+  Z_LAYOUT_ERROR_PROVIDER_INCOMPATIBLE_LAYOUT,
+#endif
+} z_layout_error_t;
 #endif
 /**
  * The priority of zenoh messages.
@@ -230,28 +266,87 @@ typedef enum zc_reply_keyexpr_t {
   ZC_REPLY_KEYEXPR_MATCHING_QUERY = 1,
 } zc_reply_keyexpr_t;
 #endif
-typedef struct z_moved_alloc_layout_t {
-  struct z_owned_alloc_layout_t *_ptr;
-} z_moved_alloc_layout_t;
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_buf_alloc_result_t {
+  z_owned_shm_mut_t buf;
+  enum z_alloc_error_t error;
+} z_buf_alloc_result_t;
+#endif
 typedef int8_t z_result_t;
+/**
+ * An AllocAlignment.
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_alloc_alignment_t {
+  uint8_t pow;
+} z_alloc_alignment_t;
+#endif
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_threadsafe_context_data_t {
+  void *ptr;
+} zc_threadsafe_context_data_t;
+#endif
+/**
+ * A tread-safe droppable context.
+ * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
+ * information to each callback.
+ *
+ * This is a thread-safe context - the associated callbacks may be executed concurrently with the same
+ * zc_context_t instance. In other words, all the callbacks associated with this context data MUST be
+ * thread-safe.
+ *
+ * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted.The
+ * delete_fn is guaranteed to be executed only once at some point of time after the last associated
+ * callback call returns.
+ * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
+ * be executed.
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_threadsafe_context_t {
+  struct zc_threadsafe_context_data_t context;
+  void (*delete_fn)(void*);
+} zc_threadsafe_context_t;
+#endif
 typedef struct z_moved_bytes_t {
-  struct z_owned_bytes_t *_ptr;
+  struct z_owned_bytes_t _this;
 } z_moved_bytes_t;
 typedef struct z_moved_slice_t {
-  struct z_owned_slice_t *_ptr;
+  struct z_owned_slice_t _this;
 } z_moved_slice_t;
 typedef struct z_moved_string_t {
-  struct z_owned_string_t *_ptr;
+  struct z_owned_string_t _this;
 } z_moved_string_t;
-typedef struct z_moved_shm_t {
-  struct z_owned_shm_t *_ptr;
-} z_moved_shm_t;
-typedef struct z_moved_shm_mut_t {
-  struct z_owned_shm_mut_t *_ptr;
-} z_moved_shm_mut_t;
-typedef struct z_moved_chunk_alloc_result_t {
-  struct z_owned_chunk_alloc_result_t *_ptr;
-} z_moved_chunk_alloc_result_t;
+/**
+ * Unique segment identifier
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef uint32_t z_segment_id_t;
+#endif
+/**
+ * Chunk id within it's segment
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef uint32_t z_chunk_id_t;
+#endif
+/**
+ * A ChunkDescriptor
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_chunk_descriptor_t {
+  z_segment_id_t segment;
+  z_chunk_id_t chunk;
+  size_t len;
+} z_chunk_descriptor_t;
+#endif
+/**
+ * An AllocatedChunk
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_allocated_chunk_t {
+  struct z_chunk_descriptor_t descriptpr;
+  void *data;
+} z_allocated_chunk_t;
+#endif
 /**
  * Monotonic clock
  */
@@ -260,7 +355,7 @@ typedef struct z_clock_t {
   const void *t_base;
 } z_clock_t;
 typedef struct z_moved_session_t {
-  struct z_owned_session_t *_ptr;
+  struct z_owned_session_t _this;
 } z_moved_session_t;
 /**
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:
@@ -291,7 +386,7 @@ typedef struct z_owned_closure_hello_t {
  * Moved closure.
  */
 typedef struct z_moved_closure_hello_t {
-  struct z_owned_closure_hello_t *_ptr;
+  struct z_owned_closure_hello_t _this;
 } z_moved_closure_hello_t;
 /**
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:
@@ -321,7 +416,7 @@ typedef struct z_owned_closure_query_t {
  * Moved closure.
  */
 typedef struct z_moved_closure_query_t {
-  struct z_owned_closure_query_t *_ptr;
+  struct z_owned_closure_query_t _this;
 } z_moved_closure_query_t;
 /**
  * A structure that contains all the elements for stateful, memory-leak-free callbacks.
@@ -351,7 +446,7 @@ typedef struct z_owned_closure_reply_t {
  * Moved closure.
  */
 typedef struct z_moved_closure_reply_t {
-  struct z_owned_closure_reply_t *_ptr;
+  struct z_owned_closure_reply_t _this;
 } z_moved_closure_reply_t;
 /**
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
@@ -381,7 +476,7 @@ typedef struct z_owned_closure_sample_t {
  * Moved closure.
  */
 typedef struct z_moved_closure_sample_t {
-  struct z_owned_closure_sample_t *_ptr;
+  struct z_owned_closure_sample_t _this;
 } z_moved_closure_sample_t;
 /**
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:
@@ -402,7 +497,7 @@ typedef struct z_owned_closure_zid_t {
   /**
    * A callback function.
    */
-  void (*call)(const struct z_id_t *z_id, void *context);
+  void (*call)(const z_id_t *z_id, void *context);
   /**
    * An optional function that will be called upon closure drop.
    */
@@ -418,13 +513,13 @@ typedef struct z_moved_closure_zid_t {
 } z_moved_closure_zid_t;
 #endif
 typedef struct z_moved_condvar_t {
-  struct z_owned_condvar_t *_ptr;
+  struct z_owned_condvar_t _this;
 } z_moved_condvar_t;
 typedef struct z_moved_config_t {
-  struct z_owned_config_t *_ptr;
+  struct z_owned_config_t _this;
 } z_moved_config_t;
 typedef struct z_moved_encoding_t {
-  struct z_owned_encoding_t *_ptr;
+  struct z_owned_encoding_t _this;
 } z_moved_encoding_t;
 /**
  * Options passed to the `z_declare_publisher()` function.
@@ -433,7 +528,7 @@ typedef struct z_publisher_options_t {
   /**
    * Default encoding for messages put by this publisher.
    */
-  struct z_moved_encoding_t encoding;
+  struct z_moved_encoding_t *encoding;
   /**
    * The congestion control to apply when routing messages from this publisher.
    */
@@ -499,13 +594,13 @@ typedef struct z_delete_options_t {
 #endif
 } z_delete_options_t;
 typedef struct z_moved_fifo_handler_query_t {
-  struct z_owned_fifo_handler_query_t *_ptr;
+  struct z_owned_fifo_handler_query_t _this;
 } z_moved_fifo_handler_query_t;
 typedef struct z_moved_fifo_handler_reply_t {
-  struct z_owned_fifo_handler_reply_t *_ptr;
+  struct z_owned_fifo_handler_reply_t _this;
 } z_moved_fifo_handler_reply_t;
 typedef struct z_moved_fifo_handler_sample_t {
-  struct z_owned_fifo_handler_sample_t *_ptr;
+  struct z_owned_fifo_handler_sample_t _this;
 } z_moved_fifo_handler_sample_t;
 /**
  * The replies consolidation strategy to apply on replies to a `z_get()`.
@@ -513,9 +608,6 @@ typedef struct z_moved_fifo_handler_sample_t {
 typedef struct z_query_consolidation_t {
   enum z_consolidation_mode_t mode;
 } z_query_consolidation_t;
-typedef struct z_moved_source_info_t {
-  struct z_owned_source_info_t *_ptr;
-} z_moved_source_info_t;
 /**
  * Options passed to the `z_get()` function.
  */
@@ -531,11 +623,11 @@ typedef struct z_get_options_t {
   /**
    * An optional payload to attach to the query.
    */
-  struct z_moved_bytes_t payload;
+  struct z_moved_bytes_t *payload;
   /**
    * An optional encoding of the query payload and or attachment.
    */
-  struct z_moved_encoding_t encoding;
+  struct z_moved_encoding_t *encoding;
   /**
    * The congestion control to apply when routing the query.
    */
@@ -564,28 +656,25 @@ typedef struct z_get_options_t {
   /**
    * The source info for the query.
    */
-  struct z_moved_source_info_t source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * An optional attachment to attach to the query.
    */
-  struct z_moved_bytes_t attachment;
+  struct z_moved_bytes_t *attachment;
   /**
    * The timeout for the query in milliseconds. 0 means default query timeout from zenoh configuration.
    */
   uint64_t timeout_ms;
 } z_get_options_t;
 typedef struct z_moved_hello_t {
-  struct z_owned_hello_t *_ptr;
+  struct z_owned_hello_t _this;
 } z_moved_hello_t;
 typedef struct z_moved_keyexpr_t {
-  struct z_owned_keyexpr_t *_ptr;
+  struct z_owned_keyexpr_t _this;
 } z_moved_keyexpr_t;
-typedef struct z_moved_memory_layout_t {
-  struct z_owned_memory_layout_t *_ptr;
-} z_moved_memory_layout_t;
 typedef struct z_moved_mutex_t {
-  struct z_owned_mutex_t *_ptr;
+  struct z_owned_mutex_t _this;
 } z_moved_mutex_t;
 /**
  * Represents the set of options that can be applied to the delete operation by a previously declared publisher,
@@ -598,7 +687,7 @@ typedef struct z_publisher_delete_options_t {
   const struct z_timestamp_t *timestamp;
 } z_publisher_delete_options_t;
 typedef struct z_moved_publisher_t {
-  struct z_owned_publisher_t *_ptr;
+  struct z_owned_publisher_t _this;
 } z_moved_publisher_t;
 /**
  * Options passed to the `z_publisher_put()` function.
@@ -607,7 +696,7 @@ typedef struct z_publisher_put_options_t {
   /**
    *  The encoding of the data to publish.
    */
-  struct z_moved_encoding_t encoding;
+  struct z_moved_encoding_t *encoding;
   /**
    * The timestamp of the publication.
    */
@@ -616,12 +705,12 @@ typedef struct z_publisher_put_options_t {
   /**
    * The source info for the publication.
    */
-  struct z_moved_source_info_t source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to attach to the publication.
    */
-  struct z_moved_bytes_t attachment;
+  struct z_moved_bytes_t *attachment;
 } z_publisher_put_options_t;
 /**
  * Options passed to the `z_put()` function.
@@ -630,7 +719,7 @@ typedef struct z_put_options_t {
   /**
    * The encoding of the message.
    */
-  struct z_moved_encoding_t encoding;
+  struct z_moved_encoding_t *encoding;
   /**
    * The congestion control to apply when routing this message.
    */
@@ -657,15 +746,15 @@ typedef struct z_put_options_t {
   /**
    * The source info for the message.
    */
-  struct z_moved_source_info_t source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this message.
    */
-  struct z_moved_bytes_t attachment;
+  struct z_moved_bytes_t *attachment;
 } z_put_options_t;
 typedef struct z_moved_query_t {
-  struct z_owned_query_t *_ptr;
+  struct z_owned_query_t _this;
 } z_moved_query_t;
 /**
  * Represents the set of options that can be applied to a query reply,
@@ -675,7 +764,7 @@ typedef struct z_query_reply_options_t {
   /**
    * The encoding of the reply payload.
    */
-  struct z_moved_encoding_t encoding;
+  struct z_moved_encoding_t *encoding;
   /**
    * The congestion control to apply when routing the reply.
    */
@@ -696,12 +785,12 @@ typedef struct z_query_reply_options_t {
   /**
    * The source info for the reply.
    */
-  struct z_moved_source_info_t source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
    */
-  struct z_moved_bytes_t attachment;
+  struct z_moved_bytes_t *attachment;
 } z_query_reply_options_t;
 /**
  * Represents the set of options that can be applied to a query delete reply,
@@ -728,12 +817,12 @@ typedef struct z_query_reply_del_options_t {
   /**
    * The source info for the reply.
    */
-  struct z_moved_source_info_t source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
    */
-  struct z_moved_bytes_t attachment;
+  struct z_moved_bytes_t *attachment;
 } z_query_reply_del_options_t;
 /**
  * Represents the set of options that can be applied to a query reply error,
@@ -743,28 +832,28 @@ typedef struct z_query_reply_err_options_t {
   /**
    * The encoding of the error payload.
    */
-  struct z_moved_encoding_t encoding;
+  struct z_moved_encoding_t *encoding;
 } z_query_reply_err_options_t;
 typedef struct z_moved_queryable_t {
-  struct z_owned_queryable_t *_ptr;
+  struct z_owned_queryable_t _this;
 } z_moved_queryable_t;
 typedef struct z_moved_reply_t {
-  struct z_owned_reply_t *_ptr;
+  struct z_owned_reply_t _this;
 } z_moved_reply_t;
 typedef struct z_moved_reply_err_t {
-  struct z_owned_reply_err_t *_ptr;
+  struct z_owned_reply_err_t _this;
 } z_moved_reply_err_t;
 typedef struct z_moved_ring_handler_query_t {
-  struct z_owned_ring_handler_query_t *_ptr;
+  struct z_owned_ring_handler_query_t _this;
 } z_moved_ring_handler_query_t;
 typedef struct z_moved_ring_handler_reply_t {
-  struct z_owned_ring_handler_reply_t *_ptr;
+  struct z_owned_ring_handler_reply_t _this;
 } z_moved_ring_handler_reply_t;
 typedef struct z_moved_ring_handler_sample_t {
-  struct z_owned_ring_handler_sample_t *_ptr;
+  struct z_owned_ring_handler_sample_t _this;
 } z_moved_ring_handler_sample_t;
 typedef struct z_moved_sample_t {
-  struct z_owned_sample_t *_ptr;
+  struct z_owned_sample_t _this;
 } z_moved_sample_t;
 /**
  * Options to pass to `z_scout()`.
@@ -779,15 +868,39 @@ typedef struct z_scout_options_t {
    */
   enum z_what_t what;
 } z_scout_options_t;
-typedef struct z_moved_shm_client_t {
-  struct z_owned_shm_client_t *_ptr;
-} z_moved_shm_client_t;
-typedef struct z_moved_shm_client_storage_t {
-  struct z_owned_shm_client_storage_t *_ptr;
-} z_moved_shm_client_storage_t;
-typedef struct z_moved_shm_provider_t {
-  struct z_owned_shm_provider_t *_ptr;
-} z_moved_shm_provider_t;
+/**
+ * A callbacks for ShmSegment
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_shm_segment_callbacks_t {
+  uint8_t *(*map_fn)(z_chunk_id_t chunk_id, void *context);
+} zc_shm_segment_callbacks_t;
+#endif
+/**
+ * A ShmSegment
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_shm_segment_t {
+  struct zc_threadsafe_context_t context;
+  struct zc_shm_segment_callbacks_t callbacks;
+} z_shm_segment_t;
+#endif
+/**
+ * A callbacks for ShmClient
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_shm_client_callbacks_t {
+  bool (*attach_fn)(struct z_shm_segment_t *out_segment, z_segment_id_t segment_id, void *context);
+} zc_shm_client_callbacks_t;
+#endif
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_buf_layout_alloc_result_t {
+  z_owned_shm_mut_t buf;
+  bool error_is_alloc;
+  enum z_alloc_error_t alloc_error;
+  enum z_layout_error_t layout_error;
+} z_buf_layout_alloc_result_t;
+#endif
 /**
  * Unique protocol identifier.
  * Here is a contract: it is up to user to make sure that incompatible ShmClient
@@ -796,14 +909,54 @@ typedef struct z_moved_shm_provider_t {
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 typedef uint32_t z_protocol_id_t;
 #endif
+/**
+ * A non-tread-safe droppable context.
+ * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
+ * information to each callback.
+ *
+ * This is a non-thread-safe context - zenoh-c guarantees that associated callbacks that share the same
+ * zc_context_t instance will never be executed concurrently. In other words, all the callbacks associated
+ * with this context data are not required to be thread-safe.
+ *
+ * NOTE: Remember that the same callback interfaces associated with different zc_context_t instances can
+ * still be executed concurrently. The exact behavior depends on user's application, but we strongly
+ * discourage our users from pinning to some specific behavior unless they _really_ understand what they
+ * are doing.
+ *
+ * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted. The
+ * delete_fn is guaranteed to be executed only once at some point of time after the last associated
+ * callback call returns.
+ * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
+ * be executed.
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_context_t {
+  void *context;
+  void (*delete_fn)(void*);
+} zc_context_t;
+#endif
+/**
+ * A callbacks for ShmProviderBackend
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_shm_provider_backend_callbacks_t {
+  void (*alloc_fn)(z_owned_chunk_alloc_result_t *out_result,
+                   const z_loaned_memory_layout_t *layout,
+                   void *context);
+  void (*free_fn)(const struct z_chunk_descriptor_t *chunk, void *context);
+  size_t (*defragment_fn)(void *context);
+  size_t (*available_fn)(void *context);
+  void (*layout_for_fn)(z_owned_memory_layout_t *layout, void *context);
+} zc_shm_provider_backend_callbacks_t;
+#endif
 typedef struct z_moved_string_array_t {
-  struct z_owned_string_array_t *_ptr;
+  struct z_owned_string_array_t _this;
 } z_moved_string_array_t;
 typedef struct z_moved_subscriber_t {
-  struct z_owned_subscriber_t *_ptr;
+  struct z_owned_subscriber_t _this;
 } z_moved_subscriber_t;
 typedef struct z_moved_task_t {
-  struct z_owned_task_t *_ptr;
+  struct z_owned_task_t _this;
 } z_moved_task_t;
 typedef struct z_task_attr_t {
   size_t _0;
@@ -842,8 +995,16 @@ typedef struct zc_owned_closure_log_t {
  * Moved closure.
  */
 typedef struct zc_moved_closure_log_t {
-  struct zc_owned_closure_log_t *_ptr;
+  struct zc_owned_closure_log_t _this;
 } zc_moved_closure_log_t;
+/**
+ * Loaned closure.
+ */
+#if defined(UNSTABLE)
+typedef struct zc_loaned_closure_matching_status_t {
+  size_t _0[3];
+} zc_loaned_closure_matching_status_t;
+#endif
 /**
  * A struct that indicates if there exist Subscribers matching the Publisher's key expression.
  */
@@ -913,15 +1074,6 @@ typedef struct zc_liveliness_get_options_t {
   uint32_t timeout_ms;
 } zc_liveliness_get_options_t;
 #endif
-typedef struct zc_moved_liveliness_token_t {
-  struct zc_owned_liveliness_token_t *_ptr;
-} zc_moved_liveliness_token_t;
-typedef struct zc_moved_matching_listener_t {
-  struct zc_owned_matching_listener_t *_ptr;
-} zc_moved_matching_listener_t;
-typedef struct zc_moved_shm_client_list_t {
-  struct zc_owned_shm_client_list_t *_ptr;
-} zc_moved_shm_client_list_t;
 /**
  * Options passed to the `ze_declare_publication_cache()` function.
  */
@@ -992,12 +1144,6 @@ typedef struct ze_querying_subscriber_options_t {
   uint64_t query_timeout_ms;
 } ze_querying_subscriber_options_t;
 #endif
-typedef struct ze_moved_publication_cache_t {
-  struct ze_owned_publication_cache_t *_ptr;
-} ze_moved_publication_cache_t;
-typedef struct ze_moved_querying_subscriber_t {
-  struct ze_owned_querying_subscriber_t *_ptr;
-} ze_moved_querying_subscriber_t;
 ZENOHC_API extern const unsigned int Z_ROUTER;
 ZENOHC_API extern const unsigned int Z_PEER;
 ZENOHC_API extern const unsigned int Z_CLIENT;
@@ -1017,54 +1163,53 @@ ZENOHC_API extern const unsigned int Z_SHM_POSIX_PROTOCOL_ID;
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc(struct z_buf_alloc_result_t *out_result,
-                          const struct z_loaned_alloc_layout_t *layout);
+                          const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc(struct z_buf_alloc_result_t *out_result,
-                             const struct z_loaned_alloc_layout_t *layout);
+                             const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag(struct z_buf_alloc_result_t *out_result,
-                                    const struct z_loaned_alloc_layout_t *layout);
+                                    const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_blocking(struct z_buf_alloc_result_t *out_result,
-                                             const struct z_loaned_alloc_layout_t *layout);
+                                             const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_dealloc(struct z_buf_alloc_result_t *out_result,
-                                            const struct z_loaned_alloc_layout_t *layout);
+                                            const z_loaned_alloc_layout_t *layout);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_alloc_layout_check(const struct z_owned_alloc_layout_t *this_);
+ZENOHC_API bool z_alloc_layout_check(const z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Deletes Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_drop(struct z_moved_alloc_layout_t this_);
+ZENOHC_API void z_alloc_layout_drop(z_moved_alloc_layout_t this_);
 #endif
 /**
  * Borrows Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-const struct z_loaned_alloc_layout_t *z_alloc_layout_loan(const struct z_owned_alloc_layout_t *this_);
+ZENOHC_API const z_loaned_alloc_layout_t *z_alloc_layout_loan(const z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Creates a new Alloc Layout for SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_alloc_layout_new(struct z_owned_alloc_layout_t *this_,
-                              const struct z_loaned_shm_provider_t *provider,
+z_result_t z_alloc_layout_new(z_owned_alloc_layout_t *this_,
+                              const z_loaned_shm_provider_t *provider,
                               size_t size,
                               struct z_alloc_alignment_t alignment);
 #endif
@@ -1072,12 +1217,12 @@ z_result_t z_alloc_layout_new(struct z_owned_alloc_layout_t *this_,
  * Constructs Alloc Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_null(struct z_owned_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_null(z_owned_alloc_layout_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_alloc_layout_threadsafe_alloc_gc_defrag_async(struct z_buf_alloc_result_t *out_result,
-                                                           const struct z_loaned_alloc_layout_t *layout,
+                                                           const z_loaned_alloc_layout_t *layout,
                                                            struct zc_threadsafe_context_t result_context,
                                                            void (*result_callback)(void*,
                                                                                    struct z_buf_alloc_result_t*));
@@ -1141,7 +1286,7 @@ z_result_t z_bytes_deserialize_into_int8(const struct z_loaned_bytes_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *this_,
-                                               const struct z_loaned_shm_t **dst);
+                                               const z_loaned_shm_t **dst);
 #endif
 /**
  * Deserializes data into a mutably loaned SHM buffer
@@ -1152,7 +1297,7 @@ z_result_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *th
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this_,
-                                                   struct z_loaned_shm_t **dst);
+                                                   z_loaned_shm_t **dst);
 #endif
 /**
  * Deserializes data into an owned SHM buffer by copying it's shared reference
@@ -1163,7 +1308,7 @@ z_result_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_owned_shm(const struct z_loaned_bytes_t *this_,
-                                              struct z_owned_shm_t *dst);
+                                              z_owned_shm_t *dst);
 #endif
 /**
  * Deserializes into a pair of `z_owned_bytes_t` objects.
@@ -1260,13 +1405,13 @@ z_result_t z_bytes_from_iter(struct z_owned_bytes_t *this_,
  */
 ZENOHC_API
 z_result_t z_bytes_from_pair(struct z_owned_bytes_t *this_,
-                             struct z_moved_bytes_t first,
-                             struct z_moved_bytes_t second);
+                             struct z_moved_bytes_t *first,
+                             struct z_moved_bytes_t *second);
 /**
  * Serializes a slice.
  * The slice is consumed upon function return.
  */
-ZENOHC_API void z_bytes_from_slice(struct z_owned_bytes_t *this_, struct z_moved_slice_t slice);
+ZENOHC_API void z_bytes_from_slice(struct z_owned_bytes_t *this_, struct z_moved_slice_t *slice);
 /**
  * Serializes a statically allocated constant data.
  * @param this_: An uninitialized location in memory where `z_owned_bytes_t` is to be constructed.
@@ -1302,7 +1447,7 @@ z_result_t z_bytes_from_str(struct z_owned_bytes_t *this_,
  * Serializes a string.
  * The string is consumed upon function return.
  */
-ZENOHC_API void z_bytes_from_string(struct z_owned_bytes_t *this_, struct z_moved_string_t s);
+ZENOHC_API void z_bytes_from_string(struct z_owned_bytes_t *this_, struct z_moved_string_t *s);
 /**
  * Returns an iterator for multi-element serialized data.
  *
@@ -1422,9 +1567,7 @@ ZENOHC_API void z_bytes_serialize_from_int8(struct z_owned_bytes_t *this_, int8_
  * Serializes from an immutable SHM buffer consuming it
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_,
-                                      struct z_moved_shm_t shm);
+ZENOHC_API z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_, z_moved_shm_t shm);
 #endif
 /**
  * Serializes from a mutable SHM buffer consuming it
@@ -1432,7 +1575,7 @@ z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_serialize_from_shm_mut(struct z_owned_bytes_t *this_,
-                                          struct z_moved_shm_mut_t shm);
+                                          z_moved_shm_mut_t shm);
 #endif
 /**
  * Serializes a slice by copying.
@@ -1478,7 +1621,7 @@ ZENOHC_API void z_bytes_serialize_from_uint8(struct z_owned_bytes_t *this_, uint
  */
 ZENOHC_API
 z_result_t z_bytes_writer_append(struct z_bytes_writer_t *this_,
-                                 struct z_moved_bytes_t bytes);
+                                 struct z_moved_bytes_t *bytes);
 /**
  * Appends bytes, with boundaries information. It would allow to read the same piece of data using `z_bytes_reader_read_bounded()`.
  *
@@ -1486,7 +1629,7 @@ z_result_t z_bytes_writer_append(struct z_bytes_writer_t *this_,
  */
 ZENOHC_API
 z_result_t z_bytes_writer_append_bounded(struct z_bytes_writer_t *this_,
-                                         struct z_moved_bytes_t bytes);
+                                         struct z_moved_bytes_t *bytes);
 /**
  * Writes `len` bytes from `src` into underlying data.
  *
@@ -1500,27 +1643,27 @@ z_result_t z_bytes_writer_write_all(struct z_bytes_writer_t *this_,
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_chunk_alloc_result_check(const struct z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API bool z_chunk_alloc_result_check(const z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Deletes Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_drop(struct z_moved_chunk_alloc_result_t this_);
+ZENOHC_API void z_chunk_alloc_result_drop(z_moved_chunk_alloc_result_t this_);
 #endif
 /**
  * Borrows Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const struct z_owned_chunk_alloc_result_t *this_);
+const z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Creates a new Chunk Alloc Result with Error value
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
+void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
                                     enum z_alloc_error_t alloc_error);
 #endif
 /**
@@ -1528,14 +1671,14 @@ void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_chunk_alloc_result_new_ok(struct z_owned_chunk_alloc_result_t *this_,
+z_result_t z_chunk_alloc_result_new_ok(z_owned_chunk_alloc_result_t *this_,
                                        struct z_allocated_chunk_t allocated_chunk);
 #endif
 /**
  * Constructs Chunk Alloc Result in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_null(struct z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API void z_chunk_alloc_result_null(z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Get number of milliseconds passed since creation of `time`.
@@ -1660,7 +1803,7 @@ ZENOHC_API void z_closure_sample_null(struct z_owned_closure_sample_t *this_);
 #if defined(UNSTABLE)
 ZENOHC_API
 void z_closure_zid_call(const struct z_loaned_closure_zid_t *closure,
-                        const struct z_id_t *z_id);
+                        const z_id_t *z_id);
 #endif
 /**
  * Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
@@ -1817,7 +1960,7 @@ ZENOHC_API
 z_result_t z_declare_queryable(struct z_owned_queryable_t *this_,
                                const struct z_loaned_session_t *session,
                                const struct z_loaned_keyexpr_t *key_expr,
-                               struct z_moved_closure_query_t callback,
+                               struct z_moved_closure_query_t *callback,
                                struct z_queryable_options_t *options);
 /**
  * Constructs and declares a subscriber for a given key expression. Dropping subscriber
@@ -1834,7 +1977,7 @@ ZENOHC_API
 z_result_t z_declare_subscriber(struct z_owned_subscriber_t *this_,
                                 const struct z_loaned_session_t *session,
                                 const struct z_loaned_keyexpr_t *key_expr,
-                                struct z_moved_closure_sample_t callback,
+                                struct z_moved_closure_sample_t *callback,
                                 struct z_subscriber_options_t *options);
 /**
  * Sends request to delete data on specified key expression (used when working with <a href="https://zenoh.io/docs/manual/abstractions/#storage"> Zenoh storages </a>).
@@ -2355,13 +2498,13 @@ ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint8(void);
  * Returns the entity id of the entity global id.
  */
 #if defined(UNSTABLE)
-ZENOHC_API uint32_t z_entity_global_id_eid(const struct z_entity_global_id_t *this_);
+ZENOHC_API uint32_t z_entity_global_id_eid(const z_entity_global_id_t *this_);
 #endif
 /**
  * Returns the zenoh id of entity global id.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_id_t z_entity_global_id_zid(const struct z_entity_global_id_t *this_);
+ZENOHC_API z_id_t z_entity_global_id_zid(const z_entity_global_id_t *this_);
 #endif
 /**
  * Constructs send and recieve ends of the fifo channel
@@ -2501,7 +2644,7 @@ ZENOHC_API
 z_result_t z_get(const struct z_loaned_session_t *session,
                  const struct z_loaned_keyexpr_t *key_expr,
                  const char *parameters,
-                 struct z_moved_closure_reply_t callback,
+                 struct z_moved_closure_reply_t *callback,
                  struct z_get_options_t *options);
 /**
  * Constructs default `z_get_options_t`
@@ -2539,7 +2682,7 @@ ZENOHC_API enum z_whatami_t z_hello_whatami(const struct z_loaned_hello_t *this_
  * Returns id of Zenoh entity that transmitted hello message.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
+ZENOHC_API z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
 #endif
 /**
  * Fetches the Zenoh IDs of all connected peers.
@@ -2575,7 +2718,7 @@ z_result_t z_info_routers_zid(const struct z_loaned_session_t *session,
  * to pass it a valid session.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_id_t z_info_zid(const struct z_loaned_session_t *session);
+ZENOHC_API z_id_t z_info_zid(const struct z_loaned_session_t *session);
 #endif
 /**
  * Constructs a non-owned non-null-terminated string from key expression.
@@ -2719,13 +2862,13 @@ enum z_keyexpr_intersection_level_t z_keyexpr_relation_to(const struct z_loaned_
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_memory_layout_check(const struct z_owned_memory_layout_t *this_);
+ZENOHC_API bool z_memory_layout_check(const z_owned_memory_layout_t *this_);
 #endif
 /**
  * Deletes Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_drop(struct z_moved_memory_layout_t this_);
+ZENOHC_API void z_memory_layout_drop(z_moved_memory_layout_t this_);
 #endif
 /**
  * Extract data from Memory Layout
@@ -2734,21 +2877,21 @@ ZENOHC_API void z_memory_layout_drop(struct z_moved_memory_layout_t this_);
 ZENOHC_API
 void z_memory_layout_get_data(size_t *out_size,
                               struct z_alloc_alignment_t *out_alignment,
-                              const struct z_loaned_memory_layout_t *this_);
+                              const z_loaned_memory_layout_t *this_);
 #endif
 /**
  * Borrows Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct z_loaned_memory_layout_t *z_memory_layout_loan(const struct z_owned_memory_layout_t *this_);
+const z_loaned_memory_layout_t *z_memory_layout_loan(const z_owned_memory_layout_t *this_);
 #endif
 /**
  * Creates a new Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_memory_layout_new(struct z_owned_memory_layout_t *this_,
+z_result_t z_memory_layout_new(z_owned_memory_layout_t *this_,
                                size_t size,
                                struct z_alloc_alignment_t alignment);
 #endif
@@ -2756,7 +2899,7 @@ z_result_t z_memory_layout_new(struct z_owned_memory_layout_t *this_,
  * Constructs Memory Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_null(struct z_owned_memory_layout_t *this_);
+ZENOHC_API void z_memory_layout_null(z_owned_memory_layout_t *this_);
 #endif
 /**
  * Returns ``true`` if mutex is valid, ``false`` otherwise.
@@ -2812,21 +2955,21 @@ z_result_t z_open(struct z_owned_session_t *this_,
 ZENOHC_API
 z_result_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
                                           struct z_moved_config_t config,
-                                          const struct z_loaned_shm_client_storage_t *shm_clients);
+                                          const z_loaned_shm_client_storage_t *shm_clients);
 #endif
 /**
  * Creates a new POSIX SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_posix_shm_client_new(struct z_owned_shm_client_t *this_);
+ZENOHC_API void z_posix_shm_client_new(z_owned_shm_client_t *this_);
 #endif
 /**
  * Creates a new POSIX SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_posix_shm_provider_new(struct z_owned_shm_provider_t *this_,
-                                    const struct z_loaned_memory_layout_t *layout);
+z_result_t z_posix_shm_provider_new(z_owned_shm_provider_t *this_,
+                                    const z_loaned_memory_layout_t *layout);
 #endif
 /**
  * Returns the default value of #z_priority_t.
@@ -2856,7 +2999,7 @@ ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t this_);
  * Returns the ID of the publisher.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
+ZENOHC_API z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
 #endif
 /**
  * Returns the key expression of the publisher.
@@ -2895,7 +3038,7 @@ ZENOHC_API void z_publisher_options_default(struct z_publisher_options_t *this_)
  */
 ZENOHC_API
 z_result_t z_publisher_put(const struct z_loaned_publisher_t *this_,
-                           struct z_moved_bytes_t payload,
+                           struct z_moved_bytes_t *payload,
                            struct z_publisher_put_options_t *options);
 /**
  * Constructs the default value for `z_publisher_put_options_t`.
@@ -2914,7 +3057,7 @@ ZENOHC_API void z_publisher_put_options_default(struct z_publisher_put_options_t
 ZENOHC_API
 z_result_t z_put(const struct z_loaned_session_t *session,
                  const struct z_loaned_keyexpr_t *key_expr,
-                 struct z_moved_bytes_t payload,
+                 struct z_moved_bytes_t *payload,
                  struct z_put_options_t *options);
 /**
  * Constructs the default value for `z_put_options_t`.
@@ -3025,7 +3168,7 @@ const struct z_loaned_bytes_t *z_query_payload(const struct z_loaned_query_t *th
 ZENOHC_API
 z_result_t z_query_reply(const struct z_loaned_query_t *this_,
                          const struct z_loaned_keyexpr_t *key_expr,
-                         struct z_moved_bytes_t payload,
+                         struct z_moved_bytes_t *payload,
                          struct z_query_reply_options_t *options);
 /**
  * Sends a delete reply to a query.
@@ -3065,7 +3208,7 @@ ZENOHC_API void z_query_reply_del_options_default(struct z_query_reply_del_optio
  */
 ZENOHC_API
 z_result_t z_query_reply_err(const struct z_loaned_query_t *this_,
-                             struct z_moved_bytes_t payload,
+                             struct z_moved_bytes_t *payload,
                              struct z_query_reply_err_options_t *options);
 /**
  * Constructs the default value for `z_query_reply_err_options_t`.
@@ -3118,7 +3261,7 @@ ZENOHC_API uint64_t z_random_u64(void);
  */
 ZENOHC_API uint8_t z_random_u8(void);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_ref_shm_client_storage_global(struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_ref_shm_client_storage_global(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Returns ``true`` if `reply` is valid, ``false`` otherwise.
@@ -3189,7 +3332,7 @@ ZENOHC_API const struct z_loaned_sample_t *z_reply_ok(const struct z_loaned_repl
  * Returns `true` if id is present.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool z_reply_replier_id(const struct z_loaned_reply_t *this_, struct z_id_t *out_id);
+ZENOHC_API bool z_reply_replier_id(const struct z_loaned_reply_t *this_, z_id_t *out_id);
 #endif
 /**
  * Constructs send and recieve ends of the ring channel
@@ -3375,7 +3518,7 @@ ZENOHC_API enum z_priority_t z_sample_priority(const struct z_loaned_sample_t *t
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const struct z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
+const z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
 #endif
 /**
  * Returns the sample timestamp.
@@ -3394,7 +3537,7 @@ ZENOHC_API const struct z_timestamp_t *z_sample_timestamp(const struct z_loaned_
  */
 ZENOHC_API
 z_result_t z_scout(struct z_moved_config_t config,
-                   struct z_moved_closure_hello_t callback,
+                   struct z_moved_closure_hello_t *callback,
                    const struct z_scout_options_t *options);
 /**
  * Constructs the default values for the scouting operation.
@@ -3428,26 +3571,26 @@ ZENOHC_API void z_session_null(struct z_owned_session_t *this_);
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_check(const struct z_owned_shm_t *this_);
+ZENOHC_API bool z_shm_check(const z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_check(const struct z_owned_shm_client_t *this_);
+ZENOHC_API bool z_shm_client_check(const z_owned_shm_client_t *this_);
 #endif
 /**
  * Deletes SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_drop(struct z_moved_shm_client_t this_);
+ZENOHC_API void z_shm_client_drop(z_moved_shm_client_t this_);
 #endif
 /**
  * Creates a new SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_new(struct z_owned_shm_client_t *this_,
+void z_shm_client_new(z_owned_shm_client_t *this_,
                       struct zc_threadsafe_context_t context,
                       struct zc_shm_client_callbacks_t callbacks);
 #endif
@@ -3455,179 +3598,177 @@ void z_shm_client_new(struct z_owned_shm_client_t *this_,
  * Constructs SHM client in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_null(struct z_owned_shm_client_t *this_);
+ZENOHC_API void z_shm_client_null(z_owned_shm_client_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_storage_check(const struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API bool z_shm_client_storage_check(const z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Performs a shallow copy of SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_storage_clone(struct z_owned_shm_client_storage_t *this_,
-                                const struct z_loaned_shm_client_storage_t *from);
+void z_shm_client_storage_clone(z_owned_shm_client_storage_t *this_,
+                                const z_loaned_shm_client_storage_t *from);
 #endif
 /**
  * Derefs SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_drop(struct z_moved_shm_client_storage_t this_);
+ZENOHC_API void z_shm_client_storage_drop(z_moved_shm_client_storage_t this_);
 #endif
 /**
  * Borrows SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const struct z_owned_shm_client_storage_t *this_);
+const z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const z_owned_shm_client_storage_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_shm_client_storage_new(struct z_owned_shm_client_storage_t *this_,
-                                    const struct zc_loaned_shm_client_list_t *clients,
+z_result_t z_shm_client_storage_new(z_owned_shm_client_storage_t *this_,
+                                    const zc_loaned_shm_client_list_t *clients,
                                     bool add_default_client_set);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_new_default(struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_new_default(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Constructs SHM Client Storage in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_null(struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_null(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Converts borrowed ZShm slice to owned ZShm slice by performing a shallow SHM reference copy
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_clone(struct z_owned_shm_t *out, const struct z_loaned_shm_t *this_);
+ZENOHC_API void z_shm_clone(z_owned_shm_t *out, const z_loaned_shm_t *this_);
 #endif
 /**
  * @return the pointer of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const unsigned char *z_shm_data(const struct z_loaned_shm_t *this_);
+ZENOHC_API const unsigned char *z_shm_data(const z_loaned_shm_t *this_);
 #endif
 /**
  * Deletes ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_drop(struct z_moved_shm_t this_);
+ZENOHC_API void z_shm_drop(z_moved_shm_t this_);
 #endif
 /**
  * Constructs ZShm slice from ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_from_mut(struct z_owned_shm_t *this_, struct z_moved_shm_mut_t that);
+ZENOHC_API void z_shm_from_mut(z_owned_shm_t *this_, z_moved_shm_mut_t that);
 #endif
 /**
  * @return the length of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_len(const struct z_loaned_shm_t *this_);
+ZENOHC_API size_t z_shm_len(const z_loaned_shm_t *this_);
 #endif
 /**
  * Borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const struct z_loaned_shm_t *z_shm_loan(const struct z_owned_shm_t *this_);
+ZENOHC_API const z_loaned_shm_t *z_shm_loan(const z_owned_shm_t *this_);
 #endif
 /**
  * Mutably borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_t *z_shm_loan_mut(struct z_owned_shm_t *this_);
+ZENOHC_API z_loaned_shm_t *z_shm_loan_mut(z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_mut_check(const struct z_owned_shm_mut_t *this_);
+ZENOHC_API bool z_shm_mut_check(const z_owned_shm_mut_t *this_);
 #endif
 /**
  * @return the immutable pointer to the underlying data
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const unsigned char *z_shm_mut_data(const struct z_loaned_shm_mut_t *this_);
+ZENOHC_API const unsigned char *z_shm_mut_data(const z_loaned_shm_mut_t *this_);
 #endif
 /**
  * @return the mutable pointer to the underlying data
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API unsigned char *z_shm_mut_data_mut(struct z_loaned_shm_mut_t *this_);
+ZENOHC_API unsigned char *z_shm_mut_data_mut(z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Deletes ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_drop(struct z_moved_shm_mut_t this_);
+ZENOHC_API void z_shm_mut_drop(z_moved_shm_mut_t this_);
 #endif
 /**
  * @return the length of the ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_mut_len(const struct z_loaned_shm_mut_t *this_);
+ZENOHC_API size_t z_shm_mut_len(const z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Borrows ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const struct z_loaned_shm_mut_t *z_shm_mut_loan(const struct z_owned_shm_mut_t *this_);
+ZENOHC_API const z_loaned_shm_mut_t *z_shm_mut_loan(const z_owned_shm_mut_t *this_);
 #endif
 /**
  * Mutably borrows ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_mut_t *z_shm_mut_loan_mut(struct z_owned_shm_mut_t *this_);
+ZENOHC_API z_loaned_shm_mut_t *z_shm_mut_loan_mut(z_owned_shm_mut_t *this_);
 #endif
 /**
  * Constructs ZShmMut slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_null(struct z_owned_shm_mut_t *this_);
+ZENOHC_API void z_shm_mut_null(z_owned_shm_mut_t *this_);
 #endif
 /**
  * Tries to construct ZShmMut slice from ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-void z_shm_mut_try_from_immut(struct z_owned_shm_mut_t *this_,
-                              struct z_moved_shm_t that);
+ZENOHC_API void z_shm_mut_try_from_immut(z_owned_shm_mut_t *this_, z_moved_shm_t that);
 #endif
 /**
  * Constructs ZShm slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_null(struct z_owned_shm_t *this_);
+ZENOHC_API void z_shm_null(z_owned_shm_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc(struct z_buf_layout_alloc_result_t *out_result,
-                          const struct z_loaned_shm_provider_t *provider,
+                          const z_loaned_shm_provider_t *provider,
                           size_t size,
                           struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc(struct z_buf_layout_alloc_result_t *out_result,
-                             const struct z_loaned_shm_provider_t *provider,
+                             const z_loaned_shm_provider_t *provider,
                              size_t size,
                              struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag(struct z_buf_layout_alloc_result_t *out_result,
-                                    const struct z_loaned_shm_provider_t *provider,
+                                    const z_loaned_shm_provider_t *provider,
                                     size_t size,
                                     struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result_t *out_result,
-                                                const struct z_loaned_shm_provider_t *provider,
+                                                const z_loaned_shm_provider_t *provider,
                                                 size_t size,
                                                 struct z_alloc_alignment_t alignment,
                                                 struct zc_threadsafe_context_t result_context,
@@ -3637,49 +3778,48 @@ z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_blocking(struct z_buf_layout_alloc_result_t *out_result,
-                                             const struct z_loaned_shm_provider_t *provider,
+                                             const z_loaned_shm_provider_t *provider,
                                              size_t size,
                                              struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_dealloc(struct z_buf_layout_alloc_result_t *out_result,
-                                            const struct z_loaned_shm_provider_t *provider,
+                                            const z_loaned_shm_provider_t *provider,
                                             size_t size,
                                             struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_available(const struct z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_available(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_provider_check(const struct z_owned_shm_provider_t *this_);
+ZENOHC_API bool z_shm_provider_check(const z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_defragment(const struct z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_defragment(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Deletes SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_drop(struct z_moved_shm_provider_t this_);
+ZENOHC_API void z_shm_provider_drop(z_moved_shm_provider_t this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_garbage_collect(const struct z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_garbage_collect(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Borrows SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-const struct z_loaned_shm_provider_t *z_shm_provider_loan(const struct z_owned_shm_provider_t *this_);
+ZENOHC_API const z_loaned_shm_provider_t *z_shm_provider_loan(const z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
-                              const struct z_loaned_shm_provider_t *provider,
+z_result_t z_shm_provider_map(z_owned_shm_mut_t *out_result,
+                              const z_loaned_shm_provider_t *provider,
                               struct z_allocated_chunk_t allocated_chunk,
                               size_t len);
 #endif
@@ -3688,7 +3828,7 @@ z_result_t z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
+void z_shm_provider_new(z_owned_shm_provider_t *this_,
                         z_protocol_id_t id,
                         struct zc_context_t context,
                         struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3697,14 +3837,14 @@ void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
  * Constructs SHM Provider in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_null(struct z_owned_shm_provider_t *this_);
+ZENOHC_API void z_shm_provider_null(z_owned_shm_provider_t *this_);
 #endif
 /**
  * Creates a new threadsafe SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
+void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
                                    z_protocol_id_t id,
                                    struct zc_threadsafe_context_t context,
                                    struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3713,13 +3853,13 @@ void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
  * Mutably borrows ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_mut(struct z_owned_shm_t *this_);
+ZENOHC_API z_loaned_shm_mut_t *z_shm_try_mut(z_owned_shm_t *this_);
 #endif
 /**
  * Tries to reborrow mutably-borrowed ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_reloan_mut(struct z_loaned_shm_t *this_);
+ZENOHC_API z_loaned_shm_mut_t *z_shm_try_reloan_mut(z_loaned_shm_t *this_);
 #endif
 /**
  * Puts current thread to sleep for specified amount of milliseconds.
@@ -3798,47 +3938,46 @@ ZENOHC_API void z_slice_null(struct z_owned_slice_t *this_);
  * Returns ``true`` if source info is valid, ``false`` if it is in gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool z_source_info_check(const struct z_owned_source_info_t *this_);
+ZENOHC_API bool z_source_info_check(const z_owned_source_info_t *this_);
 #endif
 /**
  * Frees the memory and invalidates the source info, resetting it to a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void z_source_info_drop(struct z_moved_source_info_t this_);
+ZENOHC_API void z_source_info_drop(z_moved_source_info_t this_);
 #endif
 /**
  * Returns the source_id of the source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_entity_global_id_t z_source_info_id(const struct z_loaned_source_info_t *this_);
+ZENOHC_API z_entity_global_id_t z_source_info_id(const z_loaned_source_info_t *this_);
 #endif
 /**
  * Borrows source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API
-const struct z_loaned_source_info_t *z_source_info_loan(const struct z_owned_source_info_t *this_);
+ZENOHC_API const z_loaned_source_info_t *z_source_info_loan(const z_owned_source_info_t *this_);
 #endif
 /**
  * Create source info
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t z_source_info_new(struct z_owned_source_info_t *this_,
-                             const struct z_entity_global_id_t *source_id,
+z_result_t z_source_info_new(z_owned_source_info_t *this_,
+                             const z_entity_global_id_t *source_id,
                              uint64_t source_sn);
 #endif
 /**
  * Constructs source info in its gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void z_source_info_null(struct z_owned_source_info_t *this_);
+ZENOHC_API void z_source_info_null(z_owned_source_info_t *this_);
 #endif
 /**
  * Returns the source_sn of the source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API uint64_t z_source_info_sn(const struct z_loaned_source_info_t *this_);
+ZENOHC_API uint64_t z_source_info_sn(const z_loaned_source_info_t *this_);
 #endif
 /**
  * @return ``true`` if the string array is valid, ``false`` if it is in a gravestone state.
@@ -4054,7 +4193,7 @@ const char *z_time_now_as_str(const char *buf,
  * Returns id associated with this timestamp.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
+ZENOHC_API z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
 #endif
 /**
  * Create uhlc timestamp from session id.
@@ -4422,7 +4561,7 @@ z_result_t zc_liveliness_declare_subscriber(struct z_owned_subscriber_t *this_,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_liveliness_declare_token(struct zc_owned_liveliness_token_t *this_,
+z_result_t zc_liveliness_declare_token(zc_owned_liveliness_token_t *this_,
                                        const struct z_loaned_session_t *session,
                                        const struct z_loaned_keyexpr_t *key_expr,
                                        const struct zc_liveliness_declaration_options_t *_options);
@@ -4459,32 +4598,32 @@ void zc_liveliness_subscriber_options_default(struct zc_liveliness_subscriber_op
  * Returns ``true`` if liveliness token is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool zc_liveliness_token_check(const struct zc_owned_liveliness_token_t *this_);
+ZENOHC_API bool zc_liveliness_token_check(const zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Undeclares liveliness token, frees memory and resets it to a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_liveliness_token_drop(struct zc_moved_liveliness_token_t this_);
+ZENOHC_API void zc_liveliness_token_drop(zc_moved_liveliness_token_t this_);
 #endif
 /**
  * Borrows token.
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const struct zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const struct zc_owned_liveliness_token_t *this_);
+const zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Constructs liveliness token in its gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_liveliness_token_null(struct zc_owned_liveliness_token_t *this_);
+ZENOHC_API void zc_liveliness_token_null(zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Destroys a liveliness token, notifying subscribers of its destruction.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t zc_liveliness_undeclare_token(struct zc_moved_liveliness_token_t this_);
+ZENOHC_API z_result_t zc_liveliness_undeclare_token(zc_moved_liveliness_token_t this_);
 #endif
 /**
  * Returns default value of `zc_locality_t`
@@ -4496,13 +4635,13 @@ ZENOHC_API enum zc_locality_t zc_locality_default(void);
  * Checks the matching listener is for the gravestone state
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool zc_matching_listener_check(const struct zc_owned_matching_listener_t *this_);
+ZENOHC_API bool zc_matching_listener_check(const zc_owned_matching_listener_t *this_);
 #endif
 /**
  * Constructs an empty matching listener
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_matching_listener_null(struct zc_owned_matching_listener_t *this_);
+ZENOHC_API void zc_matching_listener_null(zc_owned_matching_listener_t *this_);
 #endif
 /**
  * Gets publisher matching status - i.e. if there are any subscribers matching its key expression.
@@ -4525,7 +4664,7 @@ z_result_t zc_publisher_get_matching_status(const struct z_loaned_publisher_t *t
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_publisher_matching_listener_declare(struct zc_owned_matching_listener_t *this_,
+z_result_t zc_publisher_matching_listener_declare(zc_owned_matching_listener_t *this_,
                                                   const struct z_loaned_publisher_t *publisher,
                                                   struct zc_moved_closure_matching_status_t callback);
 #endif
@@ -4535,8 +4674,7 @@ z_result_t zc_publisher_matching_listener_declare(struct zc_owned_matching_liste
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API
-z_result_t zc_publisher_matching_listener_drop(struct zc_moved_matching_listener_t this_);
+ZENOHC_API z_result_t zc_publisher_matching_listener_drop(zc_moved_matching_listener_t *this_);
 #endif
 /**
  * Undeclares the given matching listener, droping and invalidating it.
@@ -4545,7 +4683,7 @@ z_result_t zc_publisher_matching_listener_drop(struct zc_moved_matching_listener
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_publisher_matching_listener_undeclare(struct zc_moved_matching_listener_t this_);
+z_result_t zc_publisher_matching_listener_undeclare(zc_moved_matching_listener_t2 *this_);
 #endif
 /**
  * Returns the default value of #zc_reply_keyexpr_t.
@@ -4556,46 +4694,46 @@ ZENOHC_API enum zc_reply_keyexpr_t zc_reply_keyexpr_default(void);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t zc_shm_client_list_add_client(z_protocol_id_t id,
-                                         struct z_moved_shm_client_t client,
-                                         struct zc_loaned_shm_client_list_t *list);
+                                         z_moved_shm_client_t client,
+                                         zc_loaned_shm_client_list_t *list);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool zc_shm_client_list_check(const struct zc_owned_shm_client_list_t *this_);
+ZENOHC_API bool zc_shm_client_list_check(const zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Deletes list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_drop(struct zc_moved_shm_client_list_t this_);
+ZENOHC_API void zc_shm_client_list_drop(zc_moved_shm_client_list_t this_);
 #endif
 /**
  * Borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const struct zc_owned_shm_client_list_t *this_);
+const zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Mutably borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(struct zc_owned_shm_client_list_t *this_);
+zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Creates a new empty list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_new(struct zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_new(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Constructs SHM client list in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_null(struct zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_null(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Stops all Zenoh tasks and drops all related static variables.
@@ -4617,7 +4755,7 @@ void zc_stop_z_runtime(void);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_declare_publication_cache(struct ze_owned_publication_cache_t *this_,
+z_result_t ze_declare_publication_cache(ze_owned_publication_cache_t *this_,
                                         const struct z_loaned_session_t *session,
                                         const struct z_loaned_keyexpr_t *key_expr,
                                         struct ze_publication_cache_options_t *options);
@@ -4635,7 +4773,7 @@ z_result_t ze_declare_publication_cache(struct ze_owned_publication_cache_t *thi
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_declare_querying_subscriber(struct ze_owned_querying_subscriber_t *this_,
+z_result_t ze_declare_querying_subscriber(ze_owned_querying_subscriber_t *this_,
                                           const struct z_loaned_session_t *session,
                                           const struct z_loaned_keyexpr_t *key_expr,
                                           struct z_moved_closure_sample_t callback,
@@ -4645,19 +4783,19 @@ z_result_t ze_declare_querying_subscriber(struct ze_owned_querying_subscriber_t 
  * Returns ``true`` if publication cache is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool ze_publication_cache_check(const struct ze_owned_publication_cache_t *this_);
+ZENOHC_API bool ze_publication_cache_check(const ze_owned_publication_cache_t *this_);
 #endif
 /**
  * Drops publication cache. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_publication_cache_drop(struct ze_moved_publication_cache_t this_);
+ZENOHC_API void ze_publication_cache_drop(ze_moved_publication_cache_t this_);
 #endif
 /**
  * Constructs a publication cache in a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_publication_cache_null(struct ze_owned_publication_cache_t *this_);
+ZENOHC_API void ze_publication_cache_null(ze_owned_publication_cache_t *this_);
 #endif
 /**
  * Constructs the default value for `ze_publication_cache_options_t`.
@@ -4669,13 +4807,13 @@ ZENOHC_API void ze_publication_cache_options_default(struct ze_publication_cache
  * Returns ``true`` if querying subscriber is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool ze_querying_subscriber_check(const struct ze_owned_querying_subscriber_t *this_);
+ZENOHC_API bool ze_querying_subscriber_check(const ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Drops querying subscriber. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_t this_);
+ZENOHC_API void ze_querying_subscriber_drop(ze_moved_querying_subscriber_t this_);
 #endif
 /**
  * Make querying subscriber perform an additional query on a specified selector.
@@ -4684,7 +4822,7 @@ ZENOHC_API void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_querying_subscriber_get(const struct ze_loaned_querying_subscriber_t *this_,
+z_result_t ze_querying_subscriber_get(const ze_loaned_querying_subscriber_t *this_,
                                       const struct z_loaned_keyexpr_t *selector,
                                       struct z_get_options_t *options);
 #endif
@@ -4693,13 +4831,13 @@ z_result_t ze_querying_subscriber_get(const struct ze_loaned_querying_subscriber
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const struct ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const struct ze_owned_querying_subscriber_t *this_);
+const ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Constructs a querying subscriber in a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_querying_subscriber_null(struct ze_owned_querying_subscriber_t *this_);
+ZENOHC_API void ze_querying_subscriber_null(ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Constructs the default value for `ze_querying_subscriber_options_t`.
@@ -4713,7 +4851,7 @@ void ze_querying_subscriber_options_default(struct ze_querying_subscriber_option
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t ze_undeclare_publication_cache(struct ze_moved_publication_cache_t this_);
+ZENOHC_API z_result_t ze_undeclare_publication_cache(ze_moved_publication_cache_t this_);
 #endif
 /**
  * Undeclares the given querying subscriber, drops it and resets to a gravestone state.
@@ -4721,5 +4859,5 @@ ZENOHC_API z_result_t ze_undeclare_publication_cache(struct ze_moved_publication
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t ze_undeclare_querying_subscriber(struct ze_moved_querying_subscriber_t this_);
+ZENOHC_API z_result_t ze_undeclare_querying_subscriber(ze_moved_querying_subscriber_t this_);
 #endif

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -2851,7 +2851,7 @@ ZENOHC_API void z_publisher_delete_options_default(struct z_publisher_delete_opt
 /**
  * Frees memory and resets publisher to its gravestone state. Also attempts undeclare publisher.
  */
-ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t *_this);
+ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t *this_);
 /**
  * Returns the ID of the publisher.
  */
@@ -4079,7 +4079,7 @@ z_result_t z_undeclare_keyexpr(struct z_moved_keyexpr_t *this_,
  *
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_result_t z_undeclare_publisher(struct z_moved_publisher_t *_this);
+ZENOHC_API z_result_t z_undeclare_publisher(struct z_moved_publisher_t *this_);
 /**
  * Undeclares a `z_owned_queryable_t` and drops it.
  *
@@ -4091,7 +4091,7 @@ ZENOHC_API z_result_t z_undeclare_queryable(struct z_moved_queryable_t *this_);
  *
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_result_t z_undeclare_subscriber(struct z_moved_subscriber_t *_this);
+ZENOHC_API z_result_t z_undeclare_subscriber(struct z_moved_subscriber_t *this_);
 /**
  * Constructs a view key expression in empty state
  */
@@ -4651,7 +4651,7 @@ ZENOHC_API bool ze_publication_cache_check(const struct ze_owned_publication_cac
  * Drops publication cache. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_publication_cache_drop(struct ze_moved_publication_cache_t *_this);
+ZENOHC_API void ze_publication_cache_drop(struct ze_moved_publication_cache_t *this_);
 #endif
 /**
  * Constructs a publication cache in a gravestone state.
@@ -4675,7 +4675,7 @@ ZENOHC_API bool ze_querying_subscriber_check(const struct ze_owned_querying_subs
  * Drops querying subscriber. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_t *_this);
+ZENOHC_API void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_t *this_);
 #endif
 /**
  * Make querying subscriber perform an additional query on a specified selector.

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1049,7 +1049,7 @@ ZENOHC_API bool z_alloc_layout_check(const struct z_owned_alloc_layout_t *this_)
  * Deletes Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_drop(struct z_moved_alloc_layout_t this_);
+ZENOHC_API void z_alloc_layout_drop(struct z_moved_alloc_layout_t *this_);
 #endif
 /**
  * Borrows Alloc Layout
@@ -1223,7 +1223,7 @@ z_result_t z_bytes_deserialize_into_uint8(const struct z_loaned_bytes_t *this_,
  * Drops `this_`, resetting it to gravestone value. If there are any shallow copies
  * created by `z_bytes_clone()`, they would still stay valid.
  */
-ZENOHC_API void z_bytes_drop(struct z_moved_bytes_t this_);
+ZENOHC_API void z_bytes_drop(struct z_moved_bytes_t *this_);
 /**
  * Constructs an empty instance of `z_owned_bytes_t`.
  */
@@ -1506,7 +1506,7 @@ ZENOHC_API bool z_chunk_alloc_result_check(const struct z_owned_chunk_alloc_resu
  * Deletes Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_drop(struct z_moved_chunk_alloc_result_t this_);
+ZENOHC_API void z_chunk_alloc_result_drop(struct z_moved_chunk_alloc_result_t *this_);
 #endif
 /**
  * Borrows Chunk Alloc Result
@@ -1574,7 +1574,7 @@ ZENOHC_API bool z_closure_hello_check(const struct z_owned_closure_hello_t *this
 /**
  * Drops the closure. Droping an uninitialized closure is a no-op.
  */
-ZENOHC_API void z_closure_hello_drop(struct z_moved_closure_hello_t _closure);
+ZENOHC_API void z_closure_hello_drop(struct z_moved_closure_hello_t *this_);
 /**
  * Borrows closure.
  */
@@ -1597,7 +1597,7 @@ ZENOHC_API bool z_closure_query_check(const struct z_owned_closure_query_t *this
 /**
  * Drops the closure, resetting it to its gravestone state.
  */
-ZENOHC_API void z_closure_query_drop(struct z_moved_closure_query_t closure);
+ZENOHC_API void z_closure_query_drop(struct z_moved_closure_query_t *closure_);
 /**
  * Borrows closure.
  */
@@ -1621,7 +1621,7 @@ ZENOHC_API bool z_closure_reply_check(const struct z_owned_closure_reply_t *this
  * Drops the closure, resetting it to its gravestone state. Droping an uninitialized closure is a no-op.
  */
 ZENOHC_API
-void z_closure_reply_drop(struct z_moved_closure_reply_t closure);
+void z_closure_reply_drop(struct z_moved_closure_reply_t *closure_);
 /**
  * Borrows closure.
  */
@@ -1644,7 +1644,7 @@ ZENOHC_API bool z_closure_sample_check(const struct z_owned_closure_sample_t *th
 /**
  * Drops the closure. Droping an uninitialized closure is a no-op.
  */
-ZENOHC_API void z_closure_sample_drop(struct z_moved_closure_sample_t closure);
+ZENOHC_API void z_closure_sample_drop(struct z_moved_closure_sample_t *closure_);
 /**
  * Borrows closure.
  */
@@ -1673,7 +1673,7 @@ ZENOHC_API bool z_closure_zid_check(const struct z_owned_closure_zid_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void z_closure_zid_drop(struct z_moved_closure_zid_t closure);
+void z_closure_zid_drop(struct z_moved_closure_zid_t *closure_);
 #endif
 /**
  * Vorrows closure.
@@ -1695,7 +1695,7 @@ ZENOHC_API bool z_condvar_check(const struct z_owned_condvar_t *this_);
 /**
  * Drops conditional variable.
  */
-ZENOHC_API void z_condvar_drop(struct z_moved_condvar_t this_);
+ZENOHC_API void z_condvar_drop(struct z_moved_condvar_t *this_);
 /**
  * Constructs conditional variable.
  */
@@ -1754,7 +1754,7 @@ ZENOHC_API z_result_t z_config_default(struct z_owned_config_t *this_);
 /**
  * Frees `config`, and resets it to its gravestone state.
  */
-ZENOHC_API void z_config_drop(struct z_moved_config_t this_);
+ZENOHC_API void z_config_drop(struct z_moved_config_t *this_);
 /**
  * Borrows config.
  */
@@ -2020,7 +2020,7 @@ void z_encoding_clone(struct z_owned_encoding_t *dst,
 /**
  * Frees the memory and resets the encoding it to its default value.
  */
-ZENOHC_API void z_encoding_drop(struct z_moved_encoding_t this_);
+ZENOHC_API void z_encoding_drop(struct z_moved_encoding_t *this_);
 /**
  * Constructs a `z_owned_encoding_t` from a specified string.
  */
@@ -2391,7 +2391,7 @@ ZENOHC_API bool z_fifo_handler_query_check(const struct z_owned_fifo_handler_que
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_fifo_handler_query_drop(struct z_moved_fifo_handler_query_t this_);
+ZENOHC_API void z_fifo_handler_query_drop(struct z_moved_fifo_handler_query_t *this_);
 /**
  * Borrows handler.
  */
@@ -2425,7 +2425,7 @@ ZENOHC_API bool z_fifo_handler_reply_check(const struct z_owned_fifo_handler_rep
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_fifo_handler_reply_drop(struct z_moved_fifo_handler_reply_t this_);
+ZENOHC_API void z_fifo_handler_reply_drop(struct z_moved_fifo_handler_reply_t *this_);
 /**
  * Borrows handler.
  */
@@ -2458,7 +2458,7 @@ ZENOHC_API bool z_fifo_handler_sample_check(const struct z_owned_fifo_handler_sa
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_fifo_handler_sample_drop(struct z_moved_fifo_handler_sample_t this_);
+ZENOHC_API void z_fifo_handler_sample_drop(struct z_moved_fifo_handler_sample_t *this_);
 /**
  * Borrows handler.
  */
@@ -2514,7 +2514,7 @@ ZENOHC_API bool z_hello_check(const struct z_owned_hello_t *this_);
 /**
  * Frees memory and resets hello message to its gravestone state.
  */
-ZENOHC_API void z_hello_drop(struct z_moved_hello_t this_);
+ZENOHC_API void z_hello_drop(struct z_moved_hello_t *this_);
 /**
  * Borrows hello message.
  */
@@ -2623,7 +2623,7 @@ z_result_t z_keyexpr_concat(struct z_owned_keyexpr_t *this_,
 /**
  * Frees key expression and resets it to its gravestone state.
  */
-ZENOHC_API void z_keyexpr_drop(struct z_moved_keyexpr_t this_);
+ZENOHC_API void z_keyexpr_drop(struct z_moved_keyexpr_t *this_);
 /**
  * Returns ``true`` if both ``left`` and ``right`` are equal, ``false`` otherwise.
  */
@@ -2725,7 +2725,7 @@ ZENOHC_API bool z_memory_layout_check(const struct z_owned_memory_layout_t *this
  * Deletes Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_drop(struct z_moved_memory_layout_t this_);
+ZENOHC_API void z_memory_layout_drop(struct z_moved_memory_layout_t *this_);
 #endif
 /**
  * Extract data from Memory Layout
@@ -2765,7 +2765,7 @@ ZENOHC_API bool z_mutex_check(const struct z_owned_mutex_t *this_);
 /**
  * Drops mutex and resets it to its gravestone state.
  */
-ZENOHC_API void z_mutex_drop(struct z_moved_mutex_t this_);
+ZENOHC_API void z_mutex_drop(struct z_moved_mutex_t *this_);
 /**
  * Constructs a mutex.
  * @return 0 in case of success, negative error code otherwise.
@@ -3131,7 +3131,7 @@ ZENOHC_API void z_reply_clone(struct z_owned_reply_t *dst, const struct z_loaned
 /**
  * Frees reply, resetting it to its gravestone state.
  */
-ZENOHC_API void z_reply_drop(struct z_moved_reply_t this_);
+ZENOHC_API void z_reply_drop(struct z_moved_reply_t *this_);
 /**
  * Yields the contents of the reply by asserting it indicates a failure.
  *
@@ -3145,7 +3145,7 @@ ZENOHC_API bool z_reply_err_check(const struct z_owned_reply_err_t *this_);
 /**
  * Frees the memory and resets the reply error it to its default value.
  */
-ZENOHC_API void z_reply_err_drop(struct z_moved_reply_err_t this_);
+ZENOHC_API void z_reply_err_drop(struct z_moved_reply_err_t *this_);
 /**
  * Returns reply error encoding.
  */
@@ -3219,7 +3219,7 @@ ZENOHC_API bool z_ring_handler_query_check(const struct z_owned_ring_handler_que
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_ring_handler_query_drop(struct z_moved_ring_handler_query_t this_);
+ZENOHC_API void z_ring_handler_query_drop(struct z_moved_ring_handler_query_t *this_);
 /**
  * Borrows handler.
  */
@@ -3252,7 +3252,7 @@ ZENOHC_API bool z_ring_handler_reply_check(const struct z_owned_ring_handler_rep
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_ring_handler_reply_drop(struct z_moved_ring_handler_reply_t this_);
+ZENOHC_API void z_ring_handler_reply_drop(struct z_moved_ring_handler_reply_t *this_);
 /**
  * Borrows handler.
  */
@@ -3285,7 +3285,7 @@ ZENOHC_API bool z_ring_handler_sample_check(const struct z_owned_ring_handler_sa
 /**
  * Drops the handler and resets it to a gravestone state.
  */
-ZENOHC_API void z_ring_handler_sample_drop(struct z_moved_ring_handler_sample_t this_);
+ZENOHC_API void z_ring_handler_sample_drop(struct z_moved_ring_handler_sample_t *this_);
 /**
  * Borrows handler.
  */
@@ -3336,7 +3336,7 @@ enum z_congestion_control_t z_sample_congestion_control(const struct z_loaned_sa
 /**
  * Frees the memory and invalidates the sample, resetting it to a gravestone state.
  */
-ZENOHC_API void z_sample_drop(struct z_moved_sample_t this_);
+ZENOHC_API void z_sample_drop(struct z_moved_sample_t *this_);
 /**
  * Returns the encoding associated with the sample data.
  */
@@ -3415,7 +3415,7 @@ void z_session_clone(struct z_owned_session_t *dst,
  *
  * This will also close the session if it does not have any clones left.
  */
-ZENOHC_API void z_session_drop(struct z_moved_session_t this_);
+ZENOHC_API void z_session_drop(struct z_moved_session_t *this_);
 /**
  * Borrows session.
  */
@@ -3440,7 +3440,7 @@ ZENOHC_API bool z_shm_client_check(const struct z_owned_shm_client_t *this_);
  * Deletes SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_drop(struct z_moved_shm_client_t this_);
+ZENOHC_API void z_shm_client_drop(struct z_moved_shm_client_t *this_);
 #endif
 /**
  * Creates a new SHM Client
@@ -3475,7 +3475,7 @@ void z_shm_client_storage_clone(struct z_owned_shm_client_storage_t *this_,
  * Derefs SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_drop(struct z_moved_shm_client_storage_t this_);
+ZENOHC_API void z_shm_client_storage_drop(struct z_moved_shm_client_storage_t *this_);
 #endif
 /**
  * Borrows SHM Client Storage
@@ -3515,7 +3515,7 @@ ZENOHC_API const unsigned char *z_shm_data(const struct z_loaned_shm_t *this_);
  * Deletes ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_drop(struct z_moved_shm_t this_);
+ZENOHC_API void z_shm_drop(struct z_moved_shm_t *this_);
 #endif
 /**
  * Constructs ZShm slice from ZShmMut slice
@@ -3563,7 +3563,7 @@ ZENOHC_API unsigned char *z_shm_mut_data_mut(struct z_loaned_shm_mut_t *this_);
  * Deletes ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_drop(struct z_moved_shm_mut_t this_);
+ZENOHC_API void z_shm_mut_drop(struct z_moved_shm_mut_t *this_);
 #endif
 /**
  * @return the length of the ZShmMut slice
@@ -3664,7 +3664,7 @@ ZENOHC_API size_t z_shm_provider_defragment(const struct z_loaned_shm_provider_t
  * Deletes SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_drop(struct z_moved_shm_provider_t this_);
+ZENOHC_API void z_shm_provider_drop(struct z_moved_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API size_t z_shm_provider_garbage_collect(const struct z_loaned_shm_provider_t *provider);
@@ -3757,7 +3757,7 @@ ZENOHC_API const uint8_t *z_slice_data(const struct z_loaned_slice_t *this_);
 /**
  * Frees the memory and invalidates the slice.
  */
-ZENOHC_API void z_slice_drop(struct z_moved_slice_t this_);
+ZENOHC_API void z_slice_drop(struct z_moved_slice_t *this_);
 /**
  * Constructs an empty `z_owned_slice_t`.
  */
@@ -3804,7 +3804,7 @@ ZENOHC_API bool z_source_info_check(const struct z_owned_source_info_t *this_);
  * Frees the memory and invalidates the source info, resetting it to a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void z_source_info_drop(struct z_moved_source_info_t this_);
+ZENOHC_API void z_source_info_drop(struct z_moved_source_info_t *this_);
 #endif
 /**
  * Returns the source_id of the source info.
@@ -3847,7 +3847,7 @@ ZENOHC_API bool z_string_array_check(const struct z_owned_string_array_t *this_)
 /**
  * Destroys the string array, resetting it to its gravestone value.
  */
-ZENOHC_API void z_string_array_drop(struct z_moved_string_array_t this_);
+ZENOHC_API void z_string_array_drop(struct z_moved_string_array_t *this_);
 /**
  * @return the value at the position of index in the string array.
  *
@@ -3931,7 +3931,7 @@ ZENOHC_API const char *z_string_data(const struct z_loaned_string_t *this_);
 /**
  * Frees memory and invalidates `z_owned_string_t`, putting it in gravestone state.
  */
-ZENOHC_API void z_string_drop(struct z_moved_string_t this_);
+ZENOHC_API void z_string_drop(struct z_moved_string_t *this_);
 /**
  * Constructs an empty owned string.
  */
@@ -3972,7 +3972,7 @@ ZENOHC_API bool z_subscriber_check(const struct z_owned_subscriber_t *this_);
 /**
  * Drops subscriber and resets it to its gravestone state. Also attempts to undeclare it.
  */
-ZENOHC_API void z_subscriber_drop(struct z_moved_subscriber_t this_);
+ZENOHC_API void z_subscriber_drop(struct z_moved_subscriber_t *this_);
 /**
  * Returns the key expression of the subscriber.
  */
@@ -3998,11 +3998,11 @@ ZENOHC_API bool z_task_check(const struct z_owned_task_t *this_);
 /**
  * Detaches the task and releases all allocated resources.
  */
-ZENOHC_API void z_task_detach(struct z_moved_task_t this_);
+ZENOHC_API void z_task_detach(struct z_moved_task_t *this_);
 /**
  * Drop the task. Same as `z_task_detach`. Use `z_task_join` to wait for the task completion.
  */
-ZENOHC_API void z_task_drop(struct z_moved_task_t this_);
+ZENOHC_API void z_task_drop(struct z_moved_task_t *this_);
 /**
  * Constructs a new task.
  *
@@ -4256,7 +4256,7 @@ ZENOHC_API bool zc_closure_log_check(const struct zc_owned_closure_log_t *this_)
 /**
  * Drops the closure. Droping an uninitialized closure is a no-op.
  */
-ZENOHC_API void zc_closure_log_drop(struct zc_moved_closure_log_t closure);
+ZENOHC_API void zc_closure_log_drop(struct zc_moved_closure_log_t *closure_);
 /**
  * Borrows closure.
  */
@@ -4286,7 +4286,7 @@ bool zc_closure_matching_status_check(const struct zc_owned_closure_matching_sta
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void zc_closure_matching_status_drop(struct zc_moved_closure_matching_status_t closure);
+void zc_closure_matching_status_drop(struct zc_moved_closure_matching_status_t *closure_);
 #endif
 /**
  * Borrows closure.
@@ -4465,7 +4465,7 @@ ZENOHC_API bool zc_liveliness_token_check(const struct zc_owned_liveliness_token
  * Undeclares liveliness token, frees memory and resets it to a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_liveliness_token_drop(struct zc_moved_liveliness_token_t this_);
+ZENOHC_API void zc_liveliness_token_drop(struct zc_moved_liveliness_token_t *this_);
 #endif
 /**
  * Borrows token.
@@ -4569,7 +4569,7 @@ ZENOHC_API bool zc_shm_client_list_check(const struct zc_owned_shm_client_list_t
  * Deletes list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_drop(struct zc_moved_shm_client_list_t this_);
+ZENOHC_API void zc_shm_client_list_drop(struct zc_moved_shm_client_list_t *this_);
 #endif
 /**
  * Borrows list of SHM Clients

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -414,7 +414,7 @@ typedef struct z_owned_closure_zid_t {
  */
 #if defined(UNSTABLE)
 typedef struct z_moved_closure_zid_t {
-  struct z_owned_closure_zid_t *_ptr;
+  struct z_owned_closure_zid_t _this;
 } z_moved_closure_zid_t;
 #endif
 typedef struct z_moved_condvar_t {
@@ -886,7 +886,7 @@ typedef struct zc_owned_closure_matching_status_t {
  */
 #if defined(UNSTABLE)
 typedef struct zc_moved_closure_matching_status_t {
-  struct zc_owned_closure_matching_status_t *_ptr;
+  struct zc_owned_closure_matching_status_t _this;
 } zc_moved_closure_matching_status_t;
 #endif
 /**
@@ -1424,7 +1424,7 @@ ZENOHC_API void z_bytes_serialize_from_int8(struct z_owned_bytes_t *this_, int8_
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_,
-                                      struct z_moved_shm_t shm);
+                                      struct z_moved_shm_t *shm);
 #endif
 /**
  * Serializes from a mutable SHM buffer consuming it
@@ -1432,7 +1432,7 @@ z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_serialize_from_shm_mut(struct z_owned_bytes_t *this_,
-                                          struct z_moved_shm_mut_t shm);
+                                          struct z_moved_shm_mut_t *shm);
 #endif
 /**
  * Serializes a slice by copying.
@@ -2552,7 +2552,7 @@ ZENOHC_API struct z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
 #if defined(UNSTABLE)
 ZENOHC_API
 z_result_t z_info_peers_zid(const struct z_loaned_session_t *session,
-                            struct z_moved_closure_zid_t callback);
+                            struct z_moved_closure_zid_t *callback);
 #endif
 /**
  * Fetches the Zenoh IDs of all connected routers.
@@ -2565,7 +2565,7 @@ z_result_t z_info_peers_zid(const struct z_loaned_session_t *session,
 #if defined(UNSTABLE)
 ZENOHC_API
 z_result_t z_info_routers_zid(const struct z_loaned_session_t *session,
-                              struct z_moved_closure_zid_t callback);
+                              struct z_moved_closure_zid_t *callback);
 #endif
 /**
  * Returns the session's Zenoh ID.
@@ -2811,7 +2811,7 @@ z_result_t z_open(struct z_owned_session_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
-                                          struct z_moved_config_t config,
+                                          struct z_moved_config_t *config,
                                           const struct z_loaned_shm_client_storage_t *shm_clients);
 #endif
 /**
@@ -3521,7 +3521,7 @@ ZENOHC_API void z_shm_drop(struct z_moved_shm_t this_);
  * Constructs ZShm slice from ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_from_mut(struct z_owned_shm_t *this_, struct z_moved_shm_mut_t that);
+ZENOHC_API void z_shm_from_mut(struct z_owned_shm_t *this_, struct z_moved_shm_mut_t *that);
 #endif
 /**
  * @return the length of the ZShm slice
@@ -3595,7 +3595,7 @@ ZENOHC_API void z_shm_mut_null(struct z_owned_shm_mut_t *this_);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_mut_try_from_immut(struct z_owned_shm_mut_t *this_,
-                              struct z_moved_shm_t that);
+                              struct z_moved_shm_t *that);
 #endif
 /**
  * Constructs ZShm slice in its gravestone value.
@@ -4406,7 +4406,7 @@ ZENOHC_API
 z_result_t zc_liveliness_declare_subscriber(struct z_owned_subscriber_t *this_,
                                             const struct z_loaned_session_t *session,
                                             const struct z_loaned_keyexpr_t *key_expr,
-                                            struct z_moved_closure_sample_t callback,
+                                            struct z_moved_closure_sample_t *callback,
                                             struct zc_liveliness_subscriber_options_t *_options);
 #endif
 /**
@@ -4439,7 +4439,7 @@ z_result_t zc_liveliness_declare_token(struct zc_owned_liveliness_token_t *this_
 ZENOHC_API
 z_result_t zc_liveliness_get(const struct z_loaned_session_t *session,
                              const struct z_loaned_keyexpr_t *key_expr,
-                             struct z_moved_closure_reply_t callback,
+                             struct z_moved_closure_reply_t *callback,
                              struct zc_liveliness_get_options_t *options);
 #endif
 /**
@@ -4484,7 +4484,7 @@ ZENOHC_API void zc_liveliness_token_null(struct zc_owned_liveliness_token_t *thi
  * Destroys a liveliness token, notifying subscribers of its destruction.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t zc_liveliness_undeclare_token(struct zc_moved_liveliness_token_t this_);
+ZENOHC_API z_result_t zc_liveliness_undeclare_token(struct zc_moved_liveliness_token_t *this_);
 #endif
 /**
  * Returns default value of `zc_locality_t`
@@ -4527,7 +4527,7 @@ z_result_t zc_publisher_get_matching_status(const struct z_loaned_publisher_t *t
 ZENOHC_API
 z_result_t zc_publisher_matching_listener_declare(struct zc_owned_matching_listener_t *this_,
                                                   const struct z_loaned_publisher_t *publisher,
-                                                  struct zc_moved_closure_matching_status_t callback);
+                                                  struct zc_moved_closure_matching_status_t *callback);
 #endif
 /**
  * Undeclares the given matching listener, droping and invalidating it.
@@ -4545,7 +4545,7 @@ z_result_t zc_publisher_matching_listener_drop(struct zc_moved_matching_listener
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_publisher_matching_listener_undeclare(zc_moved_matching_listener_t2 *this_);
+z_result_t zc_publisher_matching_listener_undeclare(struct zc_moved_matching_listener_t *this_);
 #endif
 /**
  * Returns the default value of #zc_reply_keyexpr_t.
@@ -4556,7 +4556,7 @@ ZENOHC_API enum zc_reply_keyexpr_t zc_reply_keyexpr_default(void);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t zc_shm_client_list_add_client(z_protocol_id_t id,
-                                         struct z_moved_shm_client_t client,
+                                         struct z_moved_shm_client_t *client,
                                          struct zc_loaned_shm_client_list_t *list);
 #endif
 /**
@@ -4638,7 +4638,7 @@ ZENOHC_API
 z_result_t ze_declare_querying_subscriber(struct ze_owned_querying_subscriber_t *this_,
                                           const struct z_loaned_session_t *session,
                                           const struct z_loaned_keyexpr_t *key_expr,
-                                          struct z_moved_closure_sample_t callback,
+                                          struct z_moved_closure_sample_t *callback,
                                           struct ze_querying_subscriber_options_t *options);
 #endif
 /**
@@ -4651,7 +4651,7 @@ ZENOHC_API bool ze_publication_cache_check(const struct ze_owned_publication_cac
  * Drops publication cache. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_publication_cache_drop(struct ze_moved_publication_cache_t this_);
+ZENOHC_API void ze_publication_cache_drop(struct ze_moved_publication_cache_t *_this);
 #endif
 /**
  * Constructs a publication cache in a gravestone state.
@@ -4675,7 +4675,7 @@ ZENOHC_API bool ze_querying_subscriber_check(const struct ze_owned_querying_subs
  * Drops querying subscriber. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_t this_);
+ZENOHC_API void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_t *_this);
 #endif
 /**
  * Make querying subscriber perform an additional query on a specified selector.
@@ -4713,7 +4713,7 @@ void ze_querying_subscriber_options_default(struct ze_querying_subscriber_option
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t ze_undeclare_publication_cache(struct ze_moved_publication_cache_t this_);
+ZENOHC_API z_result_t ze_undeclare_publication_cache(struct ze_moved_publication_cache_t *this_);
 #endif
 /**
  * Undeclares the given querying subscriber, drops it and resets to a gravestone state.
@@ -4721,5 +4721,6 @@ ZENOHC_API z_result_t ze_undeclare_publication_cache(struct ze_moved_publication
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t ze_undeclare_querying_subscriber(struct ze_moved_querying_subscriber_t this_);
+ZENOHC_API
+z_result_t ze_undeclare_querying_subscriber(struct ze_moved_querying_subscriber_t *_this);
 #endif

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -16,6 +16,26 @@
 #define ALIGN(n)
 #define ZENOHC_API
 #endif
+/**
+ * Allocation errors
+ *
+ *     - **NEED_DEFRAGMENT**: defragmentation needed
+ *     - **OUT_OF_MEMORY**: the provider is out of memory
+ *     - **OTHER**: other error
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef enum z_alloc_error_t {
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+  Z_ALLOC_ERROR_NEED_DEFRAGMENT,
+#endif
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+  Z_ALLOC_ERROR_OUT_OF_MEMORY,
+#endif
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+  Z_ALLOC_ERROR_OTHER,
+#endif
+} z_alloc_error_t;
+#endif
 typedef enum z_congestion_control_t {
   /**
    * Messages are not dropped in case of congestion.
@@ -75,6 +95,22 @@ typedef enum z_keyexpr_intersection_level_t {
    */
   Z_KEYEXPR_INTERSECTION_LEVEL_EQUALS = 3,
 } z_keyexpr_intersection_level_t;
+#endif
+/**
+ * Layouting errors
+ *
+ * INCORRECT_LAYOUT_ARGS: layout arguments are incorrect
+ * PROVIDER_INCOMPATIBLE_LAYOUT: layout incompatible with provider
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef enum z_layout_error_t {
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+  Z_LAYOUT_ERROR_INCORRECT_LAYOUT_ARGS,
+#endif
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+  Z_LAYOUT_ERROR_PROVIDER_INCOMPATIBLE_LAYOUT,
+#endif
+} z_layout_error_t;
 #endif
 /**
  * The priority of zenoh messages.
@@ -230,10 +266,47 @@ typedef enum zc_reply_keyexpr_t {
   ZC_REPLY_KEYEXPR_MATCHING_QUERY = 1,
 } zc_reply_keyexpr_t;
 #endif
-typedef struct z_moved_alloc_layout_t {
-  struct z_owned_alloc_layout_t _this;
-} z_moved_alloc_layout_t;
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_buf_alloc_result_t {
+  z_owned_shm_mut_t buf;
+  enum z_alloc_error_t error;
+} z_buf_alloc_result_t;
+#endif
 typedef int8_t z_result_t;
+/**
+ * An AllocAlignment.
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_alloc_alignment_t {
+  uint8_t pow;
+} z_alloc_alignment_t;
+#endif
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_threadsafe_context_data_t {
+  void *ptr;
+} zc_threadsafe_context_data_t;
+#endif
+/**
+ * A tread-safe droppable context.
+ * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
+ * information to each callback.
+ *
+ * This is a thread-safe context - the associated callbacks may be executed concurrently with the same
+ * zc_context_t instance. In other words, all the callbacks associated with this context data MUST be
+ * thread-safe.
+ *
+ * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted.The
+ * delete_fn is guaranteed to be executed only once at some point of time after the last associated
+ * callback call returns.
+ * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
+ * be executed.
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_threadsafe_context_t {
+  struct zc_threadsafe_context_data_t context;
+  void (*delete_fn)(void*);
+} zc_threadsafe_context_t;
+#endif
 typedef struct z_moved_bytes_t {
   struct z_owned_bytes_t _this;
 } z_moved_bytes_t;
@@ -243,15 +316,37 @@ typedef struct z_moved_slice_t {
 typedef struct z_moved_string_t {
   struct z_owned_string_t _this;
 } z_moved_string_t;
-typedef struct z_moved_shm_t {
-  struct z_owned_shm_t _this;
-} z_moved_shm_t;
-typedef struct z_moved_shm_mut_t {
-  struct z_owned_shm_mut_t _this;
-} z_moved_shm_mut_t;
-typedef struct z_moved_chunk_alloc_result_t {
-  struct z_owned_chunk_alloc_result_t _this;
-} z_moved_chunk_alloc_result_t;
+/**
+ * Unique segment identifier
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef uint32_t z_segment_id_t;
+#endif
+/**
+ * Chunk id within it's segment
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef uint32_t z_chunk_id_t;
+#endif
+/**
+ * A ChunkDescriptor
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_chunk_descriptor_t {
+  z_segment_id_t segment;
+  z_chunk_id_t chunk;
+  size_t len;
+} z_chunk_descriptor_t;
+#endif
+/**
+ * An AllocatedChunk
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_allocated_chunk_t {
+  struct z_chunk_descriptor_t descriptpr;
+  void *data;
+} z_allocated_chunk_t;
+#endif
 /**
  * Monotonic clock
  */
@@ -402,7 +497,7 @@ typedef struct z_owned_closure_zid_t {
   /**
    * A callback function.
    */
-  void (*call)(const struct z_id_t *z_id, void *context);
+  void (*call)(const z_id_t *z_id, void *context);
   /**
    * An optional function that will be called upon closure drop.
    */
@@ -513,9 +608,6 @@ typedef struct z_moved_fifo_handler_sample_t {
 typedef struct z_query_consolidation_t {
   enum z_consolidation_mode_t mode;
 } z_query_consolidation_t;
-typedef struct z_moved_source_info_t {
-  struct z_owned_source_info_t _this;
-} z_moved_source_info_t;
 /**
  * Options passed to the `z_get()` function.
  */
@@ -564,7 +656,7 @@ typedef struct z_get_options_t {
   /**
    * The source info for the query.
    */
-  struct z_moved_source_info_t *source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * An optional attachment to attach to the query.
@@ -581,9 +673,6 @@ typedef struct z_moved_hello_t {
 typedef struct z_moved_keyexpr_t {
   struct z_owned_keyexpr_t _this;
 } z_moved_keyexpr_t;
-typedef struct z_moved_memory_layout_t {
-  struct z_owned_memory_layout_t _this;
-} z_moved_memory_layout_t;
 typedef struct z_moved_mutex_t {
   struct z_owned_mutex_t _this;
 } z_moved_mutex_t;
@@ -616,7 +705,7 @@ typedef struct z_publisher_put_options_t {
   /**
    * The source info for the publication.
    */
-  struct z_moved_source_info_t *source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to attach to the publication.
@@ -657,7 +746,7 @@ typedef struct z_put_options_t {
   /**
    * The source info for the message.
    */
-  struct z_moved_source_info_t *source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this message.
@@ -696,7 +785,7 @@ typedef struct z_query_reply_options_t {
   /**
    * The source info for the reply.
    */
-  struct z_moved_source_info_t *source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
@@ -728,7 +817,7 @@ typedef struct z_query_reply_del_options_t {
   /**
    * The source info for the reply.
    */
-  struct z_moved_source_info_t *source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
@@ -779,15 +868,39 @@ typedef struct z_scout_options_t {
    */
   enum z_what_t what;
 } z_scout_options_t;
-typedef struct z_moved_shm_client_t {
-  struct z_owned_shm_client_t _this;
-} z_moved_shm_client_t;
-typedef struct z_moved_shm_client_storage_t {
-  struct z_owned_shm_client_storage_t _this;
-} z_moved_shm_client_storage_t;
-typedef struct z_moved_shm_provider_t {
-  struct z_owned_shm_provider_t _this;
-} z_moved_shm_provider_t;
+/**
+ * A callbacks for ShmSegment
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_shm_segment_callbacks_t {
+  uint8_t *(*map_fn)(z_chunk_id_t chunk_id, void *context);
+} zc_shm_segment_callbacks_t;
+#endif
+/**
+ * A ShmSegment
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_shm_segment_t {
+  struct zc_threadsafe_context_t context;
+  struct zc_shm_segment_callbacks_t callbacks;
+} z_shm_segment_t;
+#endif
+/**
+ * A callbacks for ShmClient
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_shm_client_callbacks_t {
+  bool (*attach_fn)(struct z_shm_segment_t *out_segment, z_segment_id_t segment_id, void *context);
+} zc_shm_client_callbacks_t;
+#endif
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct z_buf_layout_alloc_result_t {
+  z_owned_shm_mut_t buf;
+  bool error_is_alloc;
+  enum z_alloc_error_t alloc_error;
+  enum z_layout_error_t layout_error;
+} z_buf_layout_alloc_result_t;
+#endif
 /**
  * Unique protocol identifier.
  * Here is a contract: it is up to user to make sure that incompatible ShmClient
@@ -795,6 +908,46 @@ typedef struct z_moved_shm_provider_t {
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 typedef uint32_t z_protocol_id_t;
+#endif
+/**
+ * A non-tread-safe droppable context.
+ * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
+ * information to each callback.
+ *
+ * This is a non-thread-safe context - zenoh-c guarantees that associated callbacks that share the same
+ * zc_context_t instance will never be executed concurrently. In other words, all the callbacks associated
+ * with this context data are not required to be thread-safe.
+ *
+ * NOTE: Remember that the same callback interfaces associated with different zc_context_t instances can
+ * still be executed concurrently. The exact behavior depends on user's application, but we strongly
+ * discourage our users from pinning to some specific behavior unless they _really_ understand what they
+ * are doing.
+ *
+ * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted. The
+ * delete_fn is guaranteed to be executed only once at some point of time after the last associated
+ * callback call returns.
+ * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
+ * be executed.
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_context_t {
+  void *context;
+  void (*delete_fn)(void*);
+} zc_context_t;
+#endif
+/**
+ * A callbacks for ShmProviderBackend
+ */
+#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
+typedef struct zc_shm_provider_backend_callbacks_t {
+  void (*alloc_fn)(z_owned_chunk_alloc_result_t *out_result,
+                   const z_loaned_memory_layout_t *layout,
+                   void *context);
+  void (*free_fn)(const struct z_chunk_descriptor_t *chunk, void *context);
+  size_t (*defragment_fn)(void *context);
+  size_t (*available_fn)(void *context);
+  void (*layout_for_fn)(z_owned_memory_layout_t *layout, void *context);
+} zc_shm_provider_backend_callbacks_t;
 #endif
 typedef struct z_moved_string_array_t {
   struct z_owned_string_array_t _this;
@@ -844,6 +997,14 @@ typedef struct zc_owned_closure_log_t {
 typedef struct zc_moved_closure_log_t {
   struct zc_owned_closure_log_t _this;
 } zc_moved_closure_log_t;
+/**
+ * Loaned closure.
+ */
+#if defined(UNSTABLE)
+typedef struct zc_loaned_closure_matching_status_t {
+  size_t _0[3];
+} zc_loaned_closure_matching_status_t;
+#endif
 /**
  * A struct that indicates if there exist Subscribers matching the Publisher's key expression.
  */
@@ -913,15 +1074,6 @@ typedef struct zc_liveliness_get_options_t {
   uint32_t timeout_ms;
 } zc_liveliness_get_options_t;
 #endif
-typedef struct zc_moved_liveliness_token_t {
-  struct zc_owned_liveliness_token_t _this;
-} zc_moved_liveliness_token_t;
-typedef struct zc_moved_matching_listener_t {
-  struct zc_owned_matching_listener_t _this;
-} zc_moved_matching_listener_t;
-typedef struct zc_moved_shm_client_list_t {
-  struct zc_owned_shm_client_list_t _this;
-} zc_moved_shm_client_list_t;
 /**
  * Options passed to the `ze_declare_publication_cache()` function.
  */
@@ -992,12 +1144,6 @@ typedef struct ze_querying_subscriber_options_t {
   uint64_t query_timeout_ms;
 } ze_querying_subscriber_options_t;
 #endif
-typedef struct ze_moved_publication_cache_t {
-  struct ze_owned_publication_cache_t _this;
-} ze_moved_publication_cache_t;
-typedef struct ze_moved_querying_subscriber_t {
-  struct ze_owned_querying_subscriber_t _this;
-} ze_moved_querying_subscriber_t;
 ZENOHC_API extern const unsigned int Z_ROUTER;
 ZENOHC_API extern const unsigned int Z_PEER;
 ZENOHC_API extern const unsigned int Z_CLIENT;
@@ -1017,54 +1163,53 @@ ZENOHC_API extern const unsigned int Z_SHM_POSIX_PROTOCOL_ID;
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc(struct z_buf_alloc_result_t *out_result,
-                          const struct z_loaned_alloc_layout_t *layout);
+                          const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc(struct z_buf_alloc_result_t *out_result,
-                             const struct z_loaned_alloc_layout_t *layout);
+                             const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag(struct z_buf_alloc_result_t *out_result,
-                                    const struct z_loaned_alloc_layout_t *layout);
+                                    const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_blocking(struct z_buf_alloc_result_t *out_result,
-                                             const struct z_loaned_alloc_layout_t *layout);
+                                             const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_dealloc(struct z_buf_alloc_result_t *out_result,
-                                            const struct z_loaned_alloc_layout_t *layout);
+                                            const z_loaned_alloc_layout_t *layout);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_alloc_layout_check(const struct z_owned_alloc_layout_t *this_);
+ZENOHC_API bool z_alloc_layout_check(const z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Deletes Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_drop(struct z_moved_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_drop(z_moved_alloc_layout_t *this_);
 #endif
 /**
  * Borrows Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-const struct z_loaned_alloc_layout_t *z_alloc_layout_loan(const struct z_owned_alloc_layout_t *this_);
+ZENOHC_API const z_loaned_alloc_layout_t *z_alloc_layout_loan(const z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Creates a new Alloc Layout for SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_alloc_layout_new(struct z_owned_alloc_layout_t *this_,
-                              const struct z_loaned_shm_provider_t *provider,
+z_result_t z_alloc_layout_new(z_owned_alloc_layout_t *this_,
+                              const z_loaned_shm_provider_t *provider,
                               size_t size,
                               struct z_alloc_alignment_t alignment);
 #endif
@@ -1072,12 +1217,12 @@ z_result_t z_alloc_layout_new(struct z_owned_alloc_layout_t *this_,
  * Constructs Alloc Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_null(struct z_owned_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_null(z_owned_alloc_layout_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_alloc_layout_threadsafe_alloc_gc_defrag_async(struct z_buf_alloc_result_t *out_result,
-                                                           const struct z_loaned_alloc_layout_t *layout,
+                                                           const z_loaned_alloc_layout_t *layout,
                                                            struct zc_threadsafe_context_t result_context,
                                                            void (*result_callback)(void*,
                                                                                    struct z_buf_alloc_result_t*));
@@ -1141,7 +1286,7 @@ z_result_t z_bytes_deserialize_into_int8(const struct z_loaned_bytes_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *this_,
-                                               const struct z_loaned_shm_t **dst);
+                                               const z_loaned_shm_t **dst);
 #endif
 /**
  * Deserializes data into a mutably loaned SHM buffer
@@ -1152,7 +1297,7 @@ z_result_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *th
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this_,
-                                                   struct z_loaned_shm_t **dst);
+                                                   z_loaned_shm_t **dst);
 #endif
 /**
  * Deserializes data into an owned SHM buffer by copying it's shared reference
@@ -1163,7 +1308,7 @@ z_result_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_owned_shm(const struct z_loaned_bytes_t *this_,
-                                              struct z_owned_shm_t *dst);
+                                              z_owned_shm_t *dst);
 #endif
 /**
  * Deserializes into a pair of `z_owned_bytes_t` objects.
@@ -1422,9 +1567,7 @@ ZENOHC_API void z_bytes_serialize_from_int8(struct z_owned_bytes_t *this_, int8_
  * Serializes from an immutable SHM buffer consuming it
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_,
-                                      struct z_moved_shm_t *shm);
+ZENOHC_API z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_, z_moved_shm_t *shm);
 #endif
 /**
  * Serializes from a mutable SHM buffer consuming it
@@ -1432,7 +1575,7 @@ z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_serialize_from_shm_mut(struct z_owned_bytes_t *this_,
-                                          struct z_moved_shm_mut_t *shm);
+                                          z_moved_shm_mut_t *shm);
 #endif
 /**
  * Serializes a slice by copying.
@@ -1500,27 +1643,27 @@ z_result_t z_bytes_writer_write_all(struct z_bytes_writer_t *this_,
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_chunk_alloc_result_check(const struct z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API bool z_chunk_alloc_result_check(const z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Deletes Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_drop(struct z_moved_chunk_alloc_result_t *this_);
+ZENOHC_API void z_chunk_alloc_result_drop(z_moved_chunk_alloc_result_t *this_);
 #endif
 /**
  * Borrows Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const struct z_owned_chunk_alloc_result_t *this_);
+const z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Creates a new Chunk Alloc Result with Error value
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
+void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
                                     enum z_alloc_error_t alloc_error);
 #endif
 /**
@@ -1528,14 +1671,14 @@ void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_chunk_alloc_result_new_ok(struct z_owned_chunk_alloc_result_t *this_,
+z_result_t z_chunk_alloc_result_new_ok(z_owned_chunk_alloc_result_t *this_,
                                        struct z_allocated_chunk_t allocated_chunk);
 #endif
 /**
  * Constructs Chunk Alloc Result in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_null(struct z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API void z_chunk_alloc_result_null(z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Get number of milliseconds passed since creation of `time`.
@@ -1660,7 +1803,7 @@ ZENOHC_API void z_closure_sample_null(struct z_owned_closure_sample_t *this_);
 #if defined(UNSTABLE)
 ZENOHC_API
 void z_closure_zid_call(const struct z_loaned_closure_zid_t *closure,
-                        const struct z_id_t *z_id);
+                        const z_id_t *z_id);
 #endif
 /**
  * Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
@@ -2355,13 +2498,13 @@ ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint8(void);
  * Returns the entity id of the entity global id.
  */
 #if defined(UNSTABLE)
-ZENOHC_API uint32_t z_entity_global_id_eid(const struct z_entity_global_id_t *this_);
+ZENOHC_API uint32_t z_entity_global_id_eid(const z_entity_global_id_t *this_);
 #endif
 /**
  * Returns the zenoh id of entity global id.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_id_t z_entity_global_id_zid(const struct z_entity_global_id_t *this_);
+ZENOHC_API z_id_t z_entity_global_id_zid(const z_entity_global_id_t *this_);
 #endif
 /**
  * Constructs send and recieve ends of the fifo channel
@@ -2539,7 +2682,7 @@ ZENOHC_API enum z_whatami_t z_hello_whatami(const struct z_loaned_hello_t *this_
  * Returns id of Zenoh entity that transmitted hello message.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
+ZENOHC_API z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
 #endif
 /**
  * Fetches the Zenoh IDs of all connected peers.
@@ -2575,7 +2718,7 @@ z_result_t z_info_routers_zid(const struct z_loaned_session_t *session,
  * to pass it a valid session.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_id_t z_info_zid(const struct z_loaned_session_t *session);
+ZENOHC_API z_id_t z_info_zid(const struct z_loaned_session_t *session);
 #endif
 /**
  * Constructs a non-owned non-null-terminated string from key expression.
@@ -2719,13 +2862,13 @@ enum z_keyexpr_intersection_level_t z_keyexpr_relation_to(const struct z_loaned_
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_memory_layout_check(const struct z_owned_memory_layout_t *this_);
+ZENOHC_API bool z_memory_layout_check(const z_owned_memory_layout_t *this_);
 #endif
 /**
  * Deletes Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_drop(struct z_moved_memory_layout_t *this_);
+ZENOHC_API void z_memory_layout_drop(z_moved_memory_layout_t *this_);
 #endif
 /**
  * Extract data from Memory Layout
@@ -2734,21 +2877,21 @@ ZENOHC_API void z_memory_layout_drop(struct z_moved_memory_layout_t *this_);
 ZENOHC_API
 void z_memory_layout_get_data(size_t *out_size,
                               struct z_alloc_alignment_t *out_alignment,
-                              const struct z_loaned_memory_layout_t *this_);
+                              const z_loaned_memory_layout_t *this_);
 #endif
 /**
  * Borrows Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct z_loaned_memory_layout_t *z_memory_layout_loan(const struct z_owned_memory_layout_t *this_);
+const z_loaned_memory_layout_t *z_memory_layout_loan(const z_owned_memory_layout_t *this_);
 #endif
 /**
  * Creates a new Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_memory_layout_new(struct z_owned_memory_layout_t *this_,
+z_result_t z_memory_layout_new(z_owned_memory_layout_t *this_,
                                size_t size,
                                struct z_alloc_alignment_t alignment);
 #endif
@@ -2756,7 +2899,7 @@ z_result_t z_memory_layout_new(struct z_owned_memory_layout_t *this_,
  * Constructs Memory Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_null(struct z_owned_memory_layout_t *this_);
+ZENOHC_API void z_memory_layout_null(z_owned_memory_layout_t *this_);
 #endif
 /**
  * Returns ``true`` if mutex is valid, ``false`` otherwise.
@@ -2812,21 +2955,21 @@ z_result_t z_open(struct z_owned_session_t *this_,
 ZENOHC_API
 z_result_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
                                           struct z_moved_config_t *config,
-                                          const struct z_loaned_shm_client_storage_t *shm_clients);
+                                          const z_loaned_shm_client_storage_t *shm_clients);
 #endif
 /**
  * Creates a new POSIX SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_posix_shm_client_new(struct z_owned_shm_client_t *this_);
+ZENOHC_API void z_posix_shm_client_new(z_owned_shm_client_t *this_);
 #endif
 /**
  * Creates a new POSIX SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_posix_shm_provider_new(struct z_owned_shm_provider_t *this_,
-                                    const struct z_loaned_memory_layout_t *layout);
+z_result_t z_posix_shm_provider_new(z_owned_shm_provider_t *this_,
+                                    const z_loaned_memory_layout_t *layout);
 #endif
 /**
  * Returns the default value of #z_priority_t.
@@ -2856,7 +2999,7 @@ ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t *this_);
  * Returns the ID of the publisher.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
+ZENOHC_API z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
 #endif
 /**
  * Returns the key expression of the publisher.
@@ -3118,7 +3261,7 @@ ZENOHC_API uint64_t z_random_u64(void);
  */
 ZENOHC_API uint8_t z_random_u8(void);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_ref_shm_client_storage_global(struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_ref_shm_client_storage_global(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Returns ``true`` if `reply` is valid, ``false`` otherwise.
@@ -3189,7 +3332,7 @@ ZENOHC_API const struct z_loaned_sample_t *z_reply_ok(const struct z_loaned_repl
  * Returns `true` if id is present.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool z_reply_replier_id(const struct z_loaned_reply_t *this_, struct z_id_t *out_id);
+ZENOHC_API bool z_reply_replier_id(const struct z_loaned_reply_t *this_, z_id_t *out_id);
 #endif
 /**
  * Constructs send and recieve ends of the ring channel
@@ -3375,7 +3518,7 @@ ZENOHC_API enum z_priority_t z_sample_priority(const struct z_loaned_sample_t *t
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const struct z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
+const z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
 #endif
 /**
  * Returns the sample timestamp.
@@ -3428,26 +3571,26 @@ ZENOHC_API void z_session_null(struct z_owned_session_t *this_);
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_check(const struct z_owned_shm_t *this_);
+ZENOHC_API bool z_shm_check(const z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_check(const struct z_owned_shm_client_t *this_);
+ZENOHC_API bool z_shm_client_check(const z_owned_shm_client_t *this_);
 #endif
 /**
  * Deletes SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_drop(struct z_moved_shm_client_t *this_);
+ZENOHC_API void z_shm_client_drop(z_moved_shm_client_t *this_);
 #endif
 /**
  * Creates a new SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_new(struct z_owned_shm_client_t *this_,
+void z_shm_client_new(z_owned_shm_client_t *this_,
                       struct zc_threadsafe_context_t context,
                       struct zc_shm_client_callbacks_t callbacks);
 #endif
@@ -3455,179 +3598,177 @@ void z_shm_client_new(struct z_owned_shm_client_t *this_,
  * Constructs SHM client in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_null(struct z_owned_shm_client_t *this_);
+ZENOHC_API void z_shm_client_null(z_owned_shm_client_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_storage_check(const struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API bool z_shm_client_storage_check(const z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Performs a shallow copy of SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_storage_clone(struct z_owned_shm_client_storage_t *this_,
-                                const struct z_loaned_shm_client_storage_t *from);
+void z_shm_client_storage_clone(z_owned_shm_client_storage_t *this_,
+                                const z_loaned_shm_client_storage_t *from);
 #endif
 /**
  * Derefs SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_drop(struct z_moved_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_drop(z_moved_shm_client_storage_t *this_);
 #endif
 /**
  * Borrows SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const struct z_owned_shm_client_storage_t *this_);
+const z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const z_owned_shm_client_storage_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_shm_client_storage_new(struct z_owned_shm_client_storage_t *this_,
-                                    const struct zc_loaned_shm_client_list_t *clients,
+z_result_t z_shm_client_storage_new(z_owned_shm_client_storage_t *this_,
+                                    const zc_loaned_shm_client_list_t *clients,
                                     bool add_default_client_set);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_new_default(struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_new_default(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Constructs SHM Client Storage in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_null(struct z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_null(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Converts borrowed ZShm slice to owned ZShm slice by performing a shallow SHM reference copy
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_clone(struct z_owned_shm_t *out, const struct z_loaned_shm_t *this_);
+ZENOHC_API void z_shm_clone(z_owned_shm_t *out, const z_loaned_shm_t *this_);
 #endif
 /**
  * @return the pointer of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const unsigned char *z_shm_data(const struct z_loaned_shm_t *this_);
+ZENOHC_API const unsigned char *z_shm_data(const z_loaned_shm_t *this_);
 #endif
 /**
  * Deletes ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_drop(struct z_moved_shm_t *this_);
+ZENOHC_API void z_shm_drop(z_moved_shm_t *this_);
 #endif
 /**
  * Constructs ZShm slice from ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_from_mut(struct z_owned_shm_t *this_, struct z_moved_shm_mut_t *that);
+ZENOHC_API void z_shm_from_mut(z_owned_shm_t *this_, z_moved_shm_mut_t *that);
 #endif
 /**
  * @return the length of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_len(const struct z_loaned_shm_t *this_);
+ZENOHC_API size_t z_shm_len(const z_loaned_shm_t *this_);
 #endif
 /**
  * Borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const struct z_loaned_shm_t *z_shm_loan(const struct z_owned_shm_t *this_);
+ZENOHC_API const z_loaned_shm_t *z_shm_loan(const z_owned_shm_t *this_);
 #endif
 /**
  * Mutably borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_t *z_shm_loan_mut(struct z_owned_shm_t *this_);
+ZENOHC_API z_loaned_shm_t *z_shm_loan_mut(z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_mut_check(const struct z_owned_shm_mut_t *this_);
+ZENOHC_API bool z_shm_mut_check(const z_owned_shm_mut_t *this_);
 #endif
 /**
  * @return the immutable pointer to the underlying data
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const unsigned char *z_shm_mut_data(const struct z_loaned_shm_mut_t *this_);
+ZENOHC_API const unsigned char *z_shm_mut_data(const z_loaned_shm_mut_t *this_);
 #endif
 /**
  * @return the mutable pointer to the underlying data
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API unsigned char *z_shm_mut_data_mut(struct z_loaned_shm_mut_t *this_);
+ZENOHC_API unsigned char *z_shm_mut_data_mut(z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Deletes ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_drop(struct z_moved_shm_mut_t *this_);
+ZENOHC_API void z_shm_mut_drop(z_moved_shm_mut_t *this_);
 #endif
 /**
  * @return the length of the ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_mut_len(const struct z_loaned_shm_mut_t *this_);
+ZENOHC_API size_t z_shm_mut_len(const z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Borrows ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const struct z_loaned_shm_mut_t *z_shm_mut_loan(const struct z_owned_shm_mut_t *this_);
+ZENOHC_API const z_loaned_shm_mut_t *z_shm_mut_loan(const z_owned_shm_mut_t *this_);
 #endif
 /**
  * Mutably borrows ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_mut_t *z_shm_mut_loan_mut(struct z_owned_shm_mut_t *this_);
+ZENOHC_API z_loaned_shm_mut_t *z_shm_mut_loan_mut(z_owned_shm_mut_t *this_);
 #endif
 /**
  * Constructs ZShmMut slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_null(struct z_owned_shm_mut_t *this_);
+ZENOHC_API void z_shm_mut_null(z_owned_shm_mut_t *this_);
 #endif
 /**
  * Tries to construct ZShmMut slice from ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-void z_shm_mut_try_from_immut(struct z_owned_shm_mut_t *this_,
-                              struct z_moved_shm_t *that);
+ZENOHC_API void z_shm_mut_try_from_immut(z_owned_shm_mut_t *this_, z_moved_shm_t *that);
 #endif
 /**
  * Constructs ZShm slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_null(struct z_owned_shm_t *this_);
+ZENOHC_API void z_shm_null(z_owned_shm_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc(struct z_buf_layout_alloc_result_t *out_result,
-                          const struct z_loaned_shm_provider_t *provider,
+                          const z_loaned_shm_provider_t *provider,
                           size_t size,
                           struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc(struct z_buf_layout_alloc_result_t *out_result,
-                             const struct z_loaned_shm_provider_t *provider,
+                             const z_loaned_shm_provider_t *provider,
                              size_t size,
                              struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag(struct z_buf_layout_alloc_result_t *out_result,
-                                    const struct z_loaned_shm_provider_t *provider,
+                                    const z_loaned_shm_provider_t *provider,
                                     size_t size,
                                     struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result_t *out_result,
-                                                const struct z_loaned_shm_provider_t *provider,
+                                                const z_loaned_shm_provider_t *provider,
                                                 size_t size,
                                                 struct z_alloc_alignment_t alignment,
                                                 struct zc_threadsafe_context_t result_context,
@@ -3637,49 +3778,48 @@ z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_blocking(struct z_buf_layout_alloc_result_t *out_result,
-                                             const struct z_loaned_shm_provider_t *provider,
+                                             const z_loaned_shm_provider_t *provider,
                                              size_t size,
                                              struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_dealloc(struct z_buf_layout_alloc_result_t *out_result,
-                                            const struct z_loaned_shm_provider_t *provider,
+                                            const z_loaned_shm_provider_t *provider,
                                             size_t size,
                                             struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_available(const struct z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_available(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_provider_check(const struct z_owned_shm_provider_t *this_);
+ZENOHC_API bool z_shm_provider_check(const z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_defragment(const struct z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_defragment(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Deletes SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_drop(struct z_moved_shm_provider_t *this_);
+ZENOHC_API void z_shm_provider_drop(z_moved_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_garbage_collect(const struct z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_garbage_collect(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Borrows SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API
-const struct z_loaned_shm_provider_t *z_shm_provider_loan(const struct z_owned_shm_provider_t *this_);
+ZENOHC_API const z_loaned_shm_provider_t *z_shm_provider_loan(const z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
-                              const struct z_loaned_shm_provider_t *provider,
+z_result_t z_shm_provider_map(z_owned_shm_mut_t *out_result,
+                              const z_loaned_shm_provider_t *provider,
                               struct z_allocated_chunk_t allocated_chunk,
                               size_t len);
 #endif
@@ -3688,7 +3828,7 @@ z_result_t z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
+void z_shm_provider_new(z_owned_shm_provider_t *this_,
                         z_protocol_id_t id,
                         struct zc_context_t context,
                         struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3697,14 +3837,14 @@ void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
  * Constructs SHM Provider in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_null(struct z_owned_shm_provider_t *this_);
+ZENOHC_API void z_shm_provider_null(z_owned_shm_provider_t *this_);
 #endif
 /**
  * Creates a new threadsafe SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
+void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
                                    z_protocol_id_t id,
                                    struct zc_threadsafe_context_t context,
                                    struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3713,13 +3853,13 @@ void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
  * Mutably borrows ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_mut(struct z_owned_shm_t *this_);
+ZENOHC_API z_loaned_shm_mut_t *z_shm_try_mut(z_owned_shm_t *this_);
 #endif
 /**
  * Tries to reborrow mutably-borrowed ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_reloan_mut(struct z_loaned_shm_t *this_);
+ZENOHC_API z_loaned_shm_mut_t *z_shm_try_reloan_mut(z_loaned_shm_t *this_);
 #endif
 /**
  * Puts current thread to sleep for specified amount of milliseconds.
@@ -3798,47 +3938,46 @@ ZENOHC_API void z_slice_null(struct z_owned_slice_t *this_);
  * Returns ``true`` if source info is valid, ``false`` if it is in gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool z_source_info_check(const struct z_owned_source_info_t *this_);
+ZENOHC_API bool z_source_info_check(const z_owned_source_info_t *this_);
 #endif
 /**
  * Frees the memory and invalidates the source info, resetting it to a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void z_source_info_drop(struct z_moved_source_info_t *this_);
+ZENOHC_API void z_source_info_drop(z_moved_source_info_t *this_);
 #endif
 /**
  * Returns the source_id of the source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_entity_global_id_t z_source_info_id(const struct z_loaned_source_info_t *this_);
+ZENOHC_API z_entity_global_id_t z_source_info_id(const z_loaned_source_info_t *this_);
 #endif
 /**
  * Borrows source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API
-const struct z_loaned_source_info_t *z_source_info_loan(const struct z_owned_source_info_t *this_);
+ZENOHC_API const z_loaned_source_info_t *z_source_info_loan(const z_owned_source_info_t *this_);
 #endif
 /**
  * Create source info
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t z_source_info_new(struct z_owned_source_info_t *this_,
-                             const struct z_entity_global_id_t *source_id,
+z_result_t z_source_info_new(z_owned_source_info_t *this_,
+                             const z_entity_global_id_t *source_id,
                              uint64_t source_sn);
 #endif
 /**
  * Constructs source info in its gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void z_source_info_null(struct z_owned_source_info_t *this_);
+ZENOHC_API void z_source_info_null(z_owned_source_info_t *this_);
 #endif
 /**
  * Returns the source_sn of the source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API uint64_t z_source_info_sn(const struct z_loaned_source_info_t *this_);
+ZENOHC_API uint64_t z_source_info_sn(const z_loaned_source_info_t *this_);
 #endif
 /**
  * @return ``true`` if the string array is valid, ``false`` if it is in a gravestone state.
@@ -4054,7 +4193,7 @@ const char *z_time_now_as_str(const char *buf,
  * Returns id associated with this timestamp.
  */
 #if defined(UNSTABLE)
-ZENOHC_API struct z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
+ZENOHC_API z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
 #endif
 /**
  * Create uhlc timestamp from session id.
@@ -4422,7 +4561,7 @@ z_result_t zc_liveliness_declare_subscriber(struct z_owned_subscriber_t *this_,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_liveliness_declare_token(struct zc_owned_liveliness_token_t *this_,
+z_result_t zc_liveliness_declare_token(zc_owned_liveliness_token_t *this_,
                                        const struct z_loaned_session_t *session,
                                        const struct z_loaned_keyexpr_t *key_expr,
                                        const struct zc_liveliness_declaration_options_t *_options);
@@ -4459,32 +4598,32 @@ void zc_liveliness_subscriber_options_default(struct zc_liveliness_subscriber_op
  * Returns ``true`` if liveliness token is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool zc_liveliness_token_check(const struct zc_owned_liveliness_token_t *this_);
+ZENOHC_API bool zc_liveliness_token_check(const zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Undeclares liveliness token, frees memory and resets it to a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_liveliness_token_drop(struct zc_moved_liveliness_token_t *this_);
+ZENOHC_API void zc_liveliness_token_drop(zc_moved_liveliness_token_t *this_);
 #endif
 /**
  * Borrows token.
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const struct zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const struct zc_owned_liveliness_token_t *this_);
+const zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Constructs liveliness token in its gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_liveliness_token_null(struct zc_owned_liveliness_token_t *this_);
+ZENOHC_API void zc_liveliness_token_null(zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Destroys a liveliness token, notifying subscribers of its destruction.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t zc_liveliness_undeclare_token(struct zc_moved_liveliness_token_t *this_);
+ZENOHC_API z_result_t zc_liveliness_undeclare_token(zc_moved_liveliness_token_t *this_);
 #endif
 /**
  * Returns default value of `zc_locality_t`
@@ -4496,13 +4635,13 @@ ZENOHC_API enum zc_locality_t zc_locality_default(void);
  * Checks the matching listener is for the gravestone state
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool zc_matching_listener_check(const struct zc_owned_matching_listener_t *this_);
+ZENOHC_API bool zc_matching_listener_check(const zc_owned_matching_listener_t *this_);
 #endif
 /**
  * Constructs an empty matching listener
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_matching_listener_null(struct zc_owned_matching_listener_t *this_);
+ZENOHC_API void zc_matching_listener_null(zc_owned_matching_listener_t *this_);
 #endif
 /**
  * Gets publisher matching status - i.e. if there are any subscribers matching its key expression.
@@ -4525,7 +4664,7 @@ z_result_t zc_publisher_get_matching_status(const struct z_loaned_publisher_t *t
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_publisher_matching_listener_declare(struct zc_owned_matching_listener_t *this_,
+z_result_t zc_publisher_matching_listener_declare(zc_owned_matching_listener_t *this_,
                                                   const struct z_loaned_publisher_t *publisher,
                                                   struct zc_moved_closure_matching_status_t *callback);
 #endif
@@ -4535,8 +4674,7 @@ z_result_t zc_publisher_matching_listener_declare(struct zc_owned_matching_liste
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API
-z_result_t zc_publisher_matching_listener_drop(struct zc_moved_matching_listener_t *this_);
+ZENOHC_API z_result_t zc_publisher_matching_listener_drop(zc_moved_matching_listener_t *this_);
 #endif
 /**
  * Undeclares the given matching listener, droping and invalidating it.
@@ -4544,8 +4682,7 @@ z_result_t zc_publisher_matching_listener_drop(struct zc_moved_matching_listener
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API
-z_result_t zc_publisher_matching_listener_undeclare(struct zc_moved_matching_listener_t *this_);
+ZENOHC_API z_result_t zc_publisher_matching_listener_undeclare(zc_moved_matching_listener_t *this_);
 #endif
 /**
  * Returns the default value of #zc_reply_keyexpr_t.
@@ -4556,46 +4693,46 @@ ZENOHC_API enum zc_reply_keyexpr_t zc_reply_keyexpr_default(void);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t zc_shm_client_list_add_client(z_protocol_id_t id,
-                                         struct z_moved_shm_client_t *client,
-                                         struct zc_loaned_shm_client_list_t *list);
+                                         z_moved_shm_client_t *client,
+                                         zc_loaned_shm_client_list_t *list);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool zc_shm_client_list_check(const struct zc_owned_shm_client_list_t *this_);
+ZENOHC_API bool zc_shm_client_list_check(const zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Deletes list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_drop(struct zc_moved_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_drop(zc_moved_shm_client_list_t *this_);
 #endif
 /**
  * Borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const struct zc_owned_shm_client_list_t *this_);
+const zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Mutably borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(struct zc_owned_shm_client_list_t *this_);
+zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Creates a new empty list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_new(struct zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_new(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Constructs SHM client list in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_null(struct zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_null(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Stops all Zenoh tasks and drops all related static variables.
@@ -4617,7 +4754,7 @@ void zc_stop_z_runtime(void);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_declare_publication_cache(struct ze_owned_publication_cache_t *this_,
+z_result_t ze_declare_publication_cache(ze_owned_publication_cache_t *this_,
                                         const struct z_loaned_session_t *session,
                                         const struct z_loaned_keyexpr_t *key_expr,
                                         struct ze_publication_cache_options_t *options);
@@ -4635,7 +4772,7 @@ z_result_t ze_declare_publication_cache(struct ze_owned_publication_cache_t *thi
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_declare_querying_subscriber(struct ze_owned_querying_subscriber_t *this_,
+z_result_t ze_declare_querying_subscriber(ze_owned_querying_subscriber_t *this_,
                                           const struct z_loaned_session_t *session,
                                           const struct z_loaned_keyexpr_t *key_expr,
                                           struct z_moved_closure_sample_t *callback,
@@ -4645,19 +4782,19 @@ z_result_t ze_declare_querying_subscriber(struct ze_owned_querying_subscriber_t 
  * Returns ``true`` if publication cache is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool ze_publication_cache_check(const struct ze_owned_publication_cache_t *this_);
+ZENOHC_API bool ze_publication_cache_check(const ze_owned_publication_cache_t *this_);
 #endif
 /**
  * Drops publication cache. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_publication_cache_drop(struct ze_moved_publication_cache_t *this_);
+ZENOHC_API void ze_publication_cache_drop(ze_moved_publication_cache_t *this_);
 #endif
 /**
  * Constructs a publication cache in a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_publication_cache_null(struct ze_owned_publication_cache_t *this_);
+ZENOHC_API void ze_publication_cache_null(ze_owned_publication_cache_t *this_);
 #endif
 /**
  * Constructs the default value for `ze_publication_cache_options_t`.
@@ -4669,13 +4806,13 @@ ZENOHC_API void ze_publication_cache_options_default(struct ze_publication_cache
  * Returns ``true`` if querying subscriber is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool ze_querying_subscriber_check(const struct ze_owned_querying_subscriber_t *this_);
+ZENOHC_API bool ze_querying_subscriber_check(const ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Drops querying subscriber. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_t *this_);
+ZENOHC_API void ze_querying_subscriber_drop(ze_moved_querying_subscriber_t *this_);
 #endif
 /**
  * Make querying subscriber perform an additional query on a specified selector.
@@ -4684,7 +4821,7 @@ ZENOHC_API void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_querying_subscriber_get(const struct ze_loaned_querying_subscriber_t *this_,
+z_result_t ze_querying_subscriber_get(const ze_loaned_querying_subscriber_t *this_,
                                       const struct z_loaned_keyexpr_t *selector,
                                       struct z_get_options_t *options);
 #endif
@@ -4693,13 +4830,13 @@ z_result_t ze_querying_subscriber_get(const struct ze_loaned_querying_subscriber
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const struct ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const struct ze_owned_querying_subscriber_t *this_);
+const ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Constructs a querying subscriber in a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_querying_subscriber_null(struct ze_owned_querying_subscriber_t *this_);
+ZENOHC_API void ze_querying_subscriber_null(ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Constructs the default value for `ze_querying_subscriber_options_t`.
@@ -4713,7 +4850,7 @@ void ze_querying_subscriber_options_default(struct ze_querying_subscriber_option
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t ze_undeclare_publication_cache(struct ze_moved_publication_cache_t *this_);
+ZENOHC_API z_result_t ze_undeclare_publication_cache(ze_moved_publication_cache_t *this_);
 #endif
 /**
  * Undeclares the given querying subscriber, drops it and resets to a gravestone state.
@@ -4721,6 +4858,5 @@ ZENOHC_API z_result_t ze_undeclare_publication_cache(struct ze_moved_publication
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API
-z_result_t ze_undeclare_querying_subscriber(struct ze_moved_querying_subscriber_t *_this);
+ZENOHC_API z_result_t ze_undeclare_querying_subscriber(ze_moved_querying_subscriber_t *_this);
 #endif

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -16,26 +16,6 @@
 #define ALIGN(n)
 #define ZENOHC_API
 #endif
-/**
- * Allocation errors
- *
- *     - **NEED_DEFRAGMENT**: defragmentation needed
- *     - **OUT_OF_MEMORY**: the provider is out of memory
- *     - **OTHER**: other error
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef enum z_alloc_error_t {
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  Z_ALLOC_ERROR_NEED_DEFRAGMENT,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  Z_ALLOC_ERROR_OUT_OF_MEMORY,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  Z_ALLOC_ERROR_OTHER,
-#endif
-} z_alloc_error_t;
-#endif
 typedef enum z_congestion_control_t {
   /**
    * Messages are not dropped in case of congestion.
@@ -95,22 +75,6 @@ typedef enum z_keyexpr_intersection_level_t {
    */
   Z_KEYEXPR_INTERSECTION_LEVEL_EQUALS = 3,
 } z_keyexpr_intersection_level_t;
-#endif
-/**
- * Layouting errors
- *
- * INCORRECT_LAYOUT_ARGS: layout arguments are incorrect
- * PROVIDER_INCOMPATIBLE_LAYOUT: layout incompatible with provider
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef enum z_layout_error_t {
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  Z_LAYOUT_ERROR_INCORRECT_LAYOUT_ARGS,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  Z_LAYOUT_ERROR_PROVIDER_INCOMPATIBLE_LAYOUT,
-#endif
-} z_layout_error_t;
 #endif
 /**
  * The priority of zenoh messages.
@@ -266,47 +230,10 @@ typedef enum zc_reply_keyexpr_t {
   ZC_REPLY_KEYEXPR_MATCHING_QUERY = 1,
 } zc_reply_keyexpr_t;
 #endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_buf_alloc_result_t {
-  z_owned_shm_mut_t buf;
-  enum z_alloc_error_t error;
-} z_buf_alloc_result_t;
-#endif
+typedef struct z_moved_alloc_layout_t {
+  struct z_owned_alloc_layout_t _this;
+} z_moved_alloc_layout_t;
 typedef int8_t z_result_t;
-/**
- * An AllocAlignment.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_alloc_alignment_t {
-  uint8_t pow;
-} z_alloc_alignment_t;
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_threadsafe_context_data_t {
-  void *ptr;
-} zc_threadsafe_context_data_t;
-#endif
-/**
- * A tread-safe droppable context.
- * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
- * information to each callback.
- *
- * This is a thread-safe context - the associated callbacks may be executed concurrently with the same
- * zc_context_t instance. In other words, all the callbacks associated with this context data MUST be
- * thread-safe.
- *
- * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted.The
- * delete_fn is guaranteed to be executed only once at some point of time after the last associated
- * callback call returns.
- * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
- * be executed.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_threadsafe_context_t {
-  struct zc_threadsafe_context_data_t context;
-  void (*delete_fn)(void*);
-} zc_threadsafe_context_t;
-#endif
 typedef struct z_moved_bytes_t {
   struct z_owned_bytes_t _this;
 } z_moved_bytes_t;
@@ -316,37 +243,15 @@ typedef struct z_moved_slice_t {
 typedef struct z_moved_string_t {
   struct z_owned_string_t _this;
 } z_moved_string_t;
-/**
- * Unique segment identifier
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef uint32_t z_segment_id_t;
-#endif
-/**
- * Chunk id within it's segment
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef uint32_t z_chunk_id_t;
-#endif
-/**
- * A ChunkDescriptor
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_chunk_descriptor_t {
-  z_segment_id_t segment;
-  z_chunk_id_t chunk;
-  size_t len;
-} z_chunk_descriptor_t;
-#endif
-/**
- * An AllocatedChunk
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_allocated_chunk_t {
-  struct z_chunk_descriptor_t descriptpr;
-  void *data;
-} z_allocated_chunk_t;
-#endif
+typedef struct z_moved_shm_t {
+  struct z_owned_shm_t _this;
+} z_moved_shm_t;
+typedef struct z_moved_shm_mut_t {
+  struct z_owned_shm_mut_t _this;
+} z_moved_shm_mut_t;
+typedef struct z_moved_chunk_alloc_result_t {
+  struct z_owned_chunk_alloc_result_t _this;
+} z_moved_chunk_alloc_result_t;
 /**
  * Monotonic clock
  */
@@ -497,7 +402,7 @@ typedef struct z_owned_closure_zid_t {
   /**
    * A callback function.
    */
-  void (*call)(const z_id_t *z_id, void *context);
+  void (*call)(const struct z_id_t *z_id, void *context);
   /**
    * An optional function that will be called upon closure drop.
    */
@@ -608,6 +513,9 @@ typedef struct z_moved_fifo_handler_sample_t {
 typedef struct z_query_consolidation_t {
   enum z_consolidation_mode_t mode;
 } z_query_consolidation_t;
+typedef struct z_moved_source_info_t {
+  struct z_owned_source_info_t _this;
+} z_moved_source_info_t;
 /**
  * Options passed to the `z_get()` function.
  */
@@ -656,7 +564,7 @@ typedef struct z_get_options_t {
   /**
    * The source info for the query.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * An optional attachment to attach to the query.
@@ -673,6 +581,9 @@ typedef struct z_moved_hello_t {
 typedef struct z_moved_keyexpr_t {
   struct z_owned_keyexpr_t _this;
 } z_moved_keyexpr_t;
+typedef struct z_moved_memory_layout_t {
+  struct z_owned_memory_layout_t _this;
+} z_moved_memory_layout_t;
 typedef struct z_moved_mutex_t {
   struct z_owned_mutex_t _this;
 } z_moved_mutex_t;
@@ -705,7 +616,7 @@ typedef struct z_publisher_put_options_t {
   /**
    * The source info for the publication.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to attach to the publication.
@@ -746,7 +657,7 @@ typedef struct z_put_options_t {
   /**
    * The source info for the message.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this message.
@@ -785,7 +696,7 @@ typedef struct z_query_reply_options_t {
   /**
    * The source info for the reply.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
@@ -817,7 +728,7 @@ typedef struct z_query_reply_del_options_t {
   /**
    * The source info for the reply.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
@@ -868,39 +779,15 @@ typedef struct z_scout_options_t {
    */
   enum z_what_t what;
 } z_scout_options_t;
-/**
- * A callbacks for ShmSegment
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_shm_segment_callbacks_t {
-  uint8_t *(*map_fn)(z_chunk_id_t chunk_id, void *context);
-} zc_shm_segment_callbacks_t;
-#endif
-/**
- * A ShmSegment
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_shm_segment_t {
-  struct zc_threadsafe_context_t context;
-  struct zc_shm_segment_callbacks_t callbacks;
-} z_shm_segment_t;
-#endif
-/**
- * A callbacks for ShmClient
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_shm_client_callbacks_t {
-  bool (*attach_fn)(struct z_shm_segment_t *out_segment, z_segment_id_t segment_id, void *context);
-} zc_shm_client_callbacks_t;
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_buf_layout_alloc_result_t {
-  z_owned_shm_mut_t buf;
-  bool error_is_alloc;
-  enum z_alloc_error_t alloc_error;
-  enum z_layout_error_t layout_error;
-} z_buf_layout_alloc_result_t;
-#endif
+typedef struct z_moved_shm_client_t {
+  struct z_owned_shm_client_t _this;
+} z_moved_shm_client_t;
+typedef struct z_moved_shm_client_storage_t {
+  struct z_owned_shm_client_storage_t _this;
+} z_moved_shm_client_storage_t;
+typedef struct z_moved_shm_provider_t {
+  struct z_owned_shm_provider_t _this;
+} z_moved_shm_provider_t;
 /**
  * Unique protocol identifier.
  * Here is a contract: it is up to user to make sure that incompatible ShmClient
@@ -908,46 +795,6 @@ typedef struct z_buf_layout_alloc_result_t {
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 typedef uint32_t z_protocol_id_t;
-#endif
-/**
- * A non-tread-safe droppable context.
- * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
- * information to each callback.
- *
- * This is a non-thread-safe context - zenoh-c guarantees that associated callbacks that share the same
- * zc_context_t instance will never be executed concurrently. In other words, all the callbacks associated
- * with this context data are not required to be thread-safe.
- *
- * NOTE: Remember that the same callback interfaces associated with different zc_context_t instances can
- * still be executed concurrently. The exact behavior depends on user's application, but we strongly
- * discourage our users from pinning to some specific behavior unless they _really_ understand what they
- * are doing.
- *
- * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted. The
- * delete_fn is guaranteed to be executed only once at some point of time after the last associated
- * callback call returns.
- * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
- * be executed.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_context_t {
-  void *context;
-  void (*delete_fn)(void*);
-} zc_context_t;
-#endif
-/**
- * A callbacks for ShmProviderBackend
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_shm_provider_backend_callbacks_t {
-  void (*alloc_fn)(z_owned_chunk_alloc_result_t *out_result,
-                   const z_loaned_memory_layout_t *layout,
-                   void *context);
-  void (*free_fn)(const struct z_chunk_descriptor_t *chunk, void *context);
-  size_t (*defragment_fn)(void *context);
-  size_t (*available_fn)(void *context);
-  void (*layout_for_fn)(z_owned_memory_layout_t *layout, void *context);
-} zc_shm_provider_backend_callbacks_t;
 #endif
 typedef struct z_moved_string_array_t {
   struct z_owned_string_array_t _this;
@@ -997,14 +844,6 @@ typedef struct zc_owned_closure_log_t {
 typedef struct zc_moved_closure_log_t {
   struct zc_owned_closure_log_t _this;
 } zc_moved_closure_log_t;
-/**
- * Loaned closure.
- */
-#if defined(UNSTABLE)
-typedef struct zc_loaned_closure_matching_status_t {
-  size_t _0[3];
-} zc_loaned_closure_matching_status_t;
-#endif
 /**
  * A struct that indicates if there exist Subscribers matching the Publisher's key expression.
  */
@@ -1074,6 +913,15 @@ typedef struct zc_liveliness_get_options_t {
   uint32_t timeout_ms;
 } zc_liveliness_get_options_t;
 #endif
+typedef struct zc_moved_liveliness_token_t {
+  struct zc_owned_liveliness_token_t _this;
+} zc_moved_liveliness_token_t;
+typedef struct zc_moved_matching_listener_t {
+  struct zc_owned_matching_listener_t _this;
+} zc_moved_matching_listener_t;
+typedef struct zc_moved_shm_client_list_t {
+  struct zc_owned_shm_client_list_t _this;
+} zc_moved_shm_client_list_t;
 /**
  * Options passed to the `ze_declare_publication_cache()` function.
  */
@@ -1144,6 +992,12 @@ typedef struct ze_querying_subscriber_options_t {
   uint64_t query_timeout_ms;
 } ze_querying_subscriber_options_t;
 #endif
+typedef struct ze_moved_publication_cache_t {
+  struct ze_owned_publication_cache_t _this;
+} ze_moved_publication_cache_t;
+typedef struct ze_moved_querying_subscriber_t {
+  struct ze_owned_querying_subscriber_t _this;
+} ze_moved_querying_subscriber_t;
 ZENOHC_API extern const unsigned int Z_ROUTER;
 ZENOHC_API extern const unsigned int Z_PEER;
 ZENOHC_API extern const unsigned int Z_CLIENT;
@@ -1163,53 +1017,54 @@ ZENOHC_API extern const unsigned int Z_SHM_POSIX_PROTOCOL_ID;
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc(struct z_buf_alloc_result_t *out_result,
-                          const z_loaned_alloc_layout_t *layout);
+                          const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc(struct z_buf_alloc_result_t *out_result,
-                             const z_loaned_alloc_layout_t *layout);
+                             const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag(struct z_buf_alloc_result_t *out_result,
-                                    const z_loaned_alloc_layout_t *layout);
+                                    const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_blocking(struct z_buf_alloc_result_t *out_result,
-                                             const z_loaned_alloc_layout_t *layout);
+                                             const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_dealloc(struct z_buf_alloc_result_t *out_result,
-                                            const z_loaned_alloc_layout_t *layout);
+                                            const struct z_loaned_alloc_layout_t *layout);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_alloc_layout_check(const z_owned_alloc_layout_t *this_);
+ZENOHC_API bool z_alloc_layout_check(const struct z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Deletes Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_drop(z_moved_alloc_layout_t this_);
+ZENOHC_API void z_alloc_layout_drop(struct z_moved_alloc_layout_t this_);
 #endif
 /**
  * Borrows Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_alloc_layout_t *z_alloc_layout_loan(const z_owned_alloc_layout_t *this_);
+ZENOHC_API
+const struct z_loaned_alloc_layout_t *z_alloc_layout_loan(const struct z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Creates a new Alloc Layout for SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_alloc_layout_new(z_owned_alloc_layout_t *this_,
-                              const z_loaned_shm_provider_t *provider,
+z_result_t z_alloc_layout_new(struct z_owned_alloc_layout_t *this_,
+                              const struct z_loaned_shm_provider_t *provider,
                               size_t size,
                               struct z_alloc_alignment_t alignment);
 #endif
@@ -1217,12 +1072,12 @@ z_result_t z_alloc_layout_new(z_owned_alloc_layout_t *this_,
  * Constructs Alloc Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_null(z_owned_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_null(struct z_owned_alloc_layout_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_alloc_layout_threadsafe_alloc_gc_defrag_async(struct z_buf_alloc_result_t *out_result,
-                                                           const z_loaned_alloc_layout_t *layout,
+                                                           const struct z_loaned_alloc_layout_t *layout,
                                                            struct zc_threadsafe_context_t result_context,
                                                            void (*result_callback)(void*,
                                                                                    struct z_buf_alloc_result_t*));
@@ -1286,7 +1141,7 @@ z_result_t z_bytes_deserialize_into_int8(const struct z_loaned_bytes_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *this_,
-                                               const z_loaned_shm_t **dst);
+                                               const struct z_loaned_shm_t **dst);
 #endif
 /**
  * Deserializes data into a mutably loaned SHM buffer
@@ -1297,7 +1152,7 @@ z_result_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *th
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this_,
-                                                   z_loaned_shm_t **dst);
+                                                   struct z_loaned_shm_t **dst);
 #endif
 /**
  * Deserializes data into an owned SHM buffer by copying it's shared reference
@@ -1308,7 +1163,7 @@ z_result_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_owned_shm(const struct z_loaned_bytes_t *this_,
-                                              z_owned_shm_t *dst);
+                                              struct z_owned_shm_t *dst);
 #endif
 /**
  * Deserializes into a pair of `z_owned_bytes_t` objects.
@@ -1567,7 +1422,9 @@ ZENOHC_API void z_bytes_serialize_from_int8(struct z_owned_bytes_t *this_, int8_
  * Serializes from an immutable SHM buffer consuming it
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_, z_moved_shm_t shm);
+ZENOHC_API
+z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_,
+                                      struct z_moved_shm_t shm);
 #endif
 /**
  * Serializes from a mutable SHM buffer consuming it
@@ -1575,7 +1432,7 @@ ZENOHC_API z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_, 
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_serialize_from_shm_mut(struct z_owned_bytes_t *this_,
-                                          z_moved_shm_mut_t shm);
+                                          struct z_moved_shm_mut_t shm);
 #endif
 /**
  * Serializes a slice by copying.
@@ -1643,27 +1500,27 @@ z_result_t z_bytes_writer_write_all(struct z_bytes_writer_t *this_,
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_chunk_alloc_result_check(const z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API bool z_chunk_alloc_result_check(const struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Deletes Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_drop(z_moved_chunk_alloc_result_t this_);
+ZENOHC_API void z_chunk_alloc_result_drop(struct z_moved_chunk_alloc_result_t this_);
 #endif
 /**
  * Borrows Chunk Alloc Result
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const z_owned_chunk_alloc_result_t *this_);
+const struct z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Creates a new Chunk Alloc Result with Error value
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
+void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
                                     enum z_alloc_error_t alloc_error);
 #endif
 /**
@@ -1671,14 +1528,14 @@ void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_chunk_alloc_result_new_ok(z_owned_chunk_alloc_result_t *this_,
+z_result_t z_chunk_alloc_result_new_ok(struct z_owned_chunk_alloc_result_t *this_,
                                        struct z_allocated_chunk_t allocated_chunk);
 #endif
 /**
  * Constructs Chunk Alloc Result in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_chunk_alloc_result_null(z_owned_chunk_alloc_result_t *this_);
+ZENOHC_API void z_chunk_alloc_result_null(struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Get number of milliseconds passed since creation of `time`.
@@ -1703,7 +1560,7 @@ ZENOHC_API struct z_clock_t z_clock_now(void);
  * the remaining reference count (number of shallow copies) of the session otherwise, saturating at i8::MAX.
  */
 ZENOHC_API
-z_result_t z_close(struct z_moved_session_t session);
+z_result_t z_close(struct z_moved_session_t *session);
 /**
  * Calls the closure. Calling an uninitialized closure is a no-op.
  */
@@ -1803,7 +1660,7 @@ ZENOHC_API void z_closure_sample_null(struct z_owned_closure_sample_t *this_);
 #if defined(UNSTABLE)
 ZENOHC_API
 void z_closure_zid_call(const struct z_loaned_closure_zid_t *closure,
-                        const z_id_t *z_id);
+                        const struct z_id_t *z_id);
 #endif
 /**
  * Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
@@ -2498,13 +2355,13 @@ ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint8(void);
  * Returns the entity id of the entity global id.
  */
 #if defined(UNSTABLE)
-ZENOHC_API uint32_t z_entity_global_id_eid(const z_entity_global_id_t *this_);
+ZENOHC_API uint32_t z_entity_global_id_eid(const struct z_entity_global_id_t *this_);
 #endif
 /**
  * Returns the zenoh id of entity global id.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_id_t z_entity_global_id_zid(const z_entity_global_id_t *this_);
+ZENOHC_API struct z_id_t z_entity_global_id_zid(const struct z_entity_global_id_t *this_);
 #endif
 /**
  * Constructs send and recieve ends of the fifo channel
@@ -2682,7 +2539,7 @@ ZENOHC_API enum z_whatami_t z_hello_whatami(const struct z_loaned_hello_t *this_
  * Returns id of Zenoh entity that transmitted hello message.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
+ZENOHC_API struct z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
 #endif
 /**
  * Fetches the Zenoh IDs of all connected peers.
@@ -2718,7 +2575,7 @@ z_result_t z_info_routers_zid(const struct z_loaned_session_t *session,
  * to pass it a valid session.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_id_t z_info_zid(const struct z_loaned_session_t *session);
+ZENOHC_API struct z_id_t z_info_zid(const struct z_loaned_session_t *session);
 #endif
 /**
  * Constructs a non-owned non-null-terminated string from key expression.
@@ -2862,13 +2719,13 @@ enum z_keyexpr_intersection_level_t z_keyexpr_relation_to(const struct z_loaned_
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_memory_layout_check(const z_owned_memory_layout_t *this_);
+ZENOHC_API bool z_memory_layout_check(const struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * Deletes Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_drop(z_moved_memory_layout_t this_);
+ZENOHC_API void z_memory_layout_drop(struct z_moved_memory_layout_t this_);
 #endif
 /**
  * Extract data from Memory Layout
@@ -2877,21 +2734,21 @@ ZENOHC_API void z_memory_layout_drop(z_moved_memory_layout_t this_);
 ZENOHC_API
 void z_memory_layout_get_data(size_t *out_size,
                               struct z_alloc_alignment_t *out_alignment,
-                              const z_loaned_memory_layout_t *this_);
+                              const struct z_loaned_memory_layout_t *this_);
 #endif
 /**
  * Borrows Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_memory_layout_t *z_memory_layout_loan(const z_owned_memory_layout_t *this_);
+const struct z_loaned_memory_layout_t *z_memory_layout_loan(const struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * Creates a new Memory Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_memory_layout_new(z_owned_memory_layout_t *this_,
+z_result_t z_memory_layout_new(struct z_owned_memory_layout_t *this_,
                                size_t size,
                                struct z_alloc_alignment_t alignment);
 #endif
@@ -2899,7 +2756,7 @@ z_result_t z_memory_layout_new(z_owned_memory_layout_t *this_,
  * Constructs Memory Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_memory_layout_null(z_owned_memory_layout_t *this_);
+ZENOHC_API void z_memory_layout_null(struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * Returns ``true`` if mutex is valid, ``false`` otherwise.
@@ -2945,7 +2802,7 @@ z_result_t z_mutex_unlock(struct z_loaned_mutex_t *this_);
  */
 ZENOHC_API
 z_result_t z_open(struct z_owned_session_t *this_,
-                  struct z_moved_config_t config);
+                  struct z_moved_config_t *config);
 /**
  * Constructs and opens a new Zenoh session with specified client storage.
  *
@@ -2955,21 +2812,21 @@ z_result_t z_open(struct z_owned_session_t *this_,
 ZENOHC_API
 z_result_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
                                           struct z_moved_config_t config,
-                                          const z_loaned_shm_client_storage_t *shm_clients);
+                                          const struct z_loaned_shm_client_storage_t *shm_clients);
 #endif
 /**
  * Creates a new POSIX SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_posix_shm_client_new(z_owned_shm_client_t *this_);
+ZENOHC_API void z_posix_shm_client_new(struct z_owned_shm_client_t *this_);
 #endif
 /**
  * Creates a new POSIX SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_posix_shm_provider_new(z_owned_shm_provider_t *this_,
-                                    const z_loaned_memory_layout_t *layout);
+z_result_t z_posix_shm_provider_new(struct z_owned_shm_provider_t *this_,
+                                    const struct z_loaned_memory_layout_t *layout);
 #endif
 /**
  * Returns the default value of #z_priority_t.
@@ -2994,12 +2851,12 @@ ZENOHC_API void z_publisher_delete_options_default(struct z_publisher_delete_opt
 /**
  * Frees memory and resets publisher to its gravestone state. Also attempts undeclare publisher.
  */
-ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t this_);
+ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t *_this);
 /**
  * Returns the ID of the publisher.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
+ZENOHC_API struct z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
 #endif
 /**
  * Returns the key expression of the publisher.
@@ -3117,7 +2974,7 @@ ZENOHC_API struct z_query_consolidation_t z_query_consolidation_none(void);
 /**
  * Destroys the query resetting it to its gravestone value.
  */
-ZENOHC_API void z_query_drop(struct z_moved_query_t this_);
+ZENOHC_API void z_query_drop(struct z_moved_query_t *this_);
 /**
  * Gets query <a href="https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Query%20Payload.md">payload encoding</a>.
  *
@@ -3229,7 +3086,7 @@ ZENOHC_API bool z_queryable_check(const struct z_owned_queryable_t *this_);
 /**
  * Frees memory and resets it to its gravesztone state. Will also attempt to undeclare queryable.
  */
-ZENOHC_API void z_queryable_drop(struct z_moved_queryable_t this_);
+ZENOHC_API void z_queryable_drop(struct z_moved_queryable_t *this_);
 ZENOHC_API
 const struct z_loaned_queryable_t *z_queryable_loan(const struct z_owned_queryable_t *this_);
 /**
@@ -3261,7 +3118,7 @@ ZENOHC_API uint64_t z_random_u64(void);
  */
 ZENOHC_API uint8_t z_random_u8(void);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_ref_shm_client_storage_global(z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_ref_shm_client_storage_global(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Returns ``true`` if `reply` is valid, ``false`` otherwise.
@@ -3332,7 +3189,7 @@ ZENOHC_API const struct z_loaned_sample_t *z_reply_ok(const struct z_loaned_repl
  * Returns `true` if id is present.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool z_reply_replier_id(const struct z_loaned_reply_t *this_, z_id_t *out_id);
+ZENOHC_API bool z_reply_replier_id(const struct z_loaned_reply_t *this_, struct z_id_t *out_id);
 #endif
 /**
  * Constructs send and recieve ends of the ring channel
@@ -3518,7 +3375,7 @@ ZENOHC_API enum z_priority_t z_sample_priority(const struct z_loaned_sample_t *t
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
+const struct z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
 #endif
 /**
  * Returns the sample timestamp.
@@ -3536,7 +3393,7 @@ ZENOHC_API const struct z_timestamp_t *z_sample_timestamp(const struct z_loaned_
  * @return 0 if successful, negative error values upon failure.
  */
 ZENOHC_API
-z_result_t z_scout(struct z_moved_config_t config,
+z_result_t z_scout(struct z_moved_config_t *config,
                    struct z_moved_closure_hello_t *callback,
                    const struct z_scout_options_t *options);
 /**
@@ -3571,26 +3428,26 @@ ZENOHC_API void z_session_null(struct z_owned_session_t *this_);
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_check(const z_owned_shm_t *this_);
+ZENOHC_API bool z_shm_check(const struct z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_check(const z_owned_shm_client_t *this_);
+ZENOHC_API bool z_shm_client_check(const struct z_owned_shm_client_t *this_);
 #endif
 /**
  * Deletes SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_drop(z_moved_shm_client_t this_);
+ZENOHC_API void z_shm_client_drop(struct z_moved_shm_client_t this_);
 #endif
 /**
  * Creates a new SHM Client
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_new(z_owned_shm_client_t *this_,
+void z_shm_client_new(struct z_owned_shm_client_t *this_,
                       struct zc_threadsafe_context_t context,
                       struct zc_shm_client_callbacks_t callbacks);
 #endif
@@ -3598,177 +3455,179 @@ void z_shm_client_new(z_owned_shm_client_t *this_,
  * Constructs SHM client in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_null(z_owned_shm_client_t *this_);
+ZENOHC_API void z_shm_client_null(struct z_owned_shm_client_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_client_storage_check(const z_owned_shm_client_storage_t *this_);
+ZENOHC_API bool z_shm_client_storage_check(const struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Performs a shallow copy of SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_storage_clone(z_owned_shm_client_storage_t *this_,
-                                const z_loaned_shm_client_storage_t *from);
+void z_shm_client_storage_clone(struct z_owned_shm_client_storage_t *this_,
+                                const struct z_loaned_shm_client_storage_t *from);
 #endif
 /**
  * Derefs SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_drop(z_moved_shm_client_storage_t this_);
+ZENOHC_API void z_shm_client_storage_drop(struct z_moved_shm_client_storage_t this_);
 #endif
 /**
  * Borrows SHM Client Storage
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const z_owned_shm_client_storage_t *this_);
+const struct z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const struct z_owned_shm_client_storage_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_shm_client_storage_new(z_owned_shm_client_storage_t *this_,
-                                    const zc_loaned_shm_client_list_t *clients,
+z_result_t z_shm_client_storage_new(struct z_owned_shm_client_storage_t *this_,
+                                    const struct zc_loaned_shm_client_list_t *clients,
                                     bool add_default_client_set);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_new_default(z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_new_default(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Constructs SHM Client Storage in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_client_storage_null(z_owned_shm_client_storage_t *this_);
+ZENOHC_API void z_shm_client_storage_null(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * Converts borrowed ZShm slice to owned ZShm slice by performing a shallow SHM reference copy
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_clone(z_owned_shm_t *out, const z_loaned_shm_t *this_);
+ZENOHC_API void z_shm_clone(struct z_owned_shm_t *out, const struct z_loaned_shm_t *this_);
 #endif
 /**
  * @return the pointer of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const unsigned char *z_shm_data(const z_loaned_shm_t *this_);
+ZENOHC_API const unsigned char *z_shm_data(const struct z_loaned_shm_t *this_);
 #endif
 /**
  * Deletes ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_drop(z_moved_shm_t this_);
+ZENOHC_API void z_shm_drop(struct z_moved_shm_t this_);
 #endif
 /**
  * Constructs ZShm slice from ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_from_mut(z_owned_shm_t *this_, z_moved_shm_mut_t that);
+ZENOHC_API void z_shm_from_mut(struct z_owned_shm_t *this_, struct z_moved_shm_mut_t that);
 #endif
 /**
  * @return the length of the ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_len(const z_loaned_shm_t *this_);
+ZENOHC_API size_t z_shm_len(const struct z_loaned_shm_t *this_);
 #endif
 /**
  * Borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_shm_t *z_shm_loan(const z_owned_shm_t *this_);
+ZENOHC_API const struct z_loaned_shm_t *z_shm_loan(const struct z_owned_shm_t *this_);
 #endif
 /**
  * Mutably borrows ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_t *z_shm_loan_mut(z_owned_shm_t *this_);
+ZENOHC_API struct z_loaned_shm_t *z_shm_loan_mut(struct z_owned_shm_t *this_);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_mut_check(const z_owned_shm_mut_t *this_);
+ZENOHC_API bool z_shm_mut_check(const struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * @return the immutable pointer to the underlying data
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const unsigned char *z_shm_mut_data(const z_loaned_shm_mut_t *this_);
+ZENOHC_API const unsigned char *z_shm_mut_data(const struct z_loaned_shm_mut_t *this_);
 #endif
 /**
  * @return the mutable pointer to the underlying data
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API unsigned char *z_shm_mut_data_mut(z_loaned_shm_mut_t *this_);
+ZENOHC_API unsigned char *z_shm_mut_data_mut(struct z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Deletes ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_drop(z_moved_shm_mut_t this_);
+ZENOHC_API void z_shm_mut_drop(struct z_moved_shm_mut_t this_);
 #endif
 /**
  * @return the length of the ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_mut_len(const z_loaned_shm_mut_t *this_);
+ZENOHC_API size_t z_shm_mut_len(const struct z_loaned_shm_mut_t *this_);
 #endif
 /**
  * Borrows ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_shm_mut_t *z_shm_mut_loan(const z_owned_shm_mut_t *this_);
+ZENOHC_API const struct z_loaned_shm_mut_t *z_shm_mut_loan(const struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * Mutably borrows ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_mut_t *z_shm_mut_loan_mut(z_owned_shm_mut_t *this_);
+ZENOHC_API struct z_loaned_shm_mut_t *z_shm_mut_loan_mut(struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * Constructs ZShmMut slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_null(z_owned_shm_mut_t *this_);
+ZENOHC_API void z_shm_mut_null(struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * Tries to construct ZShmMut slice from ZShm slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_mut_try_from_immut(z_owned_shm_mut_t *this_, z_moved_shm_t that);
+ZENOHC_API
+void z_shm_mut_try_from_immut(struct z_owned_shm_mut_t *this_,
+                              struct z_moved_shm_t that);
 #endif
 /**
  * Constructs ZShm slice in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_null(z_owned_shm_t *this_);
+ZENOHC_API void z_shm_null(struct z_owned_shm_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc(struct z_buf_layout_alloc_result_t *out_result,
-                          const z_loaned_shm_provider_t *provider,
+                          const struct z_loaned_shm_provider_t *provider,
                           size_t size,
                           struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc(struct z_buf_layout_alloc_result_t *out_result,
-                             const z_loaned_shm_provider_t *provider,
+                             const struct z_loaned_shm_provider_t *provider,
                              size_t size,
                              struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag(struct z_buf_layout_alloc_result_t *out_result,
-                                    const z_loaned_shm_provider_t *provider,
+                                    const struct z_loaned_shm_provider_t *provider,
                                     size_t size,
                                     struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result_t *out_result,
-                                                const z_loaned_shm_provider_t *provider,
+                                                const struct z_loaned_shm_provider_t *provider,
                                                 size_t size,
                                                 struct z_alloc_alignment_t alignment,
                                                 struct zc_threadsafe_context_t result_context,
@@ -3778,48 +3637,49 @@ z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_blocking(struct z_buf_layout_alloc_result_t *out_result,
-                                             const z_loaned_shm_provider_t *provider,
+                                             const struct z_loaned_shm_provider_t *provider,
                                              size_t size,
                                              struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_dealloc(struct z_buf_layout_alloc_result_t *out_result,
-                                            const z_loaned_shm_provider_t *provider,
+                                            const struct z_loaned_shm_provider_t *provider,
                                             size_t size,
                                             struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_available(const z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_available(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_shm_provider_check(const z_owned_shm_provider_t *this_);
+ZENOHC_API bool z_shm_provider_check(const struct z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_defragment(const z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_defragment(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Deletes SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_drop(z_moved_shm_provider_t this_);
+ZENOHC_API void z_shm_provider_drop(struct z_moved_shm_provider_t this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API size_t z_shm_provider_garbage_collect(const z_loaned_shm_provider_t *provider);
+ZENOHC_API size_t z_shm_provider_garbage_collect(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * Borrows SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_shm_provider_t *z_shm_provider_loan(const z_owned_shm_provider_t *this_);
+ZENOHC_API
+const struct z_loaned_shm_provider_t *z_shm_provider_loan(const struct z_owned_shm_provider_t *this_);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_shm_provider_map(z_owned_shm_mut_t *out_result,
-                              const z_loaned_shm_provider_t *provider,
+z_result_t z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
+                              const struct z_loaned_shm_provider_t *provider,
                               struct z_allocated_chunk_t allocated_chunk,
                               size_t len);
 #endif
@@ -3828,7 +3688,7 @@ z_result_t z_shm_provider_map(z_owned_shm_mut_t *out_result,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_new(z_owned_shm_provider_t *this_,
+void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
                         z_protocol_id_t id,
                         struct zc_context_t context,
                         struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3837,14 +3697,14 @@ void z_shm_provider_new(z_owned_shm_provider_t *this_,
  * Constructs SHM Provider in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_shm_provider_null(z_owned_shm_provider_t *this_);
+ZENOHC_API void z_shm_provider_null(struct z_owned_shm_provider_t *this_);
 #endif
 /**
  * Creates a new threadsafe SHM Provider
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
+void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
                                    z_protocol_id_t id,
                                    struct zc_threadsafe_context_t context,
                                    struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -3853,13 +3713,13 @@ void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
  * Mutably borrows ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_mut_t *z_shm_try_mut(z_owned_shm_t *this_);
+ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_mut(struct z_owned_shm_t *this_);
 #endif
 /**
  * Tries to reborrow mutably-borrowed ZShm slice as borrowed ZShmMut slice
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_mut_t *z_shm_try_reloan_mut(z_loaned_shm_t *this_);
+ZENOHC_API struct z_loaned_shm_mut_t *z_shm_try_reloan_mut(struct z_loaned_shm_t *this_);
 #endif
 /**
  * Puts current thread to sleep for specified amount of milliseconds.
@@ -3938,46 +3798,47 @@ ZENOHC_API void z_slice_null(struct z_owned_slice_t *this_);
  * Returns ``true`` if source info is valid, ``false`` if it is in gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool z_source_info_check(const z_owned_source_info_t *this_);
+ZENOHC_API bool z_source_info_check(const struct z_owned_source_info_t *this_);
 #endif
 /**
  * Frees the memory and invalidates the source info, resetting it to a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void z_source_info_drop(z_moved_source_info_t this_);
+ZENOHC_API void z_source_info_drop(struct z_moved_source_info_t this_);
 #endif
 /**
  * Returns the source_id of the source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_entity_global_id_t z_source_info_id(const z_loaned_source_info_t *this_);
+ZENOHC_API struct z_entity_global_id_t z_source_info_id(const struct z_loaned_source_info_t *this_);
 #endif
 /**
  * Borrows source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API const z_loaned_source_info_t *z_source_info_loan(const z_owned_source_info_t *this_);
+ZENOHC_API
+const struct z_loaned_source_info_t *z_source_info_loan(const struct z_owned_source_info_t *this_);
 #endif
 /**
  * Create source info
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t z_source_info_new(z_owned_source_info_t *this_,
-                             const z_entity_global_id_t *source_id,
+z_result_t z_source_info_new(struct z_owned_source_info_t *this_,
+                             const struct z_entity_global_id_t *source_id,
                              uint64_t source_sn);
 #endif
 /**
  * Constructs source info in its gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void z_source_info_null(z_owned_source_info_t *this_);
+ZENOHC_API void z_source_info_null(struct z_owned_source_info_t *this_);
 #endif
 /**
  * Returns the source_sn of the source info.
  */
 #if defined(UNSTABLE)
-ZENOHC_API uint64_t z_source_info_sn(const z_loaned_source_info_t *this_);
+ZENOHC_API uint64_t z_source_info_sn(const struct z_loaned_source_info_t *this_);
 #endif
 /**
  * @return ``true`` if the string array is valid, ``false`` if it is in a gravestone state.
@@ -4158,7 +4019,7 @@ z_result_t z_task_init(struct z_owned_task_t *this_,
 /**
  * Joins the task and releases all allocated resources
  */
-ZENOHC_API z_result_t z_task_join(struct z_moved_task_t this_);
+ZENOHC_API z_result_t z_task_join(struct z_moved_task_t *this_);
 /**
  * Constructs task in a gravestone state.
  */
@@ -4193,7 +4054,7 @@ const char *z_time_now_as_str(const char *buf,
  * Returns id associated with this timestamp.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
+ZENOHC_API struct z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
 #endif
 /**
  * Create uhlc timestamp from session id.
@@ -4211,26 +4072,26 @@ ZENOHC_API uint64_t z_timestamp_ntp64_time(const struct z_timestamp_t *this_);
  * @return 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API
-z_result_t z_undeclare_keyexpr(struct z_moved_keyexpr_t this_,
+z_result_t z_undeclare_keyexpr(struct z_moved_keyexpr_t *this_,
                                const struct z_loaned_session_t *session);
 /**
  * Undeclares the given publisher, droping and invalidating it.
  *
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_result_t z_undeclare_publisher(struct z_moved_publisher_t this_);
+ZENOHC_API z_result_t z_undeclare_publisher(struct z_moved_publisher_t *_this);
 /**
  * Undeclares a `z_owned_queryable_t` and drops it.
  *
  * Returns 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_result_t z_undeclare_queryable(struct z_moved_queryable_t this_);
+ZENOHC_API z_result_t z_undeclare_queryable(struct z_moved_queryable_t *this_);
 /**
  * Undeclares subscriber and drops subscriber.
  *
  * @return 0 in case of success, negative error code otherwise.
  */
-ZENOHC_API z_result_t z_undeclare_subscriber(struct z_moved_subscriber_t this_);
+ZENOHC_API z_result_t z_undeclare_subscriber(struct z_moved_subscriber_t *_this);
 /**
  * Constructs a view key expression in empty state
  */
@@ -4561,7 +4422,7 @@ z_result_t zc_liveliness_declare_subscriber(struct z_owned_subscriber_t *this_,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_liveliness_declare_token(zc_owned_liveliness_token_t *this_,
+z_result_t zc_liveliness_declare_token(struct zc_owned_liveliness_token_t *this_,
                                        const struct z_loaned_session_t *session,
                                        const struct z_loaned_keyexpr_t *key_expr,
                                        const struct zc_liveliness_declaration_options_t *_options);
@@ -4598,32 +4459,32 @@ void zc_liveliness_subscriber_options_default(struct zc_liveliness_subscriber_op
  * Returns ``true`` if liveliness token is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool zc_liveliness_token_check(const zc_owned_liveliness_token_t *this_);
+ZENOHC_API bool zc_liveliness_token_check(const struct zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Undeclares liveliness token, frees memory and resets it to a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_liveliness_token_drop(zc_moved_liveliness_token_t this_);
+ZENOHC_API void zc_liveliness_token_drop(struct zc_moved_liveliness_token_t this_);
 #endif
 /**
  * Borrows token.
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const zc_owned_liveliness_token_t *this_);
+const struct zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const struct zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Constructs liveliness token in its gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_liveliness_token_null(zc_owned_liveliness_token_t *this_);
+ZENOHC_API void zc_liveliness_token_null(struct zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * Destroys a liveliness token, notifying subscribers of its destruction.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t zc_liveliness_undeclare_token(zc_moved_liveliness_token_t this_);
+ZENOHC_API z_result_t zc_liveliness_undeclare_token(struct zc_moved_liveliness_token_t this_);
 #endif
 /**
  * Returns default value of `zc_locality_t`
@@ -4635,13 +4496,13 @@ ZENOHC_API enum zc_locality_t zc_locality_default(void);
  * Checks the matching listener is for the gravestone state
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool zc_matching_listener_check(const zc_owned_matching_listener_t *this_);
+ZENOHC_API bool zc_matching_listener_check(const struct zc_owned_matching_listener_t *this_);
 #endif
 /**
  * Constructs an empty matching listener
  */
 #if defined(UNSTABLE)
-ZENOHC_API void zc_matching_listener_null(zc_owned_matching_listener_t *this_);
+ZENOHC_API void zc_matching_listener_null(struct zc_owned_matching_listener_t *this_);
 #endif
 /**
  * Gets publisher matching status - i.e. if there are any subscribers matching its key expression.
@@ -4664,7 +4525,7 @@ z_result_t zc_publisher_get_matching_status(const struct z_loaned_publisher_t *t
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_publisher_matching_listener_declare(zc_owned_matching_listener_t *this_,
+z_result_t zc_publisher_matching_listener_declare(struct zc_owned_matching_listener_t *this_,
                                                   const struct z_loaned_publisher_t *publisher,
                                                   struct zc_moved_closure_matching_status_t callback);
 #endif
@@ -4674,7 +4535,8 @@ z_result_t zc_publisher_matching_listener_declare(zc_owned_matching_listener_t *
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t zc_publisher_matching_listener_drop(zc_moved_matching_listener_t *this_);
+ZENOHC_API
+z_result_t zc_publisher_matching_listener_drop(struct zc_moved_matching_listener_t *this_);
 #endif
 /**
  * Undeclares the given matching listener, droping and invalidating it.
@@ -4694,46 +4556,46 @@ ZENOHC_API enum zc_reply_keyexpr_t zc_reply_keyexpr_default(void);
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t zc_shm_client_list_add_client(z_protocol_id_t id,
-                                         z_moved_shm_client_t client,
-                                         zc_loaned_shm_client_list_t *list);
+                                         struct z_moved_shm_client_t client,
+                                         struct zc_loaned_shm_client_list_t *list);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool zc_shm_client_list_check(const zc_owned_shm_client_list_t *this_);
+ZENOHC_API bool zc_shm_client_list_check(const struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Deletes list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_drop(zc_moved_shm_client_list_t this_);
+ZENOHC_API void zc_shm_client_list_drop(struct zc_moved_shm_client_list_t this_);
 #endif
 /**
  * Borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const zc_owned_shm_client_list_t *this_);
+const struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Mutably borrows list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(zc_owned_shm_client_list_t *this_);
+struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Creates a new empty list of SHM Clients
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_new(zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_new(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Constructs SHM client list in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void zc_shm_client_list_null(zc_owned_shm_client_list_t *this_);
+ZENOHC_API void zc_shm_client_list_null(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Stops all Zenoh tasks and drops all related static variables.
@@ -4755,7 +4617,7 @@ void zc_stop_z_runtime(void);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_declare_publication_cache(ze_owned_publication_cache_t *this_,
+z_result_t ze_declare_publication_cache(struct ze_owned_publication_cache_t *this_,
                                         const struct z_loaned_session_t *session,
                                         const struct z_loaned_keyexpr_t *key_expr,
                                         struct ze_publication_cache_options_t *options);
@@ -4773,7 +4635,7 @@ z_result_t ze_declare_publication_cache(ze_owned_publication_cache_t *this_,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_declare_querying_subscriber(ze_owned_querying_subscriber_t *this_,
+z_result_t ze_declare_querying_subscriber(struct ze_owned_querying_subscriber_t *this_,
                                           const struct z_loaned_session_t *session,
                                           const struct z_loaned_keyexpr_t *key_expr,
                                           struct z_moved_closure_sample_t callback,
@@ -4783,19 +4645,19 @@ z_result_t ze_declare_querying_subscriber(ze_owned_querying_subscriber_t *this_,
  * Returns ``true`` if publication cache is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool ze_publication_cache_check(const ze_owned_publication_cache_t *this_);
+ZENOHC_API bool ze_publication_cache_check(const struct ze_owned_publication_cache_t *this_);
 #endif
 /**
  * Drops publication cache. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_publication_cache_drop(ze_moved_publication_cache_t this_);
+ZENOHC_API void ze_publication_cache_drop(struct ze_moved_publication_cache_t this_);
 #endif
 /**
  * Constructs a publication cache in a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_publication_cache_null(ze_owned_publication_cache_t *this_);
+ZENOHC_API void ze_publication_cache_null(struct ze_owned_publication_cache_t *this_);
 #endif
 /**
  * Constructs the default value for `ze_publication_cache_options_t`.
@@ -4807,13 +4669,13 @@ ZENOHC_API void ze_publication_cache_options_default(struct ze_publication_cache
  * Returns ``true`` if querying subscriber is valid, ``false`` otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API bool ze_querying_subscriber_check(const ze_owned_querying_subscriber_t *this_);
+ZENOHC_API bool ze_querying_subscriber_check(const struct ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Drops querying subscriber. Also attempts to undeclare it.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_querying_subscriber_drop(ze_moved_querying_subscriber_t this_);
+ZENOHC_API void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_t this_);
 #endif
 /**
  * Make querying subscriber perform an additional query on a specified selector.
@@ -4822,7 +4684,7 @@ ZENOHC_API void ze_querying_subscriber_drop(ze_moved_querying_subscriber_t this_
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_querying_subscriber_get(const ze_loaned_querying_subscriber_t *this_,
+z_result_t ze_querying_subscriber_get(const struct ze_loaned_querying_subscriber_t *this_,
                                       const struct z_loaned_keyexpr_t *selector,
                                       struct z_get_options_t *options);
 #endif
@@ -4831,13 +4693,13 @@ z_result_t ze_querying_subscriber_get(const ze_loaned_querying_subscriber_t *thi
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const ze_owned_querying_subscriber_t *this_);
+const struct ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const struct ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Constructs a querying subscriber in a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_querying_subscriber_null(ze_owned_querying_subscriber_t *this_);
+ZENOHC_API void ze_querying_subscriber_null(struct ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Constructs the default value for `ze_querying_subscriber_options_t`.
@@ -4851,7 +4713,7 @@ void ze_querying_subscriber_options_default(struct ze_querying_subscriber_option
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t ze_undeclare_publication_cache(ze_moved_publication_cache_t this_);
+ZENOHC_API z_result_t ze_undeclare_publication_cache(struct ze_moved_publication_cache_t this_);
 #endif
 /**
  * Undeclares the given querying subscriber, drops it and resets to a gravestone state.
@@ -4859,5 +4721,5 @@ ZENOHC_API z_result_t ze_undeclare_publication_cache(ze_moved_publication_cache_
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t ze_undeclare_querying_subscriber(ze_moved_querying_subscriber_t this_);
+ZENOHC_API z_result_t ze_undeclare_querying_subscriber(struct ze_moved_querying_subscriber_t this_);
 #endif

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -4,14 +4,11 @@
 
 #ifndef __cplusplus
 
-static inline z_moved_alloc_layout_t z_alloc_layout_move(z_owned_alloc_layout_t* x) { return (z_moved_alloc_layout_t){x}; }
 static inline z_moved_bytes_t z_bytes_move(z_owned_bytes_t* x) { return (z_moved_bytes_t){x}; }
-static inline z_moved_chunk_alloc_result_t z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return (z_moved_chunk_alloc_result_t){x}; }
 static inline z_moved_closure_hello_t z_closure_hello_move(z_owned_closure_hello_t* x) { return (z_moved_closure_hello_t){x}; }
 static inline z_moved_closure_query_t z_closure_query_move(z_owned_closure_query_t* x) { return (z_moved_closure_query_t){x}; }
 static inline z_moved_closure_reply_t z_closure_reply_move(z_owned_closure_reply_t* x) { return (z_moved_closure_reply_t){x}; }
 static inline z_moved_closure_sample_t z_closure_sample_move(z_owned_closure_sample_t* x) { return (z_moved_closure_sample_t){x}; }
-static inline z_moved_closure_zid_t z_closure_zid_move(z_owned_closure_zid_t* x) { return (z_moved_closure_zid_t){x}; }
 static inline z_moved_condvar_t z_condvar_move(z_owned_condvar_t* x) { return (z_moved_condvar_t){x}; }
 static inline z_moved_config_t z_config_move(z_owned_config_t* x) { return (z_moved_config_t){x}; }
 static inline z_moved_encoding_t z_encoding_move(z_owned_encoding_t* x) { return (z_moved_encoding_t){x}; }
@@ -20,7 +17,6 @@ static inline z_moved_fifo_handler_reply_t z_fifo_handler_reply_move(z_owned_fif
 static inline z_moved_fifo_handler_sample_t z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return (z_moved_fifo_handler_sample_t){x}; }
 static inline z_moved_hello_t z_hello_move(z_owned_hello_t* x) { return (z_moved_hello_t){x}; }
 static inline z_moved_keyexpr_t z_keyexpr_move(z_owned_keyexpr_t* x) { return (z_moved_keyexpr_t){x}; }
-static inline z_moved_memory_layout_t z_memory_layout_move(z_owned_memory_layout_t* x) { return (z_moved_memory_layout_t){x}; }
 static inline z_moved_mutex_t z_mutex_move(z_owned_mutex_t* x) { return (z_moved_mutex_t){x}; }
 static inline z_moved_publisher_t z_publisher_move(z_owned_publisher_t* x) { return (z_moved_publisher_t){x}; }
 static inline z_moved_query_t z_query_move(z_owned_query_t* x) { return (z_moved_query_t){x}; }
@@ -32,36 +28,21 @@ static inline z_moved_ring_handler_reply_t z_ring_handler_reply_move(z_owned_rin
 static inline z_moved_ring_handler_sample_t z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return (z_moved_ring_handler_sample_t){x}; }
 static inline z_moved_sample_t z_sample_move(z_owned_sample_t* x) { return (z_moved_sample_t){x}; }
 static inline z_moved_session_t z_session_move(z_owned_session_t* x) { return (z_moved_session_t){x}; }
-static inline z_moved_shm_client_t z_shm_client_move(z_owned_shm_client_t* x) { return (z_moved_shm_client_t){x}; }
-static inline z_moved_shm_client_storage_t z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return (z_moved_shm_client_storage_t){x}; }
-static inline z_moved_shm_t z_shm_move(z_owned_shm_t* x) { return (z_moved_shm_t){x}; }
-static inline z_moved_shm_mut_t z_shm_mut_move(z_owned_shm_mut_t* x) { return (z_moved_shm_mut_t){x}; }
-static inline z_moved_shm_provider_t z_shm_provider_move(z_owned_shm_provider_t* x) { return (z_moved_shm_provider_t){x}; }
 static inline z_moved_slice_t z_slice_move(z_owned_slice_t* x) { return (z_moved_slice_t){x}; }
-static inline z_moved_source_info_t z_source_info_move(z_owned_source_info_t* x) { return (z_moved_source_info_t){x}; }
 static inline z_moved_string_array_t z_string_array_move(z_owned_string_array_t* x) { return (z_moved_string_array_t){x}; }
 static inline z_moved_string_t z_string_move(z_owned_string_t* x) { return (z_moved_string_t){x}; }
 static inline z_moved_subscriber_t z_subscriber_move(z_owned_subscriber_t* x) { return (z_moved_subscriber_t){x}; }
 static inline z_moved_task_t z_task_move(z_owned_task_t* x) { return (z_moved_task_t){x}; }
 static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t* x) { return (zc_moved_closure_log_t){x}; }
-static inline zc_moved_closure_matching_status_t zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return (zc_moved_closure_matching_status_t){x}; }
-static inline zc_moved_liveliness_token_t zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return (zc_moved_liveliness_token_t){x}; }
-static inline zc_moved_matching_listener_t zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return (zc_moved_matching_listener_t){x}; }
-static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return (zc_moved_shm_client_list_t){x}; }
-static inline ze_moved_publication_cache_t ze_publication_cache_move(ze_owned_publication_cache_t* x) { return (ze_moved_publication_cache_t){x}; }
-static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return (ze_moved_querying_subscriber_t){x}; }
 
 
 #define z_loan(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_alloc_layout_loan, \
         z_owned_bytes_t : z_bytes_loan, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_loan, \
         z_owned_closure_hello_t : z_closure_hello_loan, \
         z_owned_closure_query_t : z_closure_query_loan, \
         z_owned_closure_reply_t : z_closure_reply_loan, \
         z_owned_closure_sample_t : z_closure_sample_loan, \
-        z_owned_closure_zid_t : z_closure_zid_loan, \
         z_owned_condvar_t : z_condvar_loan, \
         z_owned_config_t : z_config_loan, \
         z_owned_encoding_t : z_encoding_loan, \
@@ -70,7 +51,6 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_loan, \
         z_owned_hello_t : z_hello_loan, \
         z_owned_keyexpr_t : z_keyexpr_loan, \
-        z_owned_memory_layout_t : z_memory_layout_loan, \
         z_owned_publisher_t : z_publisher_loan, \
         z_owned_query_t : z_query_loan, \
         z_owned_queryable_t : z_queryable_loan, \
@@ -81,23 +61,14 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_ring_handler_sample_t : z_ring_handler_sample_loan, \
         z_owned_sample_t : z_sample_loan, \
         z_owned_session_t : z_session_loan, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_loan, \
-        z_owned_shm_t : z_shm_loan, \
-        z_owned_shm_mut_t : z_shm_mut_loan, \
-        z_owned_shm_provider_t : z_shm_provider_loan, \
         z_owned_slice_t : z_slice_loan, \
-        z_owned_source_info_t : z_source_info_loan, \
         z_owned_string_array_t : z_string_array_loan, \
         z_owned_string_t : z_string_loan, \
         z_owned_subscriber_t : z_subscriber_loan, \
         z_view_keyexpr_t : z_view_keyexpr_loan, \
         z_view_slice_t : z_view_slice_loan, \
         z_view_string_t : z_view_string_loan, \
-        zc_owned_closure_log_t : zc_closure_log_loan, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_loan, \
-        zc_owned_liveliness_token_t : zc_liveliness_token_loan, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_loan, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_loan \
+        zc_owned_closure_log_t : zc_closure_log_loan \
     )(&this_)
 
 #define z_loan_mut(this_) \
@@ -108,22 +79,16 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_encoding_t : z_encoding_loan_mut, \
         z_owned_mutex_t : z_mutex_loan_mut, \
         z_owned_publisher_t : z_publisher_loan_mut, \
-        z_owned_shm_t : z_shm_loan_mut, \
-        z_owned_shm_mut_t : z_shm_mut_loan_mut, \
-        z_owned_string_array_t : z_string_array_loan_mut, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_loan_mut \
+        z_owned_string_array_t : z_string_array_loan_mut \
     )(&this_)
 
 #define z_drop(this_) \
     _Generic((this_), \
-        z_moved_alloc_layout_t : z_alloc_layout_drop, \
         z_moved_bytes_t : z_bytes_drop, \
-        z_moved_chunk_alloc_result_t : z_chunk_alloc_result_drop, \
         z_moved_closure_hello_t : z_closure_hello_drop, \
         z_moved_closure_query_t : z_closure_query_drop, \
         z_moved_closure_reply_t : z_closure_reply_drop, \
         z_moved_closure_sample_t : z_closure_sample_drop, \
-        z_moved_closure_zid_t : z_closure_zid_drop, \
         z_moved_condvar_t : z_condvar_drop, \
         z_moved_config_t : z_config_drop, \
         z_moved_encoding_t : z_encoding_drop, \
@@ -132,7 +97,6 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_moved_fifo_handler_sample_t : z_fifo_handler_sample_drop, \
         z_moved_hello_t : z_hello_drop, \
         z_moved_keyexpr_t : z_keyexpr_drop, \
-        z_moved_memory_layout_t : z_memory_layout_drop, \
         z_moved_mutex_t : z_mutex_drop, \
         z_moved_publisher_t : z_publisher_drop, \
         z_moved_query_t : z_query_drop, \
@@ -144,36 +108,21 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_moved_ring_handler_sample_t : z_ring_handler_sample_drop, \
         z_moved_sample_t : z_sample_drop, \
         z_moved_session_t : z_session_drop, \
-        z_moved_shm_client_t : z_shm_client_drop, \
-        z_moved_shm_client_storage_t : z_shm_client_storage_drop, \
-        z_moved_shm_t : z_shm_drop, \
-        z_moved_shm_mut_t : z_shm_mut_drop, \
-        z_moved_shm_provider_t : z_shm_provider_drop, \
         z_moved_slice_t : z_slice_drop, \
-        z_moved_source_info_t : z_source_info_drop, \
         z_moved_string_array_t : z_string_array_drop, \
         z_moved_string_t : z_string_drop, \
         z_moved_subscriber_t : z_subscriber_drop, \
         z_moved_task_t : z_task_drop, \
-        zc_moved_closure_log_t : zc_closure_log_drop, \
-        zc_moved_closure_matching_status_t : zc_closure_matching_status_drop, \
-        zc_moved_liveliness_token_t : zc_liveliness_token_drop, \
-        zc_moved_matching_listener_t : zc_publisher_matching_listener_drop, \
-        zc_moved_shm_client_list_t : zc_shm_client_list_drop, \
-        ze_moved_publication_cache_t : ze_publication_cache_drop, \
-        ze_moved_querying_subscriber_t : ze_querying_subscriber_drop \
+        zc_moved_closure_log_t : zc_closure_log_drop \
     )(this_)
 
 #define z_move(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_alloc_layout_move, \
         z_owned_bytes_t : z_bytes_move, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_move, \
         z_owned_closure_hello_t : z_closure_hello_move, \
         z_owned_closure_query_t : z_closure_query_move, \
         z_owned_closure_reply_t : z_closure_reply_move, \
         z_owned_closure_sample_t : z_closure_sample_move, \
-        z_owned_closure_zid_t : z_closure_zid_move, \
         z_owned_condvar_t : z_condvar_move, \
         z_owned_config_t : z_config_move, \
         z_owned_encoding_t : z_encoding_move, \
@@ -182,7 +131,6 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_move, \
         z_owned_hello_t : z_hello_move, \
         z_owned_keyexpr_t : z_keyexpr_move, \
-        z_owned_memory_layout_t : z_memory_layout_move, \
         z_owned_mutex_t : z_mutex_move, \
         z_owned_publisher_t : z_publisher_move, \
         z_owned_query_t : z_query_move, \
@@ -194,36 +142,21 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_ring_handler_sample_t : z_ring_handler_sample_move, \
         z_owned_sample_t : z_sample_move, \
         z_owned_session_t : z_session_move, \
-        z_owned_shm_client_t : z_shm_client_move, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_move, \
-        z_owned_shm_t : z_shm_move, \
-        z_owned_shm_mut_t : z_shm_mut_move, \
-        z_owned_shm_provider_t : z_shm_provider_move, \
         z_owned_slice_t : z_slice_move, \
-        z_owned_source_info_t : z_source_info_move, \
         z_owned_string_array_t : z_string_array_move, \
         z_owned_string_t : z_string_move, \
         z_owned_subscriber_t : z_subscriber_move, \
         z_owned_task_t : z_task_move, \
-        zc_owned_closure_log_t : zc_closure_log_move, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_move, \
-        zc_owned_liveliness_token_t : zc_liveliness_token_move, \
-        zc_owned_matching_listener_t : zc_publisher_matching_listener_move, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_move, \
-        ze_owned_publication_cache_t : ze_publication_cache_move, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_move \
+        zc_owned_closure_log_t : zc_closure_log_move \
     )(&this_)
 
 #define z_null(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t* : z_alloc_layout_null, \
         z_owned_bytes_t* : z_bytes_null, \
-        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_null, \
         z_owned_closure_hello_t* : z_closure_hello_null, \
         z_owned_closure_query_t* : z_closure_query_null, \
         z_owned_closure_reply_t* : z_closure_reply_null, \
         z_owned_closure_sample_t* : z_closure_sample_null, \
-        z_owned_closure_zid_t* : z_closure_zid_null, \
         z_owned_condvar_t* : z_condvar_null, \
         z_owned_config_t* : z_config_null, \
         z_owned_encoding_t* : z_encoding_null, \
@@ -232,7 +165,6 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_null, \
         z_owned_hello_t* : z_hello_null, \
         z_owned_keyexpr_t* : z_keyexpr_null, \
-        z_owned_memory_layout_t* : z_memory_layout_null, \
         z_owned_mutex_t* : z_mutex_null, \
         z_owned_publisher_t* : z_publisher_null, \
         z_owned_query_t* : z_query_null, \
@@ -244,34 +176,19 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_null, \
         z_owned_sample_t* : z_sample_null, \
         z_owned_session_t* : z_session_null, \
-        z_owned_shm_client_t* : z_shm_client_null, \
-        z_owned_shm_client_storage_t* : z_shm_client_storage_null, \
-        z_owned_shm_mut_t* : z_shm_mut_null, \
-        z_owned_shm_t* : z_shm_null, \
-        z_owned_shm_provider_t* : z_shm_provider_null, \
         z_owned_slice_t* : z_slice_null, \
-        z_owned_source_info_t* : z_source_info_null, \
         z_owned_string_array_t* : z_string_array_null, \
         z_owned_string_t* : z_string_null, \
         z_owned_subscriber_t* : z_subscriber_null, \
         z_owned_task_t* : z_task_null, \
-        zc_owned_closure_log_t* : zc_closure_log_null, \
-        zc_owned_closure_matching_status_t* : zc_closure_matching_status_null, \
-        zc_owned_liveliness_token_t* : zc_liveliness_token_null, \
-        zc_owned_matching_listener_t* : zc_matching_listener_null, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_null, \
-        ze_owned_publication_cache_t* : ze_publication_cache_null, \
-        ze_owned_querying_subscriber_t* : ze_querying_subscriber_null \
+        zc_owned_closure_log_t* : zc_closure_log_null \
     )(this_)
 
-static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t x) { *this_ = *x._ptr; z_alloc_layout_null(x._ptr); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t x) { *this_ = *x._ptr; z_bytes_null(x._ptr); }
-static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) { *this_ = *x._ptr; z_chunk_alloc_result_null(x._ptr); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t x) { *this_ = *x._ptr; z_closure_hello_null(x._ptr); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t x) { *closure_ = *x._ptr; z_closure_query_null(x._ptr); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t x) { *closure_ = *x._ptr; z_closure_reply_null(x._ptr); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t x) { *closure_ = *x._ptr; z_closure_sample_null(x._ptr); }
-static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t x) { *closure_ = *x._ptr; z_closure_zid_null(x._ptr); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t x) { *this_ = *x._ptr; z_condvar_null(x._ptr); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t x) { *this_ = *x._ptr; z_config_null(x._ptr); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t x) { *this_ = *x._ptr; z_encoding_null(x._ptr); }
@@ -280,7 +197,6 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t x) { *this_ = *x._ptr; z_fifo_handler_sample_null(x._ptr); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *this_ = *x._ptr; z_hello_null(x._ptr); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
-static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) { *this_ = *x._ptr; z_memory_layout_null(x._ptr); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t x) { *this_ = *x._ptr; z_publisher_null(x._ptr); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
@@ -292,36 +208,21 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t x) { *this_ = *x._ptr; z_ring_handler_sample_null(x._ptr); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t x) { *this_ = *x._ptr; z_sample_null(x._ptr); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t x) { *this_ = *x._ptr; z_session_null(x._ptr); }
-static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t x) { *this_ = *x._ptr; z_shm_client_null(x._ptr); }
-static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t x) { *this_ = *x._ptr; z_shm_client_storage_null(x._ptr); }
-static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t x) { *this_ = *x._ptr; z_shm_null(x._ptr); }
-static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t x) { *this_ = *x._ptr; z_shm_mut_null(x._ptr); }
-static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t x) { *this_ = *x._ptr; z_shm_provider_null(x._ptr); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t x) { *this_ = *x._ptr; z_slice_null(x._ptr); }
-static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t x) { *this_ = *x._ptr; z_source_info_null(x._ptr); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t x) { *this_ = *x._ptr; z_string_array_null(x._ptr); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t x) { *this_ = *x._ptr; z_string_null(x._ptr); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) { *this_ = *x._ptr; z_subscriber_null(x._ptr); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t x) { *this_ = *x._ptr; z_task_null(x._ptr); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t x) { *closure_ = *x._ptr; zc_closure_log_null(x._ptr); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t x) { *closure_ = *x._ptr; zc_closure_matching_status_null(x._ptr); }
-static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
-static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t x) { *this_ = *x._ptr; zc_matching_listener_null(x._ptr); }
-static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) { *this_ = *x._ptr; ze_publication_cache_null(x._ptr); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) { *this_ = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 #define z_take(this_, x) \
     _Generic((this_), \
-        z_owned_alloc_layout_t* : z_alloc_layout_take, \
         z_owned_bytes_t* : z_bytes_take, \
-        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_take, \
         z_owned_closure_hello_t* : z_closure_hello_take, \
         z_owned_closure_query_t* : z_closure_query_take, \
         z_owned_closure_reply_t* : z_closure_reply_take, \
         z_owned_closure_sample_t* : z_closure_sample_take, \
-        z_owned_closure_zid_t* : z_closure_zid_take, \
         z_owned_condvar_t* : z_condvar_take, \
         z_owned_config_t* : z_config_take, \
         z_owned_encoding_t* : z_encoding_take, \
@@ -330,7 +231,6 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_take, \
         z_owned_hello_t* : z_hello_take, \
         z_owned_keyexpr_t* : z_keyexpr_take, \
-        z_owned_memory_layout_t* : z_memory_layout_take, \
         z_owned_mutex_t* : z_mutex_take, \
         z_owned_publisher_t* : z_publisher_take, \
         z_owned_query_t* : z_query_take, \
@@ -342,36 +242,21 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_take, \
         z_owned_sample_t* : z_sample_take, \
         z_owned_session_t* : z_session_take, \
-        z_owned_shm_client_t* : z_shm_client_take, \
-        z_owned_shm_client_storage_t* : z_shm_client_storage_take, \
-        z_owned_shm_t* : z_shm_take, \
-        z_owned_shm_mut_t* : z_shm_mut_take, \
-        z_owned_shm_provider_t* : z_shm_provider_take, \
         z_owned_slice_t* : z_slice_take, \
-        z_owned_source_info_t* : z_source_info_take, \
         z_owned_string_array_t* : z_string_array_take, \
         z_owned_string_t* : z_string_take, \
         z_owned_subscriber_t* : z_subscriber_take, \
         z_owned_task_t* : z_task_take, \
-        zc_owned_closure_log_t* : zc_closure_log_take, \
-        zc_owned_closure_matching_status_t* : zc_closure_matching_status_take, \
-        zc_owned_liveliness_token_t* : zc_liveliness_token_take, \
-        zc_owned_matching_listener_t* : zc_publisher_matching_listener_take, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_take, \
-        ze_owned_publication_cache_t* : ze_publication_cache_take, \
-        ze_owned_querying_subscriber_t* : ze_querying_subscriber_take \
+        zc_owned_closure_log_t* : zc_closure_log_take \
     )(this_, x)
 
 #define z_check(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_alloc_layout_check, \
         z_owned_bytes_t : z_bytes_check, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_check, \
         z_owned_closure_hello_t : z_closure_hello_check, \
         z_owned_closure_query_t : z_closure_query_check, \
         z_owned_closure_reply_t : z_closure_reply_check, \
         z_owned_closure_sample_t : z_closure_sample_check, \
-        z_owned_closure_zid_t : z_closure_zid_check, \
         z_owned_condvar_t : z_condvar_check, \
         z_owned_config_t : z_config_check, \
         z_owned_encoding_t : z_encoding_check, \
@@ -380,7 +265,6 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_check, \
         z_owned_hello_t : z_hello_check, \
         z_owned_keyexpr_t : z_keyexpr_check, \
-        z_owned_memory_layout_t : z_memory_layout_check, \
         z_owned_mutex_t : z_mutex_check, \
         z_owned_publisher_t : z_publisher_check, \
         z_owned_query_t : z_query_check, \
@@ -392,24 +276,12 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_ring_handler_sample_t : z_ring_handler_sample_check, \
         z_owned_sample_t : z_sample_check, \
         z_owned_session_t : z_session_check, \
-        z_owned_shm_t : z_shm_check, \
-        z_owned_shm_client_t : z_shm_client_check, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_check, \
-        z_owned_shm_mut_t : z_shm_mut_check, \
-        z_owned_shm_provider_t : z_shm_provider_check, \
         z_owned_slice_t : z_slice_check, \
-        z_owned_source_info_t : z_source_info_check, \
         z_owned_string_array_t : z_string_array_check, \
         z_owned_string_t : z_string_check, \
         z_owned_subscriber_t : z_subscriber_check, \
         z_owned_task_t : z_task_check, \
-        zc_owned_closure_log_t : zc_closure_log_check, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_check, \
-        zc_owned_liveliness_token_t : zc_liveliness_token_check, \
-        zc_owned_matching_listener_t : zc_matching_listener_check, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_check, \
-        ze_owned_publication_cache_t : ze_publication_cache_check, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_check \
+        zc_owned_closure_log_t : zc_closure_log_check \
     )(&this_)
 
 #define z_call(closure, hello) \
@@ -417,9 +289,7 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         const z_loaned_closure_hello_t* : z_closure_hello_call, \
         const z_loaned_closure_query_t* : z_closure_query_call, \
         const z_loaned_closure_reply_t* : z_closure_reply_call, \
-        const z_loaned_closure_sample_t* : z_closure_sample_call, \
-        const z_loaned_closure_zid_t* : z_closure_zid_call, \
-        const zc_loaned_closure_matching_status_t* : zc_closure_matching_status_call \
+        const z_loaned_closure_sample_t* : z_closure_sample_call \
     )(closure, hello)
 
 #define z_closure(x, callback, dropper, ctx) \
@@ -447,14 +317,11 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
 #else  // #ifndef __cplusplus
 
 
-static inline z_moved_alloc_layout_t z_alloc_layout_move(z_owned_alloc_layout_t* x) { return z_moved_alloc_layout_t{x}; }
 static inline z_moved_bytes_t z_bytes_move(z_owned_bytes_t* x) { return z_moved_bytes_t{x}; }
-static inline z_moved_chunk_alloc_result_t z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return z_moved_chunk_alloc_result_t{x}; }
 static inline z_moved_closure_hello_t z_closure_hello_move(z_owned_closure_hello_t* x) { return z_moved_closure_hello_t{x}; }
 static inline z_moved_closure_query_t z_closure_query_move(z_owned_closure_query_t* x) { return z_moved_closure_query_t{x}; }
 static inline z_moved_closure_reply_t z_closure_reply_move(z_owned_closure_reply_t* x) { return z_moved_closure_reply_t{x}; }
 static inline z_moved_closure_sample_t z_closure_sample_move(z_owned_closure_sample_t* x) { return z_moved_closure_sample_t{x}; }
-static inline z_moved_closure_zid_t z_closure_zid_move(z_owned_closure_zid_t* x) { return z_moved_closure_zid_t{x}; }
 static inline z_moved_condvar_t z_condvar_move(z_owned_condvar_t* x) { return z_moved_condvar_t{x}; }
 static inline z_moved_config_t z_config_move(z_owned_config_t* x) { return z_moved_config_t{x}; }
 static inline z_moved_encoding_t z_encoding_move(z_owned_encoding_t* x) { return z_moved_encoding_t{x}; }
@@ -463,7 +330,6 @@ static inline z_moved_fifo_handler_reply_t z_fifo_handler_reply_move(z_owned_fif
 static inline z_moved_fifo_handler_sample_t z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return z_moved_fifo_handler_sample_t{x}; }
 static inline z_moved_hello_t z_hello_move(z_owned_hello_t* x) { return z_moved_hello_t{x}; }
 static inline z_moved_keyexpr_t z_keyexpr_move(z_owned_keyexpr_t* x) { return z_moved_keyexpr_t{x}; }
-static inline z_moved_memory_layout_t z_memory_layout_move(z_owned_memory_layout_t* x) { return z_moved_memory_layout_t{x}; }
 static inline z_moved_mutex_t z_mutex_move(z_owned_mutex_t* x) { return z_moved_mutex_t{x}; }
 static inline z_moved_publisher_t z_publisher_move(z_owned_publisher_t* x) { return z_moved_publisher_t{x}; }
 static inline z_moved_query_t z_query_move(z_owned_query_t* x) { return z_moved_query_t{x}; }
@@ -475,35 +341,20 @@ static inline z_moved_ring_handler_reply_t z_ring_handler_reply_move(z_owned_rin
 static inline z_moved_ring_handler_sample_t z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return z_moved_ring_handler_sample_t{x}; }
 static inline z_moved_sample_t z_sample_move(z_owned_sample_t* x) { return z_moved_sample_t{x}; }
 static inline z_moved_session_t z_session_move(z_owned_session_t* x) { return z_moved_session_t{x}; }
-static inline z_moved_shm_client_t z_shm_client_move(z_owned_shm_client_t* x) { return z_moved_shm_client_t{x}; }
-static inline z_moved_shm_client_storage_t z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return z_moved_shm_client_storage_t{x}; }
-static inline z_moved_shm_t z_shm_move(z_owned_shm_t* x) { return z_moved_shm_t{x}; }
-static inline z_moved_shm_mut_t z_shm_mut_move(z_owned_shm_mut_t* x) { return z_moved_shm_mut_t{x}; }
-static inline z_moved_shm_provider_t z_shm_provider_move(z_owned_shm_provider_t* x) { return z_moved_shm_provider_t{x}; }
 static inline z_moved_slice_t z_slice_move(z_owned_slice_t* x) { return z_moved_slice_t{x}; }
-static inline z_moved_source_info_t z_source_info_move(z_owned_source_info_t* x) { return z_moved_source_info_t{x}; }
 static inline z_moved_string_array_t z_string_array_move(z_owned_string_array_t* x) { return z_moved_string_array_t{x}; }
 static inline z_moved_string_t z_string_move(z_owned_string_t* x) { return z_moved_string_t{x}; }
 static inline z_moved_subscriber_t z_subscriber_move(z_owned_subscriber_t* x) { return z_moved_subscriber_t{x}; }
 static inline z_moved_task_t z_task_move(z_owned_task_t* x) { return z_moved_task_t{x}; }
 static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t* x) { return zc_moved_closure_log_t{x}; }
-static inline zc_moved_closure_matching_status_t zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return zc_moved_closure_matching_status_t{x}; }
-static inline zc_moved_liveliness_token_t zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return zc_moved_liveliness_token_t{x}; }
-static inline zc_moved_matching_listener_t zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return zc_moved_matching_listener_t{x}; }
-static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return zc_moved_shm_client_list_t{x}; }
-static inline ze_moved_publication_cache_t ze_publication_cache_move(ze_owned_publication_cache_t* x) { return ze_moved_publication_cache_t{x}; }
-static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return ze_moved_querying_subscriber_t{x}; }
 
 
 
-inline const z_loaned_alloc_layout_t* z_loan(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_loan(&this_); };
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& this_) { return z_bytes_loan(&this_); };
-inline const z_loaned_chunk_alloc_result_t* z_loan(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_loan(&this_); };
 inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t& closure) { return z_closure_hello_loan(&closure); };
 inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t& closure) { return z_closure_query_loan(&closure); };
 inline const z_loaned_closure_reply_t* z_loan(const z_owned_closure_reply_t& closure) { return z_closure_reply_loan(&closure); };
 inline const z_loaned_closure_sample_t* z_loan(const z_owned_closure_sample_t& closure) { return z_closure_sample_loan(&closure); };
-inline const z_loaned_closure_zid_t* z_loan(const z_owned_closure_zid_t& closure) { return z_closure_zid_loan(&closure); };
 inline const z_loaned_condvar_t* z_loan(const z_owned_condvar_t& this_) { return z_condvar_loan(&this_); };
 inline const z_loaned_config_t* z_loan(const z_owned_config_t& this_) { return z_config_loan(&this_); };
 inline const z_loaned_encoding_t* z_loan(const z_owned_encoding_t& this_) { return z_encoding_loan(&this_); };
@@ -512,7 +363,6 @@ inline const z_loaned_fifo_handler_reply_t* z_loan(const z_owned_fifo_handler_re
 inline const z_loaned_fifo_handler_sample_t* z_loan(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_loan(&this_); };
 inline const z_loaned_hello_t* z_loan(const z_owned_hello_t& this_) { return z_hello_loan(&this_); };
 inline const z_loaned_keyexpr_t* z_loan(const z_owned_keyexpr_t& this_) { return z_keyexpr_loan(&this_); };
-inline const z_loaned_memory_layout_t* z_loan(const z_owned_memory_layout_t& this_) { return z_memory_layout_loan(&this_); };
 inline const z_loaned_publisher_t* z_loan(const z_owned_publisher_t& this_) { return z_publisher_loan(&this_); };
 inline const z_loaned_query_t* z_loan(const z_owned_query_t& this_) { return z_query_loan(&this_); };
 inline const z_loaned_queryable_t* z_loan(const z_owned_queryable_t& this_) { return z_queryable_loan(&this_); };
@@ -523,12 +373,7 @@ inline const z_loaned_ring_handler_reply_t* z_loan(const z_owned_ring_handler_re
 inline const z_loaned_ring_handler_sample_t* z_loan(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_loan(&this_); };
 inline const z_loaned_sample_t* z_loan(const z_owned_sample_t& this_) { return z_sample_loan(&this_); };
 inline const z_loaned_session_t* z_loan(const z_owned_session_t& this_) { return z_session_loan(&this_); };
-inline const z_loaned_shm_client_storage_t* z_loan(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_loan(&this_); };
-inline const z_loaned_shm_t* z_loan(const z_owned_shm_t& this_) { return z_shm_loan(&this_); };
-inline const z_loaned_shm_mut_t* z_loan(const z_owned_shm_mut_t& this_) { return z_shm_mut_loan(&this_); };
-inline const z_loaned_shm_provider_t* z_loan(const z_owned_shm_provider_t& this_) { return z_shm_provider_loan(&this_); };
 inline const z_loaned_slice_t* z_loan(const z_owned_slice_t& this_) { return z_slice_loan(&this_); };
-inline const z_loaned_source_info_t* z_loan(const z_owned_source_info_t& this_) { return z_source_info_loan(&this_); };
 inline const z_loaned_string_array_t* z_loan(const z_owned_string_array_t& this_) { return z_string_array_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_owned_string_t& this_) { return z_string_loan(&this_); };
 inline const z_loaned_subscriber_t* z_loan(const z_owned_subscriber_t& this_) { return z_subscriber_loan(&this_); };
@@ -536,10 +381,6 @@ inline const z_loaned_keyexpr_t* z_loan(const z_view_keyexpr_t& this_) { return 
 inline const z_loaned_slice_t* z_loan(const z_view_slice_t& this_) { return z_view_slice_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_view_string_t& this_) { return z_view_string_loan(&this_); };
 inline const zc_loaned_closure_log_t* z_loan(const zc_owned_closure_log_t& closure) { return zc_closure_log_loan(&closure); };
-inline const zc_loaned_closure_matching_status_t* z_loan(const zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_loan(&closure); };
-inline const zc_loaned_liveliness_token_t* z_loan(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_loan(&this_); };
-inline const zc_loaned_shm_client_list_t* z_loan(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan(&this_); };
-inline const ze_loaned_querying_subscriber_t* z_loan(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_loan(&this_); };
 
 
 inline z_loaned_bytes_t* z_loan_mut(z_owned_bytes_t& this_) { return z_bytes_loan_mut(&this_); };
@@ -548,20 +389,14 @@ inline z_loaned_config_t* z_loan_mut(z_owned_config_t& this_) { return z_config_
 inline z_loaned_encoding_t* z_loan_mut(z_owned_encoding_t& this_) { return z_encoding_loan_mut(&this_); };
 inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t& this_) { return z_mutex_loan_mut(&this_); };
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& this_) { return z_publisher_loan_mut(&this_); };
-inline z_loaned_shm_t* z_loan_mut(z_owned_shm_t& this_) { return z_shm_loan_mut(&this_); };
-inline z_loaned_shm_mut_t* z_loan_mut(z_owned_shm_mut_t& this_) { return z_shm_mut_loan_mut(&this_); };
 inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { return z_string_array_loan_mut(&this_); };
-inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan_mut(&this_); };
 
 
-inline void z_drop(z_moved_alloc_layout_t this_) { z_alloc_layout_drop(this_); };
 inline void z_drop(z_moved_bytes_t this_) { z_bytes_drop(this_); };
-inline void z_drop(z_moved_chunk_alloc_result_t this_) { z_chunk_alloc_result_drop(this_); };
 inline void z_drop(z_moved_closure_hello_t this_) { z_closure_hello_drop(this_); };
 inline void z_drop(z_moved_closure_query_t closure_) { z_closure_query_drop(closure_); };
 inline void z_drop(z_moved_closure_reply_t closure_) { z_closure_reply_drop(closure_); };
 inline void z_drop(z_moved_closure_sample_t closure_) { z_closure_sample_drop(closure_); };
-inline void z_drop(z_moved_closure_zid_t closure_) { z_closure_zid_drop(closure_); };
 inline void z_drop(z_moved_condvar_t this_) { z_condvar_drop(this_); };
 inline void z_drop(z_moved_config_t this_) { z_config_drop(this_); };
 inline void z_drop(z_moved_encoding_t this_) { z_encoding_drop(this_); };
@@ -570,7 +405,6 @@ inline void z_drop(z_moved_fifo_handler_reply_t this_) { z_fifo_handler_reply_dr
 inline void z_drop(z_moved_fifo_handler_sample_t this_) { z_fifo_handler_sample_drop(this_); };
 inline void z_drop(z_moved_hello_t this_) { z_hello_drop(this_); };
 inline void z_drop(z_moved_keyexpr_t this_) { z_keyexpr_drop(this_); };
-inline void z_drop(z_moved_memory_layout_t this_) { z_memory_layout_drop(this_); };
 inline void z_drop(z_moved_mutex_t this_) { z_mutex_drop(this_); };
 inline void z_drop(z_moved_publisher_t this_) { z_publisher_drop(this_); };
 inline void z_drop(z_moved_query_t this_) { z_query_drop(this_); };
@@ -582,34 +416,19 @@ inline void z_drop(z_moved_ring_handler_reply_t this_) { z_ring_handler_reply_dr
 inline void z_drop(z_moved_ring_handler_sample_t this_) { z_ring_handler_sample_drop(this_); };
 inline void z_drop(z_moved_sample_t this_) { z_sample_drop(this_); };
 inline void z_drop(z_moved_session_t this_) { z_session_drop(this_); };
-inline void z_drop(z_moved_shm_client_t this_) { z_shm_client_drop(this_); };
-inline void z_drop(z_moved_shm_client_storage_t this_) { z_shm_client_storage_drop(this_); };
-inline void z_drop(z_moved_shm_t this_) { z_shm_drop(this_); };
-inline void z_drop(z_moved_shm_mut_t this_) { z_shm_mut_drop(this_); };
-inline void z_drop(z_moved_shm_provider_t this_) { z_shm_provider_drop(this_); };
 inline void z_drop(z_moved_slice_t this_) { z_slice_drop(this_); };
-inline void z_drop(z_moved_source_info_t this_) { z_source_info_drop(this_); };
 inline void z_drop(z_moved_string_array_t this_) { z_string_array_drop(this_); };
 inline void z_drop(z_moved_string_t this_) { z_string_drop(this_); };
 inline void z_drop(z_moved_subscriber_t this_) { z_subscriber_drop(this_); };
 inline void z_drop(z_moved_task_t this_) { z_task_drop(this_); };
 inline void z_drop(zc_moved_closure_log_t closure_) { zc_closure_log_drop(closure_); };
-inline void z_drop(zc_moved_closure_matching_status_t closure_) { zc_closure_matching_status_drop(closure_); };
-inline void z_drop(zc_moved_liveliness_token_t this_) { zc_liveliness_token_drop(this_); };
-inline z_result_t z_drop(zc_moved_matching_listener_t this_) { return zc_publisher_matching_listener_drop(this_); };
-inline void z_drop(zc_moved_shm_client_list_t this_) { zc_shm_client_list_drop(this_); };
-inline void z_drop(ze_moved_publication_cache_t this_) { ze_publication_cache_drop(this_); };
-inline void z_drop(ze_moved_querying_subscriber_t this_) { ze_querying_subscriber_drop(this_); };
 
 
-inline z_moved_alloc_layout_t z_move(z_owned_alloc_layout_t& this_) { return z_alloc_layout_move(&this_); };
 inline z_moved_bytes_t z_move(z_owned_bytes_t& this_) { return z_bytes_move(&this_); };
-inline z_moved_chunk_alloc_result_t z_move(z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_move(&this_); };
 inline z_moved_closure_hello_t z_move(z_owned_closure_hello_t& this_) { return z_closure_hello_move(&this_); };
 inline z_moved_closure_query_t z_move(z_owned_closure_query_t& closure_) { return z_closure_query_move(&closure_); };
 inline z_moved_closure_reply_t z_move(z_owned_closure_reply_t& closure_) { return z_closure_reply_move(&closure_); };
 inline z_moved_closure_sample_t z_move(z_owned_closure_sample_t& closure_) { return z_closure_sample_move(&closure_); };
-inline z_moved_closure_zid_t z_move(z_owned_closure_zid_t& closure_) { return z_closure_zid_move(&closure_); };
 inline z_moved_condvar_t z_move(z_owned_condvar_t& this_) { return z_condvar_move(&this_); };
 inline z_moved_config_t z_move(z_owned_config_t& this_) { return z_config_move(&this_); };
 inline z_moved_encoding_t z_move(z_owned_encoding_t& this_) { return z_encoding_move(&this_); };
@@ -618,7 +437,6 @@ inline z_moved_fifo_handler_reply_t z_move(z_owned_fifo_handler_reply_t& this_) 
 inline z_moved_fifo_handler_sample_t z_move(z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_move(&this_); };
 inline z_moved_hello_t z_move(z_owned_hello_t& this_) { return z_hello_move(&this_); };
 inline z_moved_keyexpr_t z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
-inline z_moved_memory_layout_t z_move(z_owned_memory_layout_t& this_) { return z_memory_layout_move(&this_); };
 inline z_moved_mutex_t z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
 inline z_moved_publisher_t z_move(z_owned_publisher_t& this_) { return z_publisher_move(&this_); };
 inline z_moved_query_t z_move(z_owned_query_t& this_) { return z_query_move(&this_); };
@@ -630,34 +448,19 @@ inline z_moved_ring_handler_reply_t z_move(z_owned_ring_handler_reply_t& this_) 
 inline z_moved_ring_handler_sample_t z_move(z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_move(&this_); };
 inline z_moved_sample_t z_move(z_owned_sample_t& this_) { return z_sample_move(&this_); };
 inline z_moved_session_t z_move(z_owned_session_t& this_) { return z_session_move(&this_); };
-inline z_moved_shm_client_t z_move(z_owned_shm_client_t& this_) { return z_shm_client_move(&this_); };
-inline z_moved_shm_client_storage_t z_move(z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_move(&this_); };
-inline z_moved_shm_t z_move(z_owned_shm_t& this_) { return z_shm_move(&this_); };
-inline z_moved_shm_mut_t z_move(z_owned_shm_mut_t& this_) { return z_shm_mut_move(&this_); };
-inline z_moved_shm_provider_t z_move(z_owned_shm_provider_t& this_) { return z_shm_provider_move(&this_); };
 inline z_moved_slice_t z_move(z_owned_slice_t& this_) { return z_slice_move(&this_); };
-inline z_moved_source_info_t z_move(z_owned_source_info_t& this_) { return z_source_info_move(&this_); };
 inline z_moved_string_array_t z_move(z_owned_string_array_t& this_) { return z_string_array_move(&this_); };
 inline z_moved_string_t z_move(z_owned_string_t& this_) { return z_string_move(&this_); };
 inline z_moved_subscriber_t z_move(z_owned_subscriber_t& this_) { return z_subscriber_move(&this_); };
 inline z_moved_task_t z_move(z_owned_task_t& this_) { return z_task_move(&this_); };
 inline zc_moved_closure_log_t z_move(zc_owned_closure_log_t& closure_) { return zc_closure_log_move(&closure_); };
-inline zc_moved_closure_matching_status_t z_move(zc_owned_closure_matching_status_t& closure_) { return zc_closure_matching_status_move(&closure_); };
-inline zc_moved_liveliness_token_t z_move(zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_move(&this_); };
-inline zc_moved_matching_listener_t z_move(zc_owned_matching_listener_t& this_) { return zc_publisher_matching_listener_move(&this_); };
-inline zc_moved_shm_client_list_t z_move(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_move(&this_); };
-inline ze_moved_publication_cache_t z_move(ze_owned_publication_cache_t& this_) { return ze_publication_cache_move(&this_); };
-inline ze_moved_querying_subscriber_t z_move(ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_move(&this_); };
 
 
-inline void z_null(z_owned_alloc_layout_t* this_) { z_alloc_layout_null(this_); };
 inline void z_null(z_owned_bytes_t* this_) { z_bytes_null(this_); };
-inline void z_null(z_owned_chunk_alloc_result_t* this_) { z_chunk_alloc_result_null(this_); };
 inline void z_null(z_owned_closure_hello_t* this_) { z_closure_hello_null(this_); };
 inline void z_null(z_owned_closure_query_t* this_) { z_closure_query_null(this_); };
 inline void z_null(z_owned_closure_reply_t* this_) { z_closure_reply_null(this_); };
 inline void z_null(z_owned_closure_sample_t* this_) { z_closure_sample_null(this_); };
-inline void z_null(z_owned_closure_zid_t* this_) { z_closure_zid_null(this_); };
 inline void z_null(z_owned_condvar_t* this_) { z_condvar_null(this_); };
 inline void z_null(z_owned_config_t* this_) { z_config_null(this_); };
 inline void z_null(z_owned_encoding_t* this_) { z_encoding_null(this_); };
@@ -666,7 +469,6 @@ inline void z_null(z_owned_fifo_handler_reply_t* this_) { z_fifo_handler_reply_n
 inline void z_null(z_owned_fifo_handler_sample_t* this_) { z_fifo_handler_sample_null(this_); };
 inline void z_null(z_owned_hello_t* this_) { z_hello_null(this_); };
 inline void z_null(z_owned_keyexpr_t* this_) { z_keyexpr_null(this_); };
-inline void z_null(z_owned_memory_layout_t* this_) { z_memory_layout_null(this_); };
 inline void z_null(z_owned_mutex_t* this_) { z_mutex_null(this_); };
 inline void z_null(z_owned_publisher_t* this_) { z_publisher_null(this_); };
 inline void z_null(z_owned_query_t* this_) { z_query_null(this_); };
@@ -678,33 +480,18 @@ inline void z_null(z_owned_ring_handler_reply_t* this_) { z_ring_handler_reply_n
 inline void z_null(z_owned_ring_handler_sample_t* this_) { z_ring_handler_sample_null(this_); };
 inline void z_null(z_owned_sample_t* this_) { z_sample_null(this_); };
 inline void z_null(z_owned_session_t* this_) { z_session_null(this_); };
-inline void z_null(z_owned_shm_client_t* this_) { z_shm_client_null(this_); };
-inline void z_null(z_owned_shm_client_storage_t* this_) { z_shm_client_storage_null(this_); };
-inline void z_null(z_owned_shm_mut_t* this_) { z_shm_mut_null(this_); };
-inline void z_null(z_owned_shm_t* this_) { z_shm_null(this_); };
-inline void z_null(z_owned_shm_provider_t* this_) { z_shm_provider_null(this_); };
 inline void z_null(z_owned_slice_t* this_) { z_slice_null(this_); };
-inline void z_null(z_owned_source_info_t* this_) { z_source_info_null(this_); };
 inline void z_null(z_owned_string_array_t* this_) { z_string_array_null(this_); };
 inline void z_null(z_owned_string_t* this_) { z_string_null(this_); };
 inline void z_null(z_owned_subscriber_t* this_) { z_subscriber_null(this_); };
 inline void z_null(z_owned_task_t* this_) { z_task_null(this_); };
 inline void z_null(zc_owned_closure_log_t* this_) { zc_closure_log_null(this_); };
-inline void z_null(zc_owned_closure_matching_status_t* this_) { zc_closure_matching_status_null(this_); };
-inline void z_null(zc_owned_liveliness_token_t* this_) { zc_liveliness_token_null(this_); };
-inline void z_null(zc_owned_matching_listener_t* this_) { zc_matching_listener_null(this_); };
-inline void z_null(zc_owned_shm_client_list_t* this_) { zc_shm_client_list_null(this_); };
-inline void z_null(ze_owned_publication_cache_t* this_) { ze_publication_cache_null(this_); };
-inline void z_null(ze_owned_querying_subscriber_t* this_) { ze_querying_subscriber_null(this_); };
 
-static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t x) { *this_ = *x._ptr; z_alloc_layout_null(x._ptr); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t x) { *this_ = *x._ptr; z_bytes_null(x._ptr); }
-static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) { *this_ = *x._ptr; z_chunk_alloc_result_null(x._ptr); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t x) { *this_ = *x._ptr; z_closure_hello_null(x._ptr); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t x) { *closure_ = *x._ptr; z_closure_query_null(x._ptr); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t x) { *closure_ = *x._ptr; z_closure_reply_null(x._ptr); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t x) { *closure_ = *x._ptr; z_closure_sample_null(x._ptr); }
-static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t x) { *closure_ = *x._ptr; z_closure_zid_null(x._ptr); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t x) { *this_ = *x._ptr; z_condvar_null(x._ptr); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t x) { *this_ = *x._ptr; z_config_null(x._ptr); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t x) { *this_ = *x._ptr; z_encoding_null(x._ptr); }
@@ -713,7 +500,6 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t x) { *this_ = *x._ptr; z_fifo_handler_sample_null(x._ptr); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *this_ = *x._ptr; z_hello_null(x._ptr); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
-static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) { *this_ = *x._ptr; z_memory_layout_null(x._ptr); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t x) { *this_ = *x._ptr; z_publisher_null(x._ptr); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
@@ -725,35 +511,17 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t x) { *this_ = *x._ptr; z_ring_handler_sample_null(x._ptr); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t x) { *this_ = *x._ptr; z_sample_null(x._ptr); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t x) { *this_ = *x._ptr; z_session_null(x._ptr); }
-static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t x) { *this_ = *x._ptr; z_shm_client_null(x._ptr); }
-static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t x) { *this_ = *x._ptr; z_shm_client_storage_null(x._ptr); }
-static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t x) { *this_ = *x._ptr; z_shm_null(x._ptr); }
-static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t x) { *this_ = *x._ptr; z_shm_mut_null(x._ptr); }
-static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t x) { *this_ = *x._ptr; z_shm_provider_null(x._ptr); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t x) { *this_ = *x._ptr; z_slice_null(x._ptr); }
-static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t x) { *this_ = *x._ptr; z_source_info_null(x._ptr); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t x) { *this_ = *x._ptr; z_string_array_null(x._ptr); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t x) { *this_ = *x._ptr; z_string_null(x._ptr); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) { *this_ = *x._ptr; z_subscriber_null(x._ptr); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t x) { *this_ = *x._ptr; z_task_null(x._ptr); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t x) { *closure_ = *x._ptr; zc_closure_log_null(x._ptr); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t x) { *closure_ = *x._ptr; zc_closure_matching_status_null(x._ptr); }
-static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
-static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t x) { *this_ = *x._ptr; zc_matching_listener_null(x._ptr); }
-static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) { *this_ = *x._ptr; ze_publication_cache_null(x._ptr); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) { *this_ = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 
-inline void z_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t x) {
-    z_alloc_layout_take(this_, x);
-};
 inline void z_take(z_owned_bytes_t* this_, z_moved_bytes_t x) {
     z_bytes_take(this_, x);
-};
-inline void z_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) {
-    z_chunk_alloc_result_take(this_, x);
 };
 inline void z_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t x) {
     z_closure_hello_take(this_, x);
@@ -766,9 +534,6 @@ inline void z_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t x)
 };
 inline void z_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t x) {
     z_closure_sample_take(closure_, x);
-};
-inline void z_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t x) {
-    z_closure_zid_take(closure_, x);
 };
 inline void z_take(z_owned_condvar_t* this_, z_moved_condvar_t x) {
     z_condvar_take(this_, x);
@@ -793,9 +558,6 @@ inline void z_take(z_owned_hello_t* this_, z_moved_hello_t x) {
 };
 inline void z_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) {
     z_keyexpr_take(this_, x);
-};
-inline void z_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) {
-    z_memory_layout_take(this_, x);
 };
 inline void z_take(z_owned_mutex_t* this_, z_moved_mutex_t x) {
     z_mutex_take(this_, x);
@@ -830,26 +592,8 @@ inline void z_take(z_owned_sample_t* this_, z_moved_sample_t x) {
 inline void z_take(z_owned_session_t* this_, z_moved_session_t x) {
     z_session_take(this_, x);
 };
-inline void z_take(z_owned_shm_client_t* this_, z_moved_shm_client_t x) {
-    z_shm_client_take(this_, x);
-};
-inline void z_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t x) {
-    z_shm_client_storage_take(this_, x);
-};
-inline void z_take(z_owned_shm_t* this_, z_moved_shm_t x) {
-    z_shm_take(this_, x);
-};
-inline void z_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t x) {
-    z_shm_mut_take(this_, x);
-};
-inline void z_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t x) {
-    z_shm_provider_take(this_, x);
-};
 inline void z_take(z_owned_slice_t* this_, z_moved_slice_t x) {
     z_slice_take(this_, x);
-};
-inline void z_take(z_owned_source_info_t* this_, z_moved_source_info_t x) {
-    z_source_info_take(this_, x);
 };
 inline void z_take(z_owned_string_array_t* this_, z_moved_string_array_t x) {
     z_string_array_take(this_, x);
@@ -866,34 +610,13 @@ inline void z_take(z_owned_task_t* this_, z_moved_task_t x) {
 inline void z_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t x) {
     zc_closure_log_take(closure_, x);
 };
-inline void z_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t x) {
-    zc_closure_matching_status_take(closure_, x);
-};
-inline void z_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) {
-    zc_liveliness_token_take(this_, x);
-};
-inline void z_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t x) {
-    zc_publisher_matching_listener_take(this_, x);
-};
-inline void z_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) {
-    zc_shm_client_list_take(this_, x);
-};
-inline void z_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) {
-    ze_publication_cache_take(this_, x);
-};
-inline void z_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) {
-    ze_querying_subscriber_take(this_, x);
-};
 
 
-inline bool z_check(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_check(&this_); };
 inline bool z_check(const z_owned_bytes_t& this_) { return z_bytes_check(&this_); };
-inline bool z_check(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_check(&this_); };
 inline bool z_check(const z_owned_closure_hello_t& this_) { return z_closure_hello_check(&this_); };
 inline bool z_check(const z_owned_closure_query_t& this_) { return z_closure_query_check(&this_); };
 inline bool z_check(const z_owned_closure_reply_t& this_) { return z_closure_reply_check(&this_); };
 inline bool z_check(const z_owned_closure_sample_t& this_) { return z_closure_sample_check(&this_); };
-inline bool z_check(const z_owned_closure_zid_t& this_) { return z_closure_zid_check(&this_); };
 inline bool z_check(const z_owned_condvar_t& this_) { return z_condvar_check(&this_); };
 inline bool z_check(const z_owned_config_t& this_) { return z_config_check(&this_); };
 inline bool z_check(const z_owned_encoding_t& this_) { return z_encoding_check(&this_); };
@@ -902,7 +625,6 @@ inline bool z_check(const z_owned_fifo_handler_reply_t& this_) { return z_fifo_h
 inline bool z_check(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_hello_t& this_) { return z_hello_check(&this_); };
 inline bool z_check(const z_owned_keyexpr_t& this_) { return z_keyexpr_check(&this_); };
-inline bool z_check(const z_owned_memory_layout_t& this_) { return z_memory_layout_check(&this_); };
 inline bool z_check(const z_owned_mutex_t& this_) { return z_mutex_check(&this_); };
 inline bool z_check(const z_owned_publisher_t& this_) { return z_publisher_check(&this_); };
 inline bool z_check(const z_owned_query_t& query) { return z_query_check(&query); };
@@ -914,24 +636,12 @@ inline bool z_check(const z_owned_ring_handler_reply_t& this_) { return z_ring_h
 inline bool z_check(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_sample_t& this_) { return z_sample_check(&this_); };
 inline bool z_check(const z_owned_session_t& this_) { return z_session_check(&this_); };
-inline bool z_check(const z_owned_shm_t& this_) { return z_shm_check(&this_); };
-inline bool z_check(const z_owned_shm_client_t& this_) { return z_shm_client_check(&this_); };
-inline bool z_check(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_check(&this_); };
-inline bool z_check(const z_owned_shm_mut_t& this_) { return z_shm_mut_check(&this_); };
-inline bool z_check(const z_owned_shm_provider_t& this_) { return z_shm_provider_check(&this_); };
 inline bool z_check(const z_owned_slice_t& this_) { return z_slice_check(&this_); };
-inline bool z_check(const z_owned_source_info_t& this_) { return z_source_info_check(&this_); };
 inline bool z_check(const z_owned_string_array_t& this_) { return z_string_array_check(&this_); };
 inline bool z_check(const z_owned_string_t& this_) { return z_string_check(&this_); };
 inline bool z_check(const z_owned_subscriber_t& this_) { return z_subscriber_check(&this_); };
 inline bool z_check(const z_owned_task_t& this_) { return z_task_check(&this_); };
 inline bool z_check(const zc_owned_closure_log_t& this_) { return zc_closure_log_check(&this_); };
-inline bool z_check(const zc_owned_closure_matching_status_t& this_) { return zc_closure_matching_status_check(&this_); };
-inline bool z_check(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_check(&this_); };
-inline bool z_check(const zc_owned_matching_listener_t& this_) { return zc_matching_listener_check(&this_); };
-inline bool z_check(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_check(&this_); };
-inline bool z_check(const ze_owned_publication_cache_t& this_) { return ze_publication_cache_check(&this_); };
-inline bool z_check(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_check(&this_); };
 
 
 inline void z_call(const z_loaned_closure_hello_t* closure, const z_loaned_hello_t* hello) {
@@ -945,12 +655,6 @@ inline void z_call(const z_loaned_closure_reply_t* closure, const z_loaned_reply
 };
 inline void z_call(const z_loaned_closure_sample_t* closure, const z_loaned_sample_t* sample) {
     z_closure_sample_call(closure, sample);
-};
-inline void z_call(const z_loaned_closure_zid_t* closure, const z_id_t* z_id) {
-    z_closure_zid_call(closure, z_id);
-};
-inline void z_call(const zc_loaned_closure_matching_status_t* closure, const zc_matching_status_t* mathing_status) {
-    zc_closure_matching_status_call(closure, mathing_status);
 };
 
 
@@ -984,24 +688,6 @@ inline void z_closure(
 inline void z_closure(
     z_owned_closure_sample_t* closure,
     void (*call)(const z_loaned_sample_t*, void*),
-    void (*drop)(void*),
-    void *context) {
-    closure->context = context;
-    closure->drop = drop;
-    closure->call = call;
-};
-inline void z_closure(
-    z_owned_closure_zid_t* closure,
-    void (*call)(const z_id_t*, void*),
-    void (*drop)(void*),
-    void *context) {
-    closure->context = context;
-    closure->drop = drop;
-    closure->call = call;
-};
-inline void z_closure(
-    zc_owned_closure_matching_status_t* closure,
-    void (*call)(const zc_matching_status_t*, void*),
     void (*drop)(void*),
     void *context) {
     closure->context = context;
@@ -1051,12 +737,8 @@ inline z_result_t z_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sa
 
 template<class T> struct z_loaned_to_owned_type_t {};
 template<class T> struct z_owned_to_loaned_type_t {};
-template<> struct z_loaned_to_owned_type_t<z_loaned_alloc_layout_t> { typedef z_owned_alloc_layout_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_alloc_layout_t> { typedef z_loaned_alloc_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_t> { typedef z_owned_bytes_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_t> { typedef z_loaned_bytes_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_chunk_alloc_result_t> { typedef z_owned_chunk_alloc_result_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_chunk_alloc_result_t> { typedef z_loaned_chunk_alloc_result_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_hello_t> { typedef z_owned_closure_hello_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_hello_t> { typedef z_loaned_closure_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_query_t> { typedef z_owned_closure_query_t type; };
@@ -1065,8 +747,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_closure_reply_t> { typedef z
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_reply_t> { typedef z_loaned_closure_reply_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_sample_t> { typedef z_owned_closure_sample_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_sample_t> { typedef z_loaned_closure_sample_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_closure_zid_t> { typedef z_owned_closure_zid_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_closure_zid_t> { typedef z_loaned_closure_zid_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_condvar_t> { typedef z_owned_condvar_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_condvar_t> { typedef z_loaned_condvar_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_config_t> { typedef z_owned_config_t type; };
@@ -1083,8 +763,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_hello_t> { typedef z_owned_h
 template<> struct z_owned_to_loaned_type_t<z_owned_hello_t> { typedef z_loaned_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_keyexpr_t> { typedef z_owned_keyexpr_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_keyexpr_t> { typedef z_loaned_keyexpr_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_memory_layout_t> { typedef z_owned_memory_layout_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_memory_layout_t> { typedef z_loaned_memory_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_publisher_t> { typedef z_owned_publisher_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_publisher_t> { typedef z_loaned_publisher_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_query_t> { typedef z_owned_query_t type; };
@@ -1105,18 +783,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_sample_t> { typedef z_owned_
 template<> struct z_owned_to_loaned_type_t<z_owned_sample_t> { typedef z_loaned_sample_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_session_t> { typedef z_owned_session_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_session_t> { typedef z_loaned_session_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_client_storage_t> { typedef z_owned_shm_client_storage_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_client_storage_t> { typedef z_loaned_shm_client_storage_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_t> { typedef z_owned_shm_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_t> { typedef z_loaned_shm_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_mut_t> { typedef z_owned_shm_mut_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_mut_t> { typedef z_loaned_shm_mut_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_provider_t> { typedef z_owned_shm_provider_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_provider_t> { typedef z_loaned_shm_provider_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_slice_t> { typedef z_owned_slice_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_slice_t> { typedef z_loaned_slice_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_source_info_t> { typedef z_owned_source_info_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_source_info_t> { typedef z_loaned_source_info_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_array_t> { typedef z_owned_string_array_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_string_array_t> { typedef z_loaned_string_array_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_t> { typedef z_owned_string_t type; };
@@ -1125,14 +793,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_subscriber_t> { typedef z_ow
 template<> struct z_owned_to_loaned_type_t<z_owned_subscriber_t> { typedef z_loaned_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_log_t> { typedef zc_owned_closure_log_t type; };
 template<> struct z_owned_to_loaned_type_t<zc_owned_closure_log_t> { typedef zc_loaned_closure_log_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_matching_status_t> { typedef zc_owned_closure_matching_status_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_closure_matching_status_t> { typedef zc_loaned_closure_matching_status_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_liveliness_token_t> { typedef zc_owned_liveliness_token_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_liveliness_token_t> { typedef zc_loaned_liveliness_token_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_shm_client_list_t> { typedef zc_owned_shm_client_list_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_shm_client_list_t> { typedef zc_loaned_shm_client_list_t type; };
-template<> struct z_loaned_to_owned_type_t<ze_loaned_querying_subscriber_t> { typedef ze_owned_querying_subscriber_t type; };
-template<> struct z_owned_to_loaned_type_t<ze_owned_querying_subscriber_t> { typedef ze_loaned_querying_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_mutex_t> { typedef z_owned_mutex_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_mutex_t> { typedef z_loaned_mutex_t type; };
 #endif  // #ifndef __cplusplus

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -282,7 +282,7 @@ static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *th
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
 static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) { *this_ = *x._ptr; z_memory_layout_null(x._ptr); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
-static inline void z_publisher_take(z_owned_publisher_t* _this, z_moved_publisher_t x) { *_this = *x._ptr; z_publisher_null(x._ptr); }
+static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t x) { *this_ = *x._ptr; z_publisher_null(x._ptr); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
 static inline void z_queryable_take(z_owned_queryable_t* this_, z_moved_queryable_t x) { *this_ = *x._ptr; z_queryable_null(x._ptr); }
 static inline void z_reply_take(z_owned_reply_t* this_, z_moved_reply_t x) { *this_ = *x._ptr; z_reply_null(x._ptr); }
@@ -308,8 +308,8 @@ static inline void zc_closure_matching_status_take(zc_owned_closure_matching_sta
 static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
 static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t x) { *this_ = *x._ptr; zc_matching_listener_null(x._ptr); }
 static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* _this, ze_moved_publication_cache_t x) { *_this = *x._ptr; ze_publication_cache_null(x._ptr); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* _this, ze_moved_querying_subscriber_t x) { *_this = *x._ptr; ze_querying_subscriber_null(x._ptr); }
+static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) { *this_ = *x._ptr; ze_publication_cache_null(x._ptr); }
+static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) { *this_ = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 #define z_take(this_, x) \
@@ -572,7 +572,7 @@ inline void z_drop(z_moved_hello_t this_) { z_hello_drop(this_); };
 inline void z_drop(z_moved_keyexpr_t this_) { z_keyexpr_drop(this_); };
 inline void z_drop(z_moved_memory_layout_t this_) { z_memory_layout_drop(this_); };
 inline void z_drop(z_moved_mutex_t this_) { z_mutex_drop(this_); };
-inline void z_drop(z_moved_publisher_t _this) { z_publisher_drop(_this); };
+inline void z_drop(z_moved_publisher_t this_) { z_publisher_drop(this_); };
 inline void z_drop(z_moved_query_t this_) { z_query_drop(this_); };
 inline void z_drop(z_moved_queryable_t this_) { z_queryable_drop(this_); };
 inline void z_drop(z_moved_reply_t this_) { z_reply_drop(this_); };
@@ -598,8 +598,8 @@ inline void z_drop(zc_moved_closure_matching_status_t closure_) { zc_closure_mat
 inline void z_drop(zc_moved_liveliness_token_t this_) { zc_liveliness_token_drop(this_); };
 inline z_result_t z_drop(zc_moved_matching_listener_t this_) { return zc_publisher_matching_listener_drop(this_); };
 inline void z_drop(zc_moved_shm_client_list_t this_) { zc_shm_client_list_drop(this_); };
-inline void z_drop(ze_moved_publication_cache_t _this) { ze_publication_cache_drop(_this); };
-inline void z_drop(ze_moved_querying_subscriber_t _this) { ze_querying_subscriber_drop(_this); };
+inline void z_drop(ze_moved_publication_cache_t this_) { ze_publication_cache_drop(this_); };
+inline void z_drop(ze_moved_querying_subscriber_t this_) { ze_querying_subscriber_drop(this_); };
 
 
 inline z_moved_alloc_layout_t z_move(z_owned_alloc_layout_t& this_) { return z_alloc_layout_move(&this_); };
@@ -620,7 +620,7 @@ inline z_moved_hello_t z_move(z_owned_hello_t& this_) { return z_hello_move(&thi
 inline z_moved_keyexpr_t z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
 inline z_moved_memory_layout_t z_move(z_owned_memory_layout_t& this_) { return z_memory_layout_move(&this_); };
 inline z_moved_mutex_t z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
-inline z_moved_publisher_t z_move(z_owned_publisher_t& _this) { return z_publisher_move(&_this); };
+inline z_moved_publisher_t z_move(z_owned_publisher_t& this_) { return z_publisher_move(&this_); };
 inline z_moved_query_t z_move(z_owned_query_t& this_) { return z_query_move(&this_); };
 inline z_moved_queryable_t z_move(z_owned_queryable_t& this_) { return z_queryable_move(&this_); };
 inline z_moved_reply_t z_move(z_owned_reply_t& this_) { return z_reply_move(&this_); };
@@ -646,8 +646,8 @@ inline zc_moved_closure_matching_status_t z_move(zc_owned_closure_matching_statu
 inline zc_moved_liveliness_token_t z_move(zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_move(&this_); };
 inline zc_moved_matching_listener_t z_move(zc_owned_matching_listener_t& this_) { return zc_publisher_matching_listener_move(&this_); };
 inline zc_moved_shm_client_list_t z_move(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_move(&this_); };
-inline ze_moved_publication_cache_t z_move(ze_owned_publication_cache_t& _this) { return ze_publication_cache_move(&_this); };
-inline ze_moved_querying_subscriber_t z_move(ze_owned_querying_subscriber_t& _this) { return ze_querying_subscriber_move(&_this); };
+inline ze_moved_publication_cache_t z_move(ze_owned_publication_cache_t& this_) { return ze_publication_cache_move(&this_); };
+inline ze_moved_querying_subscriber_t z_move(ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_move(&this_); };
 
 
 inline void z_null(z_owned_alloc_layout_t* this_) { z_alloc_layout_null(this_); };
@@ -715,7 +715,7 @@ static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *th
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
 static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) { *this_ = *x._ptr; z_memory_layout_null(x._ptr); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
-static inline void z_publisher_take(z_owned_publisher_t* _this, z_moved_publisher_t x) { *_this = *x._ptr; z_publisher_null(x._ptr); }
+static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t x) { *this_ = *x._ptr; z_publisher_null(x._ptr); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
 static inline void z_queryable_take(z_owned_queryable_t* this_, z_moved_queryable_t x) { *this_ = *x._ptr; z_queryable_null(x._ptr); }
 static inline void z_reply_take(z_owned_reply_t* this_, z_moved_reply_t x) { *this_ = *x._ptr; z_reply_null(x._ptr); }
@@ -741,8 +741,8 @@ static inline void zc_closure_matching_status_take(zc_owned_closure_matching_sta
 static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
 static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t x) { *this_ = *x._ptr; zc_matching_listener_null(x._ptr); }
 static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* _this, ze_moved_publication_cache_t x) { *_this = *x._ptr; ze_publication_cache_null(x._ptr); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* _this, ze_moved_querying_subscriber_t x) { *_this = *x._ptr; ze_querying_subscriber_null(x._ptr); }
+static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) { *this_ = *x._ptr; ze_publication_cache_null(x._ptr); }
+static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) { *this_ = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 
@@ -800,8 +800,8 @@ inline void z_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) {
 inline void z_take(z_owned_mutex_t* this_, z_moved_mutex_t x) {
     z_mutex_take(this_, x);
 };
-inline void z_take(z_owned_publisher_t* _this, z_moved_publisher_t x) {
-    z_publisher_take(_this, x);
+inline void z_take(z_owned_publisher_t* this_, z_moved_publisher_t x) {
+    z_publisher_take(this_, x);
 };
 inline void z_take(z_owned_query_t* this_, z_moved_query_t x) {
     z_query_take(this_, x);
@@ -878,11 +878,11 @@ inline void z_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listen
 inline void z_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) {
     zc_shm_client_list_take(this_, x);
 };
-inline void z_take(ze_owned_publication_cache_t* _this, ze_moved_publication_cache_t x) {
-    ze_publication_cache_take(_this, x);
+inline void z_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) {
+    ze_publication_cache_take(this_, x);
 };
-inline void z_take(ze_owned_querying_subscriber_t* _this, ze_moved_querying_subscriber_t x) {
-    ze_querying_subscriber_take(_this, x);
+inline void z_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) {
+    ze_querying_subscriber_take(this_, x);
 };
 
 

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -4,11 +4,14 @@
 
 #ifndef __cplusplus
 
+static inline z_moved_alloc_layout_t z_alloc_layout_move(z_owned_alloc_layout_t* x) { return (z_moved_alloc_layout_t){x}; }
 static inline z_moved_bytes_t z_bytes_move(z_owned_bytes_t* x) { return (z_moved_bytes_t){x}; }
+static inline z_moved_chunk_alloc_result_t z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return (z_moved_chunk_alloc_result_t){x}; }
 static inline z_moved_closure_hello_t z_closure_hello_move(z_owned_closure_hello_t* x) { return (z_moved_closure_hello_t){x}; }
 static inline z_moved_closure_query_t z_closure_query_move(z_owned_closure_query_t* x) { return (z_moved_closure_query_t){x}; }
 static inline z_moved_closure_reply_t z_closure_reply_move(z_owned_closure_reply_t* x) { return (z_moved_closure_reply_t){x}; }
 static inline z_moved_closure_sample_t z_closure_sample_move(z_owned_closure_sample_t* x) { return (z_moved_closure_sample_t){x}; }
+static inline z_moved_closure_zid_t z_closure_zid_move(z_owned_closure_zid_t* x) { return (z_moved_closure_zid_t){x}; }
 static inline z_moved_condvar_t z_condvar_move(z_owned_condvar_t* x) { return (z_moved_condvar_t){x}; }
 static inline z_moved_config_t z_config_move(z_owned_config_t* x) { return (z_moved_config_t){x}; }
 static inline z_moved_encoding_t z_encoding_move(z_owned_encoding_t* x) { return (z_moved_encoding_t){x}; }
@@ -17,10 +20,8 @@ static inline z_moved_fifo_handler_reply_t z_fifo_handler_reply_move(z_owned_fif
 static inline z_moved_fifo_handler_sample_t z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return (z_moved_fifo_handler_sample_t){x}; }
 static inline z_moved_hello_t z_hello_move(z_owned_hello_t* x) { return (z_moved_hello_t){x}; }
 static inline z_moved_keyexpr_t z_keyexpr_move(z_owned_keyexpr_t* x) { return (z_moved_keyexpr_t){x}; }
+static inline z_moved_memory_layout_t z_memory_layout_move(z_owned_memory_layout_t* x) { return (z_moved_memory_layout_t){x}; }
 static inline z_moved_mutex_t z_mutex_move(z_owned_mutex_t* x) { return (z_moved_mutex_t){x}; }
-static inline z_moved_publisher_t z_publisher_move(z_owned_publisher_t* x) { return (z_moved_publisher_t){x}; }
-static inline z_moved_query_t z_query_move(z_owned_query_t* x) { return (z_moved_query_t){x}; }
-static inline z_moved_queryable_t z_queryable_move(z_owned_queryable_t* x) { return (z_moved_queryable_t){x}; }
 static inline z_moved_reply_t z_reply_move(z_owned_reply_t* x) { return (z_moved_reply_t){x}; }
 static inline z_moved_reply_err_t z_reply_err_move(z_owned_reply_err_t* x) { return (z_moved_reply_err_t){x}; }
 static inline z_moved_ring_handler_query_t z_ring_handler_query_move(z_owned_ring_handler_query_t* x) { return (z_moved_ring_handler_query_t){x}; }
@@ -28,21 +29,35 @@ static inline z_moved_ring_handler_reply_t z_ring_handler_reply_move(z_owned_rin
 static inline z_moved_ring_handler_sample_t z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return (z_moved_ring_handler_sample_t){x}; }
 static inline z_moved_sample_t z_sample_move(z_owned_sample_t* x) { return (z_moved_sample_t){x}; }
 static inline z_moved_session_t z_session_move(z_owned_session_t* x) { return (z_moved_session_t){x}; }
+static inline z_moved_shm_client_t z_shm_client_move(z_owned_shm_client_t* x) { return (z_moved_shm_client_t){x}; }
+static inline z_moved_shm_client_storage_t z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return (z_moved_shm_client_storage_t){x}; }
+static inline z_moved_shm_t z_shm_move(z_owned_shm_t* x) { return (z_moved_shm_t){x}; }
+static inline z_moved_shm_mut_t z_shm_mut_move(z_owned_shm_mut_t* x) { return (z_moved_shm_mut_t){x}; }
+static inline z_moved_shm_provider_t z_shm_provider_move(z_owned_shm_provider_t* x) { return (z_moved_shm_provider_t){x}; }
 static inline z_moved_slice_t z_slice_move(z_owned_slice_t* x) { return (z_moved_slice_t){x}; }
+static inline z_moved_source_info_t z_source_info_move(z_owned_source_info_t* x) { return (z_moved_source_info_t){x}; }
 static inline z_moved_string_array_t z_string_array_move(z_owned_string_array_t* x) { return (z_moved_string_array_t){x}; }
 static inline z_moved_string_t z_string_move(z_owned_string_t* x) { return (z_moved_string_t){x}; }
 static inline z_moved_subscriber_t z_subscriber_move(z_owned_subscriber_t* x) { return (z_moved_subscriber_t){x}; }
 static inline z_moved_task_t z_task_move(z_owned_task_t* x) { return (z_moved_task_t){x}; }
 static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t* x) { return (zc_moved_closure_log_t){x}; }
+static inline zc_moved_closure_matching_status_t zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return (zc_moved_closure_matching_status_t){x}; }
+static inline zc_moved_liveliness_token_t zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return (zc_moved_liveliness_token_t){x}; }
+static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return (zc_moved_shm_client_list_t){x}; }
+static inline ze_moved_publication_cache_t ze_publication_cache_move(ze_owned_publication_cache_t* x) { return (ze_moved_publication_cache_t){x}; }
+static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return (ze_moved_querying_subscriber_t){x}; }
 
 
 #define z_loan(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t : z_alloc_layout_loan, \
         z_owned_bytes_t : z_bytes_loan, \
+        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_loan, \
         z_owned_closure_hello_t : z_closure_hello_loan, \
         z_owned_closure_query_t : z_closure_query_loan, \
         z_owned_closure_reply_t : z_closure_reply_loan, \
         z_owned_closure_sample_t : z_closure_sample_loan, \
+        z_owned_closure_zid_t : z_closure_zid_loan, \
         z_owned_condvar_t : z_condvar_loan, \
         z_owned_config_t : z_config_loan, \
         z_owned_encoding_t : z_encoding_loan, \
@@ -51,6 +66,7 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_loan, \
         z_owned_hello_t : z_hello_loan, \
         z_owned_keyexpr_t : z_keyexpr_loan, \
+        z_owned_memory_layout_t : z_memory_layout_loan, \
         z_owned_publisher_t : z_publisher_loan, \
         z_owned_query_t : z_query_loan, \
         z_owned_queryable_t : z_queryable_loan, \
@@ -61,14 +77,23 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
         z_owned_ring_handler_sample_t : z_ring_handler_sample_loan, \
         z_owned_sample_t : z_sample_loan, \
         z_owned_session_t : z_session_loan, \
+        z_owned_shm_client_storage_t : z_shm_client_storage_loan, \
+        z_owned_shm_t : z_shm_loan, \
+        z_owned_shm_mut_t : z_shm_mut_loan, \
+        z_owned_shm_provider_t : z_shm_provider_loan, \
         z_owned_slice_t : z_slice_loan, \
+        z_owned_source_info_t : z_source_info_loan, \
         z_owned_string_array_t : z_string_array_loan, \
         z_owned_string_t : z_string_loan, \
         z_owned_subscriber_t : z_subscriber_loan, \
         z_view_keyexpr_t : z_view_keyexpr_loan, \
         z_view_slice_t : z_view_slice_loan, \
         z_view_string_t : z_view_string_loan, \
-        zc_owned_closure_log_t : zc_closure_log_loan \
+        zc_owned_closure_log_t : zc_closure_log_loan, \
+        zc_owned_closure_matching_status_t : zc_closure_matching_status_loan, \
+        zc_owned_liveliness_token_t : zc_liveliness_token_loan, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_loan, \
+        ze_owned_querying_subscriber_t : ze_querying_subscriber_loan \
     )(&this_)
 
 #define z_loan_mut(this_) \
@@ -79,16 +104,22 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
         z_owned_encoding_t : z_encoding_loan_mut, \
         z_owned_mutex_t : z_mutex_loan_mut, \
         z_owned_publisher_t : z_publisher_loan_mut, \
-        z_owned_string_array_t : z_string_array_loan_mut \
+        z_owned_shm_t : z_shm_loan_mut, \
+        z_owned_shm_mut_t : z_shm_mut_loan_mut, \
+        z_owned_string_array_t : z_string_array_loan_mut, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_loan_mut \
     )(&this_)
 
 #define z_drop(this_) \
     _Generic((this_), \
+        z_moved_alloc_layout_t : z_alloc_layout_drop, \
         z_moved_bytes_t : z_bytes_drop, \
+        z_moved_chunk_alloc_result_t : z_chunk_alloc_result_drop, \
         z_moved_closure_hello_t : z_closure_hello_drop, \
         z_moved_closure_query_t : z_closure_query_drop, \
         z_moved_closure_reply_t : z_closure_reply_drop, \
         z_moved_closure_sample_t : z_closure_sample_drop, \
+        z_moved_closure_zid_t : z_closure_zid_drop, \
         z_moved_condvar_t : z_condvar_drop, \
         z_moved_config_t : z_config_drop, \
         z_moved_encoding_t : z_encoding_drop, \
@@ -97,10 +128,8 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
         z_moved_fifo_handler_sample_t : z_fifo_handler_sample_drop, \
         z_moved_hello_t : z_hello_drop, \
         z_moved_keyexpr_t : z_keyexpr_drop, \
+        z_moved_memory_layout_t : z_memory_layout_drop, \
         z_moved_mutex_t : z_mutex_drop, \
-        z_moved_publisher_t : z_publisher_drop, \
-        z_moved_query_t : z_query_drop, \
-        z_moved_queryable_t : z_queryable_drop, \
         z_moved_reply_t : z_reply_drop, \
         z_moved_reply_err_t : z_reply_err_drop, \
         z_moved_ring_handler_query_t : z_ring_handler_query_drop, \
@@ -108,21 +137,35 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
         z_moved_ring_handler_sample_t : z_ring_handler_sample_drop, \
         z_moved_sample_t : z_sample_drop, \
         z_moved_session_t : z_session_drop, \
+        z_moved_shm_client_t : z_shm_client_drop, \
+        z_moved_shm_client_storage_t : z_shm_client_storage_drop, \
+        z_moved_shm_t : z_shm_drop, \
+        z_moved_shm_mut_t : z_shm_mut_drop, \
+        z_moved_shm_provider_t : z_shm_provider_drop, \
         z_moved_slice_t : z_slice_drop, \
+        z_moved_source_info_t : z_source_info_drop, \
         z_moved_string_array_t : z_string_array_drop, \
         z_moved_string_t : z_string_drop, \
         z_moved_subscriber_t : z_subscriber_drop, \
         z_moved_task_t : z_task_drop, \
-        zc_moved_closure_log_t : zc_closure_log_drop \
+        zc_moved_closure_log_t : zc_closure_log_drop, \
+        zc_moved_closure_matching_status_t : zc_closure_matching_status_drop, \
+        zc_moved_liveliness_token_t : zc_liveliness_token_drop, \
+        zc_moved_shm_client_list_t : zc_shm_client_list_drop, \
+        ze_moved_publication_cache_t : ze_publication_cache_drop, \
+        ze_moved_querying_subscriber_t : ze_querying_subscriber_drop \
     )(this_)
 
 #define z_move(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t : z_alloc_layout_move, \
         z_owned_bytes_t : z_bytes_move, \
+        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_move, \
         z_owned_closure_hello_t : z_closure_hello_move, \
         z_owned_closure_query_t : z_closure_query_move, \
         z_owned_closure_reply_t : z_closure_reply_move, \
         z_owned_closure_sample_t : z_closure_sample_move, \
+        z_owned_closure_zid_t : z_closure_zid_move, \
         z_owned_condvar_t : z_condvar_move, \
         z_owned_config_t : z_config_move, \
         z_owned_encoding_t : z_encoding_move, \
@@ -131,10 +174,8 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_move, \
         z_owned_hello_t : z_hello_move, \
         z_owned_keyexpr_t : z_keyexpr_move, \
+        z_owned_memory_layout_t : z_memory_layout_move, \
         z_owned_mutex_t : z_mutex_move, \
-        z_owned_publisher_t : z_publisher_move, \
-        z_owned_query_t : z_query_move, \
-        z_owned_queryable_t : z_queryable_move, \
         z_owned_reply_t : z_reply_move, \
         z_owned_reply_err_t : z_reply_err_move, \
         z_owned_ring_handler_query_t : z_ring_handler_query_move, \
@@ -142,21 +183,35 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
         z_owned_ring_handler_sample_t : z_ring_handler_sample_move, \
         z_owned_sample_t : z_sample_move, \
         z_owned_session_t : z_session_move, \
+        z_owned_shm_client_t : z_shm_client_move, \
+        z_owned_shm_client_storage_t : z_shm_client_storage_move, \
+        z_owned_shm_t : z_shm_move, \
+        z_owned_shm_mut_t : z_shm_mut_move, \
+        z_owned_shm_provider_t : z_shm_provider_move, \
         z_owned_slice_t : z_slice_move, \
+        z_owned_source_info_t : z_source_info_move, \
         z_owned_string_array_t : z_string_array_move, \
         z_owned_string_t : z_string_move, \
         z_owned_subscriber_t : z_subscriber_move, \
         z_owned_task_t : z_task_move, \
-        zc_owned_closure_log_t : zc_closure_log_move \
+        zc_owned_closure_log_t : zc_closure_log_move, \
+        zc_owned_closure_matching_status_t : zc_closure_matching_status_move, \
+        zc_owned_liveliness_token_t : zc_liveliness_token_move, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_move, \
+        ze_owned_publication_cache_t : ze_publication_cache_move, \
+        ze_owned_querying_subscriber_t : ze_querying_subscriber_move \
     )(&this_)
 
 #define z_null(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t* : z_alloc_layout_null, \
         z_owned_bytes_t* : z_bytes_null, \
+        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_null, \
         z_owned_closure_hello_t* : z_closure_hello_null, \
         z_owned_closure_query_t* : z_closure_query_null, \
         z_owned_closure_reply_t* : z_closure_reply_null, \
         z_owned_closure_sample_t* : z_closure_sample_null, \
+        z_owned_closure_zid_t* : z_closure_zid_null, \
         z_owned_condvar_t* : z_condvar_null, \
         z_owned_config_t* : z_config_null, \
         z_owned_encoding_t* : z_encoding_null, \
@@ -165,6 +220,7 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_null, \
         z_owned_hello_t* : z_hello_null, \
         z_owned_keyexpr_t* : z_keyexpr_null, \
+        z_owned_memory_layout_t* : z_memory_layout_null, \
         z_owned_mutex_t* : z_mutex_null, \
         z_owned_publisher_t* : z_publisher_null, \
         z_owned_query_t* : z_query_null, \
@@ -176,19 +232,34 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_null, \
         z_owned_sample_t* : z_sample_null, \
         z_owned_session_t* : z_session_null, \
+        z_owned_shm_client_t* : z_shm_client_null, \
+        z_owned_shm_client_storage_t* : z_shm_client_storage_null, \
+        z_owned_shm_mut_t* : z_shm_mut_null, \
+        z_owned_shm_t* : z_shm_null, \
+        z_owned_shm_provider_t* : z_shm_provider_null, \
         z_owned_slice_t* : z_slice_null, \
+        z_owned_source_info_t* : z_source_info_null, \
         z_owned_string_array_t* : z_string_array_null, \
         z_owned_string_t* : z_string_null, \
         z_owned_subscriber_t* : z_subscriber_null, \
         z_owned_task_t* : z_task_null, \
-        zc_owned_closure_log_t* : zc_closure_log_null \
+        zc_owned_closure_log_t* : zc_closure_log_null, \
+        zc_owned_closure_matching_status_t* : zc_closure_matching_status_null, \
+        zc_owned_liveliness_token_t* : zc_liveliness_token_null, \
+        zc_owned_matching_listener_t* : zc_matching_listener_null, \
+        zc_owned_shm_client_list_t* : zc_shm_client_list_null, \
+        ze_owned_publication_cache_t* : ze_publication_cache_null, \
+        ze_owned_querying_subscriber_t* : ze_querying_subscriber_null \
     )(this_)
 
+static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t x) { *this_ = *x._ptr; z_alloc_layout_null(x._ptr); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t x) { *this_ = *x._ptr; z_bytes_null(x._ptr); }
+static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) { *this_ = *x._ptr; z_chunk_alloc_result_null(x._ptr); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* _closure, z_moved_closure_hello_t x) { *_closure = *x._ptr; z_closure_hello_null(x._ptr); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure, z_moved_closure_query_t x) { *closure = *x._ptr; z_closure_query_null(x._ptr); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure, z_moved_closure_reply_t x) { *closure = *x._ptr; z_closure_reply_null(x._ptr); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure, z_moved_closure_sample_t x) { *closure = *x._ptr; z_closure_sample_null(x._ptr); }
+static inline void z_closure_zid_take(z_owned_closure_zid_t* closure, z_moved_closure_zid_t x) { *closure = *x._ptr; z_closure_zid_null(x._ptr); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t x) { *this_ = *x._ptr; z_condvar_null(x._ptr); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t x) { *this_ = *x._ptr; z_config_null(x._ptr); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t x) { *this_ = *x._ptr; z_encoding_null(x._ptr); }
@@ -197,10 +268,8 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t x) { *this_ = *x._ptr; z_fifo_handler_sample_null(x._ptr); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *this_ = *x._ptr; z_hello_null(x._ptr); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
+static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) { *this_ = *x._ptr; z_memory_layout_null(x._ptr); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
-static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t x) { *this_ = *x._ptr; z_publisher_null(x._ptr); }
-static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
-static inline void z_queryable_take(z_owned_queryable_t* this_, z_moved_queryable_t x) { *this_ = *x._ptr; z_queryable_null(x._ptr); }
 static inline void z_reply_take(z_owned_reply_t* this_, z_moved_reply_t x) { *this_ = *x._ptr; z_reply_null(x._ptr); }
 static inline void z_reply_err_take(z_owned_reply_err_t* this_, z_moved_reply_err_t x) { *this_ = *x._ptr; z_reply_err_null(x._ptr); }
 static inline void z_ring_handler_query_take(z_owned_ring_handler_query_t* this_, z_moved_ring_handler_query_t x) { *this_ = *x._ptr; z_ring_handler_query_null(x._ptr); }
@@ -208,21 +277,35 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t x) { *this_ = *x._ptr; z_ring_handler_sample_null(x._ptr); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t x) { *this_ = *x._ptr; z_sample_null(x._ptr); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t x) { *this_ = *x._ptr; z_session_null(x._ptr); }
+static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t x) { *this_ = *x._ptr; z_shm_client_null(x._ptr); }
+static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t x) { *this_ = *x._ptr; z_shm_client_storage_null(x._ptr); }
+static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t x) { *this_ = *x._ptr; z_shm_null(x._ptr); }
+static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t x) { *this_ = *x._ptr; z_shm_mut_null(x._ptr); }
+static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t x) { *this_ = *x._ptr; z_shm_provider_null(x._ptr); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t x) { *this_ = *x._ptr; z_slice_null(x._ptr); }
+static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t x) { *this_ = *x._ptr; z_source_info_null(x._ptr); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t x) { *this_ = *x._ptr; z_string_array_null(x._ptr); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t x) { *this_ = *x._ptr; z_string_null(x._ptr); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) { *this_ = *x._ptr; z_subscriber_null(x._ptr); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t x) { *this_ = *x._ptr; z_task_null(x._ptr); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved_closure_log_t x) { *closure = *x._ptr; zc_closure_log_null(x._ptr); }
+static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure, zc_moved_closure_matching_status_t x) { *closure = *x._ptr; zc_closure_matching_status_null(x._ptr); }
+static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
+static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
+static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) { *this_ = *x._ptr; ze_publication_cache_null(x._ptr); }
+static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) { *this_ = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 #define z_take(this_, x) \
     _Generic((this_), \
+        z_owned_alloc_layout_t* : z_alloc_layout_take, \
         z_owned_bytes_t* : z_bytes_take, \
+        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_take, \
         z_owned_closure_hello_t* : z_closure_hello_take, \
         z_owned_closure_query_t* : z_closure_query_take, \
         z_owned_closure_reply_t* : z_closure_reply_take, \
         z_owned_closure_sample_t* : z_closure_sample_take, \
+        z_owned_closure_zid_t* : z_closure_zid_take, \
         z_owned_condvar_t* : z_condvar_take, \
         z_owned_config_t* : z_config_take, \
         z_owned_encoding_t* : z_encoding_take, \
@@ -231,10 +314,8 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_take, \
         z_owned_hello_t* : z_hello_take, \
         z_owned_keyexpr_t* : z_keyexpr_take, \
+        z_owned_memory_layout_t* : z_memory_layout_take, \
         z_owned_mutex_t* : z_mutex_take, \
-        z_owned_publisher_t* : z_publisher_take, \
-        z_owned_query_t* : z_query_take, \
-        z_owned_queryable_t* : z_queryable_take, \
         z_owned_reply_t* : z_reply_take, \
         z_owned_reply_err_t* : z_reply_err_take, \
         z_owned_ring_handler_query_t* : z_ring_handler_query_take, \
@@ -242,21 +323,35 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_take, \
         z_owned_sample_t* : z_sample_take, \
         z_owned_session_t* : z_session_take, \
+        z_owned_shm_client_t* : z_shm_client_take, \
+        z_owned_shm_client_storage_t* : z_shm_client_storage_take, \
+        z_owned_shm_t* : z_shm_take, \
+        z_owned_shm_mut_t* : z_shm_mut_take, \
+        z_owned_shm_provider_t* : z_shm_provider_take, \
         z_owned_slice_t* : z_slice_take, \
+        z_owned_source_info_t* : z_source_info_take, \
         z_owned_string_array_t* : z_string_array_take, \
         z_owned_string_t* : z_string_take, \
         z_owned_subscriber_t* : z_subscriber_take, \
         z_owned_task_t* : z_task_take, \
-        zc_owned_closure_log_t* : zc_closure_log_take \
+        zc_owned_closure_log_t* : zc_closure_log_take, \
+        zc_owned_closure_matching_status_t* : zc_closure_matching_status_take, \
+        zc_owned_liveliness_token_t* : zc_liveliness_token_take, \
+        zc_owned_shm_client_list_t* : zc_shm_client_list_take, \
+        ze_owned_publication_cache_t* : ze_publication_cache_take, \
+        ze_owned_querying_subscriber_t* : ze_querying_subscriber_take \
     )(this_, x)
 
 #define z_check(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t : z_alloc_layout_check, \
         z_owned_bytes_t : z_bytes_check, \
+        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_check, \
         z_owned_closure_hello_t : z_closure_hello_check, \
         z_owned_closure_query_t : z_closure_query_check, \
         z_owned_closure_reply_t : z_closure_reply_check, \
         z_owned_closure_sample_t : z_closure_sample_check, \
+        z_owned_closure_zid_t : z_closure_zid_check, \
         z_owned_condvar_t : z_condvar_check, \
         z_owned_config_t : z_config_check, \
         z_owned_encoding_t : z_encoding_check, \
@@ -265,6 +360,7 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_check, \
         z_owned_hello_t : z_hello_check, \
         z_owned_keyexpr_t : z_keyexpr_check, \
+        z_owned_memory_layout_t : z_memory_layout_check, \
         z_owned_mutex_t : z_mutex_check, \
         z_owned_publisher_t : z_publisher_check, \
         z_owned_query_t : z_query_check, \
@@ -276,12 +372,24 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved
         z_owned_ring_handler_sample_t : z_ring_handler_sample_check, \
         z_owned_sample_t : z_sample_check, \
         z_owned_session_t : z_session_check, \
+        z_owned_shm_t : z_shm_check, \
+        z_owned_shm_client_t : z_shm_client_check, \
+        z_owned_shm_client_storage_t : z_shm_client_storage_check, \
+        z_owned_shm_mut_t : z_shm_mut_check, \
+        z_owned_shm_provider_t : z_shm_provider_check, \
         z_owned_slice_t : z_slice_check, \
+        z_owned_source_info_t : z_source_info_check, \
         z_owned_string_array_t : z_string_array_check, \
         z_owned_string_t : z_string_check, \
         z_owned_subscriber_t : z_subscriber_check, \
         z_owned_task_t : z_task_check, \
-        zc_owned_closure_log_t : zc_closure_log_check \
+        zc_owned_closure_log_t : zc_closure_log_check, \
+        zc_owned_closure_matching_status_t : zc_closure_matching_status_check, \
+        zc_owned_liveliness_token_t : zc_liveliness_token_check, \
+        zc_owned_matching_listener_t : zc_matching_listener_check, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_check, \
+        ze_owned_publication_cache_t : ze_publication_cache_check, \
+        ze_owned_querying_subscriber_t : ze_querying_subscriber_check \
     )(&this_)
 
 #define z_call(closure, hello) \
@@ -289,7 +397,9 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved
         const z_loaned_closure_hello_t* : z_closure_hello_call, \
         const z_loaned_closure_query_t* : z_closure_query_call, \
         const z_loaned_closure_reply_t* : z_closure_reply_call, \
-        const z_loaned_closure_sample_t* : z_closure_sample_call \
+        const z_loaned_closure_sample_t* : z_closure_sample_call, \
+        const z_loaned_closure_zid_t* : z_closure_zid_call, \
+        const zc_loaned_closure_matching_status_t* : zc_closure_matching_status_call \
     )(closure, hello)
 
 #define z_closure(x, callback, dropper, ctx) \
@@ -317,11 +427,14 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved
 #else  // #ifndef __cplusplus
 
 
+static inline z_moved_alloc_layout_t z_alloc_layout_move(z_owned_alloc_layout_t* x) { return z_moved_alloc_layout_t{x}; }
 static inline z_moved_bytes_t z_bytes_move(z_owned_bytes_t* x) { return z_moved_bytes_t{x}; }
+static inline z_moved_chunk_alloc_result_t z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return z_moved_chunk_alloc_result_t{x}; }
 static inline z_moved_closure_hello_t z_closure_hello_move(z_owned_closure_hello_t* x) { return z_moved_closure_hello_t{x}; }
 static inline z_moved_closure_query_t z_closure_query_move(z_owned_closure_query_t* x) { return z_moved_closure_query_t{x}; }
 static inline z_moved_closure_reply_t z_closure_reply_move(z_owned_closure_reply_t* x) { return z_moved_closure_reply_t{x}; }
 static inline z_moved_closure_sample_t z_closure_sample_move(z_owned_closure_sample_t* x) { return z_moved_closure_sample_t{x}; }
+static inline z_moved_closure_zid_t z_closure_zid_move(z_owned_closure_zid_t* x) { return z_moved_closure_zid_t{x}; }
 static inline z_moved_condvar_t z_condvar_move(z_owned_condvar_t* x) { return z_moved_condvar_t{x}; }
 static inline z_moved_config_t z_config_move(z_owned_config_t* x) { return z_moved_config_t{x}; }
 static inline z_moved_encoding_t z_encoding_move(z_owned_encoding_t* x) { return z_moved_encoding_t{x}; }
@@ -330,10 +443,8 @@ static inline z_moved_fifo_handler_reply_t z_fifo_handler_reply_move(z_owned_fif
 static inline z_moved_fifo_handler_sample_t z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return z_moved_fifo_handler_sample_t{x}; }
 static inline z_moved_hello_t z_hello_move(z_owned_hello_t* x) { return z_moved_hello_t{x}; }
 static inline z_moved_keyexpr_t z_keyexpr_move(z_owned_keyexpr_t* x) { return z_moved_keyexpr_t{x}; }
+static inline z_moved_memory_layout_t z_memory_layout_move(z_owned_memory_layout_t* x) { return z_moved_memory_layout_t{x}; }
 static inline z_moved_mutex_t z_mutex_move(z_owned_mutex_t* x) { return z_moved_mutex_t{x}; }
-static inline z_moved_publisher_t z_publisher_move(z_owned_publisher_t* x) { return z_moved_publisher_t{x}; }
-static inline z_moved_query_t z_query_move(z_owned_query_t* x) { return z_moved_query_t{x}; }
-static inline z_moved_queryable_t z_queryable_move(z_owned_queryable_t* x) { return z_moved_queryable_t{x}; }
 static inline z_moved_reply_t z_reply_move(z_owned_reply_t* x) { return z_moved_reply_t{x}; }
 static inline z_moved_reply_err_t z_reply_err_move(z_owned_reply_err_t* x) { return z_moved_reply_err_t{x}; }
 static inline z_moved_ring_handler_query_t z_ring_handler_query_move(z_owned_ring_handler_query_t* x) { return z_moved_ring_handler_query_t{x}; }
@@ -341,20 +452,34 @@ static inline z_moved_ring_handler_reply_t z_ring_handler_reply_move(z_owned_rin
 static inline z_moved_ring_handler_sample_t z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return z_moved_ring_handler_sample_t{x}; }
 static inline z_moved_sample_t z_sample_move(z_owned_sample_t* x) { return z_moved_sample_t{x}; }
 static inline z_moved_session_t z_session_move(z_owned_session_t* x) { return z_moved_session_t{x}; }
+static inline z_moved_shm_client_t z_shm_client_move(z_owned_shm_client_t* x) { return z_moved_shm_client_t{x}; }
+static inline z_moved_shm_client_storage_t z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return z_moved_shm_client_storage_t{x}; }
+static inline z_moved_shm_t z_shm_move(z_owned_shm_t* x) { return z_moved_shm_t{x}; }
+static inline z_moved_shm_mut_t z_shm_mut_move(z_owned_shm_mut_t* x) { return z_moved_shm_mut_t{x}; }
+static inline z_moved_shm_provider_t z_shm_provider_move(z_owned_shm_provider_t* x) { return z_moved_shm_provider_t{x}; }
 static inline z_moved_slice_t z_slice_move(z_owned_slice_t* x) { return z_moved_slice_t{x}; }
+static inline z_moved_source_info_t z_source_info_move(z_owned_source_info_t* x) { return z_moved_source_info_t{x}; }
 static inline z_moved_string_array_t z_string_array_move(z_owned_string_array_t* x) { return z_moved_string_array_t{x}; }
 static inline z_moved_string_t z_string_move(z_owned_string_t* x) { return z_moved_string_t{x}; }
 static inline z_moved_subscriber_t z_subscriber_move(z_owned_subscriber_t* x) { return z_moved_subscriber_t{x}; }
 static inline z_moved_task_t z_task_move(z_owned_task_t* x) { return z_moved_task_t{x}; }
 static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t* x) { return zc_moved_closure_log_t{x}; }
+static inline zc_moved_closure_matching_status_t zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return zc_moved_closure_matching_status_t{x}; }
+static inline zc_moved_liveliness_token_t zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return zc_moved_liveliness_token_t{x}; }
+static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return zc_moved_shm_client_list_t{x}; }
+static inline ze_moved_publication_cache_t ze_publication_cache_move(ze_owned_publication_cache_t* x) { return ze_moved_publication_cache_t{x}; }
+static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return ze_moved_querying_subscriber_t{x}; }
 
 
 
+inline const z_loaned_alloc_layout_t* z_loan(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_loan(&this_); };
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& this_) { return z_bytes_loan(&this_); };
+inline const z_loaned_chunk_alloc_result_t* z_loan(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_loan(&this_); };
 inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t& closure) { return z_closure_hello_loan(&closure); };
 inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t& closure) { return z_closure_query_loan(&closure); };
 inline const z_loaned_closure_reply_t* z_loan(const z_owned_closure_reply_t& closure) { return z_closure_reply_loan(&closure); };
 inline const z_loaned_closure_sample_t* z_loan(const z_owned_closure_sample_t& closure) { return z_closure_sample_loan(&closure); };
+inline const z_loaned_closure_zid_t* z_loan(const z_owned_closure_zid_t& closure) { return z_closure_zid_loan(&closure); };
 inline const z_loaned_condvar_t* z_loan(const z_owned_condvar_t& this_) { return z_condvar_loan(&this_); };
 inline const z_loaned_config_t* z_loan(const z_owned_config_t& this_) { return z_config_loan(&this_); };
 inline const z_loaned_encoding_t* z_loan(const z_owned_encoding_t& this_) { return z_encoding_loan(&this_); };
@@ -363,6 +488,7 @@ inline const z_loaned_fifo_handler_reply_t* z_loan(const z_owned_fifo_handler_re
 inline const z_loaned_fifo_handler_sample_t* z_loan(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_loan(&this_); };
 inline const z_loaned_hello_t* z_loan(const z_owned_hello_t& this_) { return z_hello_loan(&this_); };
 inline const z_loaned_keyexpr_t* z_loan(const z_owned_keyexpr_t& this_) { return z_keyexpr_loan(&this_); };
+inline const z_loaned_memory_layout_t* z_loan(const z_owned_memory_layout_t& this_) { return z_memory_layout_loan(&this_); };
 inline const z_loaned_publisher_t* z_loan(const z_owned_publisher_t& this_) { return z_publisher_loan(&this_); };
 inline const z_loaned_query_t* z_loan(const z_owned_query_t& this_) { return z_query_loan(&this_); };
 inline const z_loaned_queryable_t* z_loan(const z_owned_queryable_t& this_) { return z_queryable_loan(&this_); };
@@ -373,7 +499,12 @@ inline const z_loaned_ring_handler_reply_t* z_loan(const z_owned_ring_handler_re
 inline const z_loaned_ring_handler_sample_t* z_loan(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_loan(&this_); };
 inline const z_loaned_sample_t* z_loan(const z_owned_sample_t& this_) { return z_sample_loan(&this_); };
 inline const z_loaned_session_t* z_loan(const z_owned_session_t& this_) { return z_session_loan(&this_); };
+inline const z_loaned_shm_client_storage_t* z_loan(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_loan(&this_); };
+inline const z_loaned_shm_t* z_loan(const z_owned_shm_t& this_) { return z_shm_loan(&this_); };
+inline const z_loaned_shm_mut_t* z_loan(const z_owned_shm_mut_t& this_) { return z_shm_mut_loan(&this_); };
+inline const z_loaned_shm_provider_t* z_loan(const z_owned_shm_provider_t& this_) { return z_shm_provider_loan(&this_); };
 inline const z_loaned_slice_t* z_loan(const z_owned_slice_t& this_) { return z_slice_loan(&this_); };
+inline const z_loaned_source_info_t* z_loan(const z_owned_source_info_t& this_) { return z_source_info_loan(&this_); };
 inline const z_loaned_string_array_t* z_loan(const z_owned_string_array_t& this_) { return z_string_array_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_owned_string_t& this_) { return z_string_loan(&this_); };
 inline const z_loaned_subscriber_t* z_loan(const z_owned_subscriber_t& this_) { return z_subscriber_loan(&this_); };
@@ -381,6 +512,10 @@ inline const z_loaned_keyexpr_t* z_loan(const z_view_keyexpr_t& this_) { return 
 inline const z_loaned_slice_t* z_loan(const z_view_slice_t& this_) { return z_view_slice_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_view_string_t& this_) { return z_view_string_loan(&this_); };
 inline const zc_loaned_closure_log_t* z_loan(const zc_owned_closure_log_t& closure) { return zc_closure_log_loan(&closure); };
+inline const zc_loaned_closure_matching_status_t* z_loan(const zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_loan(&closure); };
+inline const zc_loaned_liveliness_token_t* z_loan(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_loan(&this_); };
+inline const zc_loaned_shm_client_list_t* z_loan(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan(&this_); };
+inline const ze_loaned_querying_subscriber_t* z_loan(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_loan(&this_); };
 
 
 inline z_loaned_bytes_t* z_loan_mut(z_owned_bytes_t& this_) { return z_bytes_loan_mut(&this_); };
@@ -389,14 +524,20 @@ inline z_loaned_config_t* z_loan_mut(z_owned_config_t& this_) { return z_config_
 inline z_loaned_encoding_t* z_loan_mut(z_owned_encoding_t& this_) { return z_encoding_loan_mut(&this_); };
 inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t& this_) { return z_mutex_loan_mut(&this_); };
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& this_) { return z_publisher_loan_mut(&this_); };
+inline z_loaned_shm_t* z_loan_mut(z_owned_shm_t& this_) { return z_shm_loan_mut(&this_); };
+inline z_loaned_shm_mut_t* z_loan_mut(z_owned_shm_mut_t& this_) { return z_shm_mut_loan_mut(&this_); };
 inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { return z_string_array_loan_mut(&this_); };
+inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan_mut(&this_); };
 
 
+inline void z_drop(z_moved_alloc_layout_t this_) { z_alloc_layout_drop(this_); };
 inline void z_drop(z_moved_bytes_t this_) { z_bytes_drop(this_); };
+inline void z_drop(z_moved_chunk_alloc_result_t this_) { z_chunk_alloc_result_drop(this_); };
 inline void z_drop(z_moved_closure_hello_t _closure) { z_closure_hello_drop(_closure); };
 inline void z_drop(z_moved_closure_query_t closure) { z_closure_query_drop(closure); };
 inline void z_drop(z_moved_closure_reply_t closure) { z_closure_reply_drop(closure); };
 inline void z_drop(z_moved_closure_sample_t closure) { z_closure_sample_drop(closure); };
+inline void z_drop(z_moved_closure_zid_t closure) { z_closure_zid_drop(closure); };
 inline void z_drop(z_moved_condvar_t this_) { z_condvar_drop(this_); };
 inline void z_drop(z_moved_config_t this_) { z_config_drop(this_); };
 inline void z_drop(z_moved_encoding_t this_) { z_encoding_drop(this_); };
@@ -405,10 +546,8 @@ inline void z_drop(z_moved_fifo_handler_reply_t this_) { z_fifo_handler_reply_dr
 inline void z_drop(z_moved_fifo_handler_sample_t this_) { z_fifo_handler_sample_drop(this_); };
 inline void z_drop(z_moved_hello_t this_) { z_hello_drop(this_); };
 inline void z_drop(z_moved_keyexpr_t this_) { z_keyexpr_drop(this_); };
+inline void z_drop(z_moved_memory_layout_t this_) { z_memory_layout_drop(this_); };
 inline void z_drop(z_moved_mutex_t this_) { z_mutex_drop(this_); };
-inline void z_drop(z_moved_publisher_t this_) { z_publisher_drop(this_); };
-inline void z_drop(z_moved_query_t this_) { z_query_drop(this_); };
-inline void z_drop(z_moved_queryable_t this_) { z_queryable_drop(this_); };
 inline void z_drop(z_moved_reply_t this_) { z_reply_drop(this_); };
 inline void z_drop(z_moved_reply_err_t this_) { z_reply_err_drop(this_); };
 inline void z_drop(z_moved_ring_handler_query_t this_) { z_ring_handler_query_drop(this_); };
@@ -416,19 +555,33 @@ inline void z_drop(z_moved_ring_handler_reply_t this_) { z_ring_handler_reply_dr
 inline void z_drop(z_moved_ring_handler_sample_t this_) { z_ring_handler_sample_drop(this_); };
 inline void z_drop(z_moved_sample_t this_) { z_sample_drop(this_); };
 inline void z_drop(z_moved_session_t this_) { z_session_drop(this_); };
+inline void z_drop(z_moved_shm_client_t this_) { z_shm_client_drop(this_); };
+inline void z_drop(z_moved_shm_client_storage_t this_) { z_shm_client_storage_drop(this_); };
+inline void z_drop(z_moved_shm_t this_) { z_shm_drop(this_); };
+inline void z_drop(z_moved_shm_mut_t this_) { z_shm_mut_drop(this_); };
+inline void z_drop(z_moved_shm_provider_t this_) { z_shm_provider_drop(this_); };
 inline void z_drop(z_moved_slice_t this_) { z_slice_drop(this_); };
+inline void z_drop(z_moved_source_info_t this_) { z_source_info_drop(this_); };
 inline void z_drop(z_moved_string_array_t this_) { z_string_array_drop(this_); };
 inline void z_drop(z_moved_string_t this_) { z_string_drop(this_); };
 inline void z_drop(z_moved_subscriber_t this_) { z_subscriber_drop(this_); };
 inline void z_drop(z_moved_task_t this_) { z_task_drop(this_); };
 inline void z_drop(zc_moved_closure_log_t closure) { zc_closure_log_drop(closure); };
+inline void z_drop(zc_moved_closure_matching_status_t closure) { zc_closure_matching_status_drop(closure); };
+inline void z_drop(zc_moved_liveliness_token_t this_) { zc_liveliness_token_drop(this_); };
+inline void z_drop(zc_moved_shm_client_list_t this_) { zc_shm_client_list_drop(this_); };
+inline void z_drop(ze_moved_publication_cache_t this_) { ze_publication_cache_drop(this_); };
+inline void z_drop(ze_moved_querying_subscriber_t this_) { ze_querying_subscriber_drop(this_); };
 
 
+inline z_moved_alloc_layout_t z_move(z_owned_alloc_layout_t& this_) { return z_alloc_layout_move(&this_); };
 inline z_moved_bytes_t z_move(z_owned_bytes_t& this_) { return z_bytes_move(&this_); };
+inline z_moved_chunk_alloc_result_t z_move(z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_move(&this_); };
 inline z_moved_closure_hello_t z_move(z_owned_closure_hello_t& _closure) { return z_closure_hello_move(&_closure); };
 inline z_moved_closure_query_t z_move(z_owned_closure_query_t& closure) { return z_closure_query_move(&closure); };
 inline z_moved_closure_reply_t z_move(z_owned_closure_reply_t& closure) { return z_closure_reply_move(&closure); };
 inline z_moved_closure_sample_t z_move(z_owned_closure_sample_t& closure) { return z_closure_sample_move(&closure); };
+inline z_moved_closure_zid_t z_move(z_owned_closure_zid_t& closure) { return z_closure_zid_move(&closure); };
 inline z_moved_condvar_t z_move(z_owned_condvar_t& this_) { return z_condvar_move(&this_); };
 inline z_moved_config_t z_move(z_owned_config_t& this_) { return z_config_move(&this_); };
 inline z_moved_encoding_t z_move(z_owned_encoding_t& this_) { return z_encoding_move(&this_); };
@@ -437,10 +590,8 @@ inline z_moved_fifo_handler_reply_t z_move(z_owned_fifo_handler_reply_t& this_) 
 inline z_moved_fifo_handler_sample_t z_move(z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_move(&this_); };
 inline z_moved_hello_t z_move(z_owned_hello_t& this_) { return z_hello_move(&this_); };
 inline z_moved_keyexpr_t z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
+inline z_moved_memory_layout_t z_move(z_owned_memory_layout_t& this_) { return z_memory_layout_move(&this_); };
 inline z_moved_mutex_t z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
-inline z_moved_publisher_t z_move(z_owned_publisher_t& this_) { return z_publisher_move(&this_); };
-inline z_moved_query_t z_move(z_owned_query_t& this_) { return z_query_move(&this_); };
-inline z_moved_queryable_t z_move(z_owned_queryable_t& this_) { return z_queryable_move(&this_); };
 inline z_moved_reply_t z_move(z_owned_reply_t& this_) { return z_reply_move(&this_); };
 inline z_moved_reply_err_t z_move(z_owned_reply_err_t& this_) { return z_reply_err_move(&this_); };
 inline z_moved_ring_handler_query_t z_move(z_owned_ring_handler_query_t& this_) { return z_ring_handler_query_move(&this_); };
@@ -448,19 +599,33 @@ inline z_moved_ring_handler_reply_t z_move(z_owned_ring_handler_reply_t& this_) 
 inline z_moved_ring_handler_sample_t z_move(z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_move(&this_); };
 inline z_moved_sample_t z_move(z_owned_sample_t& this_) { return z_sample_move(&this_); };
 inline z_moved_session_t z_move(z_owned_session_t& this_) { return z_session_move(&this_); };
+inline z_moved_shm_client_t z_move(z_owned_shm_client_t& this_) { return z_shm_client_move(&this_); };
+inline z_moved_shm_client_storage_t z_move(z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_move(&this_); };
+inline z_moved_shm_t z_move(z_owned_shm_t& this_) { return z_shm_move(&this_); };
+inline z_moved_shm_mut_t z_move(z_owned_shm_mut_t& this_) { return z_shm_mut_move(&this_); };
+inline z_moved_shm_provider_t z_move(z_owned_shm_provider_t& this_) { return z_shm_provider_move(&this_); };
 inline z_moved_slice_t z_move(z_owned_slice_t& this_) { return z_slice_move(&this_); };
+inline z_moved_source_info_t z_move(z_owned_source_info_t& this_) { return z_source_info_move(&this_); };
 inline z_moved_string_array_t z_move(z_owned_string_array_t& this_) { return z_string_array_move(&this_); };
 inline z_moved_string_t z_move(z_owned_string_t& this_) { return z_string_move(&this_); };
 inline z_moved_subscriber_t z_move(z_owned_subscriber_t& this_) { return z_subscriber_move(&this_); };
 inline z_moved_task_t z_move(z_owned_task_t& this_) { return z_task_move(&this_); };
 inline zc_moved_closure_log_t z_move(zc_owned_closure_log_t& closure) { return zc_closure_log_move(&closure); };
+inline zc_moved_closure_matching_status_t z_move(zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_move(&closure); };
+inline zc_moved_liveliness_token_t z_move(zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_move(&this_); };
+inline zc_moved_shm_client_list_t z_move(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_move(&this_); };
+inline ze_moved_publication_cache_t z_move(ze_owned_publication_cache_t& this_) { return ze_publication_cache_move(&this_); };
+inline ze_moved_querying_subscriber_t z_move(ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_move(&this_); };
 
 
+inline void z_null(z_owned_alloc_layout_t* this_) { z_alloc_layout_null(this_); };
 inline void z_null(z_owned_bytes_t* this_) { z_bytes_null(this_); };
+inline void z_null(z_owned_chunk_alloc_result_t* this_) { z_chunk_alloc_result_null(this_); };
 inline void z_null(z_owned_closure_hello_t* this_) { z_closure_hello_null(this_); };
 inline void z_null(z_owned_closure_query_t* this_) { z_closure_query_null(this_); };
 inline void z_null(z_owned_closure_reply_t* this_) { z_closure_reply_null(this_); };
 inline void z_null(z_owned_closure_sample_t* this_) { z_closure_sample_null(this_); };
+inline void z_null(z_owned_closure_zid_t* this_) { z_closure_zid_null(this_); };
 inline void z_null(z_owned_condvar_t* this_) { z_condvar_null(this_); };
 inline void z_null(z_owned_config_t* this_) { z_config_null(this_); };
 inline void z_null(z_owned_encoding_t* this_) { z_encoding_null(this_); };
@@ -469,6 +634,7 @@ inline void z_null(z_owned_fifo_handler_reply_t* this_) { z_fifo_handler_reply_n
 inline void z_null(z_owned_fifo_handler_sample_t* this_) { z_fifo_handler_sample_null(this_); };
 inline void z_null(z_owned_hello_t* this_) { z_hello_null(this_); };
 inline void z_null(z_owned_keyexpr_t* this_) { z_keyexpr_null(this_); };
+inline void z_null(z_owned_memory_layout_t* this_) { z_memory_layout_null(this_); };
 inline void z_null(z_owned_mutex_t* this_) { z_mutex_null(this_); };
 inline void z_null(z_owned_publisher_t* this_) { z_publisher_null(this_); };
 inline void z_null(z_owned_query_t* this_) { z_query_null(this_); };
@@ -480,18 +646,33 @@ inline void z_null(z_owned_ring_handler_reply_t* this_) { z_ring_handler_reply_n
 inline void z_null(z_owned_ring_handler_sample_t* this_) { z_ring_handler_sample_null(this_); };
 inline void z_null(z_owned_sample_t* this_) { z_sample_null(this_); };
 inline void z_null(z_owned_session_t* this_) { z_session_null(this_); };
+inline void z_null(z_owned_shm_client_t* this_) { z_shm_client_null(this_); };
+inline void z_null(z_owned_shm_client_storage_t* this_) { z_shm_client_storage_null(this_); };
+inline void z_null(z_owned_shm_mut_t* this_) { z_shm_mut_null(this_); };
+inline void z_null(z_owned_shm_t* this_) { z_shm_null(this_); };
+inline void z_null(z_owned_shm_provider_t* this_) { z_shm_provider_null(this_); };
 inline void z_null(z_owned_slice_t* this_) { z_slice_null(this_); };
+inline void z_null(z_owned_source_info_t* this_) { z_source_info_null(this_); };
 inline void z_null(z_owned_string_array_t* this_) { z_string_array_null(this_); };
 inline void z_null(z_owned_string_t* this_) { z_string_null(this_); };
 inline void z_null(z_owned_subscriber_t* this_) { z_subscriber_null(this_); };
 inline void z_null(z_owned_task_t* this_) { z_task_null(this_); };
 inline void z_null(zc_owned_closure_log_t* this_) { zc_closure_log_null(this_); };
+inline void z_null(zc_owned_closure_matching_status_t* this_) { zc_closure_matching_status_null(this_); };
+inline void z_null(zc_owned_liveliness_token_t* this_) { zc_liveliness_token_null(this_); };
+inline void z_null(zc_owned_matching_listener_t* this_) { zc_matching_listener_null(this_); };
+inline void z_null(zc_owned_shm_client_list_t* this_) { zc_shm_client_list_null(this_); };
+inline void z_null(ze_owned_publication_cache_t* this_) { ze_publication_cache_null(this_); };
+inline void z_null(ze_owned_querying_subscriber_t* this_) { ze_querying_subscriber_null(this_); };
 
+static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t x) { *this_ = *x._ptr; z_alloc_layout_null(x._ptr); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t x) { *this_ = *x._ptr; z_bytes_null(x._ptr); }
+static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) { *this_ = *x._ptr; z_chunk_alloc_result_null(x._ptr); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* _closure, z_moved_closure_hello_t x) { *_closure = *x._ptr; z_closure_hello_null(x._ptr); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure, z_moved_closure_query_t x) { *closure = *x._ptr; z_closure_query_null(x._ptr); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure, z_moved_closure_reply_t x) { *closure = *x._ptr; z_closure_reply_null(x._ptr); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure, z_moved_closure_sample_t x) { *closure = *x._ptr; z_closure_sample_null(x._ptr); }
+static inline void z_closure_zid_take(z_owned_closure_zid_t* closure, z_moved_closure_zid_t x) { *closure = *x._ptr; z_closure_zid_null(x._ptr); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t x) { *this_ = *x._ptr; z_condvar_null(x._ptr); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t x) { *this_ = *x._ptr; z_config_null(x._ptr); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t x) { *this_ = *x._ptr; z_encoding_null(x._ptr); }
@@ -500,10 +681,8 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t x) { *this_ = *x._ptr; z_fifo_handler_sample_null(x._ptr); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *this_ = *x._ptr; z_hello_null(x._ptr); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
+static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) { *this_ = *x._ptr; z_memory_layout_null(x._ptr); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
-static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t x) { *this_ = *x._ptr; z_publisher_null(x._ptr); }
-static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
-static inline void z_queryable_take(z_owned_queryable_t* this_, z_moved_queryable_t x) { *this_ = *x._ptr; z_queryable_null(x._ptr); }
 static inline void z_reply_take(z_owned_reply_t* this_, z_moved_reply_t x) { *this_ = *x._ptr; z_reply_null(x._ptr); }
 static inline void z_reply_err_take(z_owned_reply_err_t* this_, z_moved_reply_err_t x) { *this_ = *x._ptr; z_reply_err_null(x._ptr); }
 static inline void z_ring_handler_query_take(z_owned_ring_handler_query_t* this_, z_moved_ring_handler_query_t x) { *this_ = *x._ptr; z_ring_handler_query_null(x._ptr); }
@@ -511,17 +690,34 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t x) { *this_ = *x._ptr; z_ring_handler_sample_null(x._ptr); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t x) { *this_ = *x._ptr; z_sample_null(x._ptr); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t x) { *this_ = *x._ptr; z_session_null(x._ptr); }
+static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t x) { *this_ = *x._ptr; z_shm_client_null(x._ptr); }
+static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t x) { *this_ = *x._ptr; z_shm_client_storage_null(x._ptr); }
+static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t x) { *this_ = *x._ptr; z_shm_null(x._ptr); }
+static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t x) { *this_ = *x._ptr; z_shm_mut_null(x._ptr); }
+static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t x) { *this_ = *x._ptr; z_shm_provider_null(x._ptr); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t x) { *this_ = *x._ptr; z_slice_null(x._ptr); }
+static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t x) { *this_ = *x._ptr; z_source_info_null(x._ptr); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t x) { *this_ = *x._ptr; z_string_array_null(x._ptr); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t x) { *this_ = *x._ptr; z_string_null(x._ptr); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) { *this_ = *x._ptr; z_subscriber_null(x._ptr); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t x) { *this_ = *x._ptr; z_task_null(x._ptr); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved_closure_log_t x) { *closure = *x._ptr; zc_closure_log_null(x._ptr); }
+static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure, zc_moved_closure_matching_status_t x) { *closure = *x._ptr; zc_closure_matching_status_null(x._ptr); }
+static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
+static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
+static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) { *this_ = *x._ptr; ze_publication_cache_null(x._ptr); }
+static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) { *this_ = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 
+inline void z_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t x) {
+    z_alloc_layout_take(this_, x);
+};
 inline void z_take(z_owned_bytes_t* this_, z_moved_bytes_t x) {
     z_bytes_take(this_, x);
+};
+inline void z_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) {
+    z_chunk_alloc_result_take(this_, x);
 };
 inline void z_take(z_owned_closure_hello_t* _closure, z_moved_closure_hello_t x) {
     z_closure_hello_take(_closure, x);
@@ -534,6 +730,9 @@ inline void z_take(z_owned_closure_reply_t* closure, z_moved_closure_reply_t x) 
 };
 inline void z_take(z_owned_closure_sample_t* closure, z_moved_closure_sample_t x) {
     z_closure_sample_take(closure, x);
+};
+inline void z_take(z_owned_closure_zid_t* closure, z_moved_closure_zid_t x) {
+    z_closure_zid_take(closure, x);
 };
 inline void z_take(z_owned_condvar_t* this_, z_moved_condvar_t x) {
     z_condvar_take(this_, x);
@@ -559,17 +758,11 @@ inline void z_take(z_owned_hello_t* this_, z_moved_hello_t x) {
 inline void z_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) {
     z_keyexpr_take(this_, x);
 };
+inline void z_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) {
+    z_memory_layout_take(this_, x);
+};
 inline void z_take(z_owned_mutex_t* this_, z_moved_mutex_t x) {
     z_mutex_take(this_, x);
-};
-inline void z_take(z_owned_publisher_t* this_, z_moved_publisher_t x) {
-    z_publisher_take(this_, x);
-};
-inline void z_take(z_owned_query_t* this_, z_moved_query_t x) {
-    z_query_take(this_, x);
-};
-inline void z_take(z_owned_queryable_t* this_, z_moved_queryable_t x) {
-    z_queryable_take(this_, x);
 };
 inline void z_take(z_owned_reply_t* this_, z_moved_reply_t x) {
     z_reply_take(this_, x);
@@ -592,8 +785,26 @@ inline void z_take(z_owned_sample_t* this_, z_moved_sample_t x) {
 inline void z_take(z_owned_session_t* this_, z_moved_session_t x) {
     z_session_take(this_, x);
 };
+inline void z_take(z_owned_shm_client_t* this_, z_moved_shm_client_t x) {
+    z_shm_client_take(this_, x);
+};
+inline void z_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t x) {
+    z_shm_client_storage_take(this_, x);
+};
+inline void z_take(z_owned_shm_t* this_, z_moved_shm_t x) {
+    z_shm_take(this_, x);
+};
+inline void z_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t x) {
+    z_shm_mut_take(this_, x);
+};
+inline void z_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t x) {
+    z_shm_provider_take(this_, x);
+};
 inline void z_take(z_owned_slice_t* this_, z_moved_slice_t x) {
     z_slice_take(this_, x);
+};
+inline void z_take(z_owned_source_info_t* this_, z_moved_source_info_t x) {
+    z_source_info_take(this_, x);
 };
 inline void z_take(z_owned_string_array_t* this_, z_moved_string_array_t x) {
     z_string_array_take(this_, x);
@@ -610,13 +821,31 @@ inline void z_take(z_owned_task_t* this_, z_moved_task_t x) {
 inline void z_take(zc_owned_closure_log_t* closure, zc_moved_closure_log_t x) {
     zc_closure_log_take(closure, x);
 };
+inline void z_take(zc_owned_closure_matching_status_t* closure, zc_moved_closure_matching_status_t x) {
+    zc_closure_matching_status_take(closure, x);
+};
+inline void z_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) {
+    zc_liveliness_token_take(this_, x);
+};
+inline void z_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) {
+    zc_shm_client_list_take(this_, x);
+};
+inline void z_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) {
+    ze_publication_cache_take(this_, x);
+};
+inline void z_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) {
+    ze_querying_subscriber_take(this_, x);
+};
 
 
+inline bool z_check(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_check(&this_); };
 inline bool z_check(const z_owned_bytes_t& this_) { return z_bytes_check(&this_); };
+inline bool z_check(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_check(&this_); };
 inline bool z_check(const z_owned_closure_hello_t& this_) { return z_closure_hello_check(&this_); };
 inline bool z_check(const z_owned_closure_query_t& this_) { return z_closure_query_check(&this_); };
 inline bool z_check(const z_owned_closure_reply_t& this_) { return z_closure_reply_check(&this_); };
 inline bool z_check(const z_owned_closure_sample_t& this_) { return z_closure_sample_check(&this_); };
+inline bool z_check(const z_owned_closure_zid_t& this_) { return z_closure_zid_check(&this_); };
 inline bool z_check(const z_owned_condvar_t& this_) { return z_condvar_check(&this_); };
 inline bool z_check(const z_owned_config_t& this_) { return z_config_check(&this_); };
 inline bool z_check(const z_owned_encoding_t& this_) { return z_encoding_check(&this_); };
@@ -625,6 +854,7 @@ inline bool z_check(const z_owned_fifo_handler_reply_t& this_) { return z_fifo_h
 inline bool z_check(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_hello_t& this_) { return z_hello_check(&this_); };
 inline bool z_check(const z_owned_keyexpr_t& this_) { return z_keyexpr_check(&this_); };
+inline bool z_check(const z_owned_memory_layout_t& this_) { return z_memory_layout_check(&this_); };
 inline bool z_check(const z_owned_mutex_t& this_) { return z_mutex_check(&this_); };
 inline bool z_check(const z_owned_publisher_t& this_) { return z_publisher_check(&this_); };
 inline bool z_check(const z_owned_query_t& query) { return z_query_check(&query); };
@@ -636,12 +866,24 @@ inline bool z_check(const z_owned_ring_handler_reply_t& this_) { return z_ring_h
 inline bool z_check(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_sample_t& this_) { return z_sample_check(&this_); };
 inline bool z_check(const z_owned_session_t& this_) { return z_session_check(&this_); };
+inline bool z_check(const z_owned_shm_t& this_) { return z_shm_check(&this_); };
+inline bool z_check(const z_owned_shm_client_t& this_) { return z_shm_client_check(&this_); };
+inline bool z_check(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_check(&this_); };
+inline bool z_check(const z_owned_shm_mut_t& this_) { return z_shm_mut_check(&this_); };
+inline bool z_check(const z_owned_shm_provider_t& this_) { return z_shm_provider_check(&this_); };
 inline bool z_check(const z_owned_slice_t& this_) { return z_slice_check(&this_); };
+inline bool z_check(const z_owned_source_info_t& this_) { return z_source_info_check(&this_); };
 inline bool z_check(const z_owned_string_array_t& this_) { return z_string_array_check(&this_); };
 inline bool z_check(const z_owned_string_t& this_) { return z_string_check(&this_); };
 inline bool z_check(const z_owned_subscriber_t& this_) { return z_subscriber_check(&this_); };
 inline bool z_check(const z_owned_task_t& this_) { return z_task_check(&this_); };
 inline bool z_check(const zc_owned_closure_log_t& this_) { return zc_closure_log_check(&this_); };
+inline bool z_check(const zc_owned_closure_matching_status_t& this_) { return zc_closure_matching_status_check(&this_); };
+inline bool z_check(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_check(&this_); };
+inline bool z_check(const zc_owned_matching_listener_t& this_) { return zc_matching_listener_check(&this_); };
+inline bool z_check(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_check(&this_); };
+inline bool z_check(const ze_owned_publication_cache_t& this_) { return ze_publication_cache_check(&this_); };
+inline bool z_check(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_check(&this_); };
 
 
 inline void z_call(const z_loaned_closure_hello_t* closure, const z_loaned_hello_t* hello) {
@@ -655,6 +897,12 @@ inline void z_call(const z_loaned_closure_reply_t* closure, const z_loaned_reply
 };
 inline void z_call(const z_loaned_closure_sample_t* closure, const z_loaned_sample_t* sample) {
     z_closure_sample_call(closure, sample);
+};
+inline void z_call(const z_loaned_closure_zid_t* closure, const z_id_t* z_id) {
+    z_closure_zid_call(closure, z_id);
+};
+inline void z_call(const zc_loaned_closure_matching_status_t* closure, const zc_matching_status_t* mathing_status) {
+    zc_closure_matching_status_call(closure, mathing_status);
 };
 
 
@@ -688,6 +936,24 @@ inline void z_closure(
 inline void z_closure(
     z_owned_closure_sample_t* closure,
     void (*call)(const z_loaned_sample_t*, void*),
+    void (*drop)(void*),
+    void *context) {
+    closure->context = context;
+    closure->drop = drop;
+    closure->call = call;
+};
+inline void z_closure(
+    z_owned_closure_zid_t* closure,
+    void (*call)(const z_id_t*, void*),
+    void (*drop)(void*),
+    void *context) {
+    closure->context = context;
+    closure->drop = drop;
+    closure->call = call;
+};
+inline void z_closure(
+    zc_owned_closure_matching_status_t* closure,
+    void (*call)(const zc_matching_status_t*, void*),
     void (*drop)(void*),
     void *context) {
     closure->context = context;
@@ -737,8 +1003,12 @@ inline z_result_t z_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sa
 
 template<class T> struct z_loaned_to_owned_type_t {};
 template<class T> struct z_owned_to_loaned_type_t {};
+template<> struct z_loaned_to_owned_type_t<z_loaned_alloc_layout_t> { typedef z_owned_alloc_layout_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_alloc_layout_t> { typedef z_loaned_alloc_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_t> { typedef z_owned_bytes_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_t> { typedef z_loaned_bytes_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_chunk_alloc_result_t> { typedef z_owned_chunk_alloc_result_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_chunk_alloc_result_t> { typedef z_loaned_chunk_alloc_result_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_hello_t> { typedef z_owned_closure_hello_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_hello_t> { typedef z_loaned_closure_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_query_t> { typedef z_owned_closure_query_t type; };
@@ -747,6 +1017,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_closure_reply_t> { typedef z
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_reply_t> { typedef z_loaned_closure_reply_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_sample_t> { typedef z_owned_closure_sample_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_sample_t> { typedef z_loaned_closure_sample_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_closure_zid_t> { typedef z_owned_closure_zid_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_closure_zid_t> { typedef z_loaned_closure_zid_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_condvar_t> { typedef z_owned_condvar_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_condvar_t> { typedef z_loaned_condvar_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_config_t> { typedef z_owned_config_t type; };
@@ -763,6 +1035,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_hello_t> { typedef z_owned_h
 template<> struct z_owned_to_loaned_type_t<z_owned_hello_t> { typedef z_loaned_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_keyexpr_t> { typedef z_owned_keyexpr_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_keyexpr_t> { typedef z_loaned_keyexpr_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_memory_layout_t> { typedef z_owned_memory_layout_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_memory_layout_t> { typedef z_loaned_memory_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_publisher_t> { typedef z_owned_publisher_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_publisher_t> { typedef z_loaned_publisher_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_query_t> { typedef z_owned_query_t type; };
@@ -783,8 +1057,18 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_sample_t> { typedef z_owned_
 template<> struct z_owned_to_loaned_type_t<z_owned_sample_t> { typedef z_loaned_sample_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_session_t> { typedef z_owned_session_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_session_t> { typedef z_loaned_session_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_client_storage_t> { typedef z_owned_shm_client_storage_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_client_storage_t> { typedef z_loaned_shm_client_storage_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_t> { typedef z_owned_shm_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_t> { typedef z_loaned_shm_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_mut_t> { typedef z_owned_shm_mut_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_mut_t> { typedef z_loaned_shm_mut_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_provider_t> { typedef z_owned_shm_provider_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_provider_t> { typedef z_loaned_shm_provider_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_slice_t> { typedef z_owned_slice_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_slice_t> { typedef z_loaned_slice_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_source_info_t> { typedef z_owned_source_info_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_source_info_t> { typedef z_loaned_source_info_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_array_t> { typedef z_owned_string_array_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_string_array_t> { typedef z_loaned_string_array_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_t> { typedef z_owned_string_t type; };
@@ -793,6 +1077,14 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_subscriber_t> { typedef z_ow
 template<> struct z_owned_to_loaned_type_t<z_owned_subscriber_t> { typedef z_loaned_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_log_t> { typedef zc_owned_closure_log_t type; };
 template<> struct z_owned_to_loaned_type_t<zc_owned_closure_log_t> { typedef zc_loaned_closure_log_t type; };
+template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_matching_status_t> { typedef zc_owned_closure_matching_status_t type; };
+template<> struct z_owned_to_loaned_type_t<zc_owned_closure_matching_status_t> { typedef zc_loaned_closure_matching_status_t type; };
+template<> struct z_loaned_to_owned_type_t<zc_loaned_liveliness_token_t> { typedef zc_owned_liveliness_token_t type; };
+template<> struct z_owned_to_loaned_type_t<zc_owned_liveliness_token_t> { typedef zc_loaned_liveliness_token_t type; };
+template<> struct z_loaned_to_owned_type_t<zc_loaned_shm_client_list_t> { typedef zc_owned_shm_client_list_t type; };
+template<> struct z_owned_to_loaned_type_t<zc_owned_shm_client_list_t> { typedef zc_loaned_shm_client_list_t type; };
+template<> struct z_loaned_to_owned_type_t<ze_loaned_querying_subscriber_t> { typedef ze_owned_querying_subscriber_t type; };
+template<> struct z_owned_to_loaned_type_t<ze_owned_querying_subscriber_t> { typedef ze_loaned_querying_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_mutex_t> { typedef z_owned_mutex_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_mutex_t> { typedef z_loaned_mutex_t type; };
 #endif  // #ifndef __cplusplus

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -4,11 +4,14 @@
 
 #ifndef __cplusplus
 
+static inline z_moved_alloc_layout_t* z_alloc_layout_move(z_owned_alloc_layout_t* x) { return (z_moved_alloc_layout_t*)(x); }
 static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return (z_moved_bytes_t*)(x); }
+static inline z_moved_chunk_alloc_result_t* z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return (z_moved_chunk_alloc_result_t*)(x); }
 static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return (z_moved_closure_hello_t*)(x); }
 static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return (z_moved_closure_query_t*)(x); }
 static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return (z_moved_closure_reply_t*)(x); }
 static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return (z_moved_closure_sample_t*)(x); }
+static inline z_moved_closure_zid_t* z_closure_zid_move(z_owned_closure_zid_t* x) { return (z_moved_closure_zid_t*)(x); }
 static inline z_moved_condvar_t* z_condvar_move(z_owned_condvar_t* x) { return (z_moved_condvar_t*)(x); }
 static inline z_moved_config_t* z_config_move(z_owned_config_t* x) { return (z_moved_config_t*)(x); }
 static inline z_moved_encoding_t* z_encoding_move(z_owned_encoding_t* x) { return (z_moved_encoding_t*)(x); }
@@ -17,6 +20,7 @@ static inline z_moved_fifo_handler_reply_t* z_fifo_handler_reply_move(z_owned_fi
 static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return (z_moved_fifo_handler_sample_t*)(x); }
 static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return (z_moved_hello_t*)(x); }
 static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return (z_moved_keyexpr_t*)(x); }
+static inline z_moved_memory_layout_t* z_memory_layout_move(z_owned_memory_layout_t* x) { return (z_moved_memory_layout_t*)(x); }
 static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return (z_moved_mutex_t*)(x); }
 static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return (z_moved_publisher_t*)(x); }
 static inline z_moved_query_t* z_query_move(z_owned_query_t* x) { return (z_moved_query_t*)(x); }
@@ -28,21 +32,36 @@ static inline z_moved_ring_handler_reply_t* z_ring_handler_reply_move(z_owned_ri
 static inline z_moved_ring_handler_sample_t* z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return (z_moved_ring_handler_sample_t*)(x); }
 static inline z_moved_sample_t* z_sample_move(z_owned_sample_t* x) { return (z_moved_sample_t*)(x); }
 static inline z_moved_session_t* z_session_move(z_owned_session_t* x) { return (z_moved_session_t*)(x); }
+static inline z_moved_shm_client_t* z_shm_client_move(z_owned_shm_client_t* x) { return (z_moved_shm_client_t*)(x); }
+static inline z_moved_shm_client_storage_t* z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return (z_moved_shm_client_storage_t*)(x); }
+static inline z_moved_shm_t* z_shm_move(z_owned_shm_t* x) { return (z_moved_shm_t*)(x); }
+static inline z_moved_shm_mut_t* z_shm_mut_move(z_owned_shm_mut_t* x) { return (z_moved_shm_mut_t*)(x); }
+static inline z_moved_shm_provider_t* z_shm_provider_move(z_owned_shm_provider_t* x) { return (z_moved_shm_provider_t*)(x); }
 static inline z_moved_slice_t* z_slice_move(z_owned_slice_t* x) { return (z_moved_slice_t*)(x); }
+static inline z_moved_source_info_t* z_source_info_move(z_owned_source_info_t* x) { return (z_moved_source_info_t*)(x); }
 static inline z_moved_string_array_t* z_string_array_move(z_owned_string_array_t* x) { return (z_moved_string_array_t*)(x); }
 static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return (z_moved_string_t*)(x); }
 static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return (z_moved_subscriber_t*)(x); }
 static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return (z_moved_task_t*)(x); }
 static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return (zc_moved_closure_log_t*)(x); }
+static inline zc_moved_closure_matching_status_t* zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return (zc_moved_closure_matching_status_t*)(x); }
+static inline zc_moved_liveliness_token_t* zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return (zc_moved_liveliness_token_t*)(x); }
+static inline zc_moved_matching_listener_t* zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return (zc_moved_matching_listener_t*)(x); }
+static inline zc_moved_shm_client_list_t* zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return (zc_moved_shm_client_list_t*)(x); }
+static inline ze_moved_publication_cache_t* ze_publication_cache_move(ze_owned_publication_cache_t* x) { return (ze_moved_publication_cache_t*)(x); }
+static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return (ze_moved_querying_subscriber_t*)(x); }
 
 
 #define z_loan(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t : z_alloc_layout_loan, \
         z_owned_bytes_t : z_bytes_loan, \
+        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_loan, \
         z_owned_closure_hello_t : z_closure_hello_loan, \
         z_owned_closure_query_t : z_closure_query_loan, \
         z_owned_closure_reply_t : z_closure_reply_loan, \
         z_owned_closure_sample_t : z_closure_sample_loan, \
+        z_owned_closure_zid_t : z_closure_zid_loan, \
         z_owned_condvar_t : z_condvar_loan, \
         z_owned_config_t : z_config_loan, \
         z_owned_encoding_t : z_encoding_loan, \
@@ -51,6 +70,7 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_loan, \
         z_owned_hello_t : z_hello_loan, \
         z_owned_keyexpr_t : z_keyexpr_loan, \
+        z_owned_memory_layout_t : z_memory_layout_loan, \
         z_owned_publisher_t : z_publisher_loan, \
         z_owned_query_t : z_query_loan, \
         z_owned_queryable_t : z_queryable_loan, \
@@ -61,14 +81,23 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_ring_handler_sample_t : z_ring_handler_sample_loan, \
         z_owned_sample_t : z_sample_loan, \
         z_owned_session_t : z_session_loan, \
+        z_owned_shm_client_storage_t : z_shm_client_storage_loan, \
+        z_owned_shm_t : z_shm_loan, \
+        z_owned_shm_mut_t : z_shm_mut_loan, \
+        z_owned_shm_provider_t : z_shm_provider_loan, \
         z_owned_slice_t : z_slice_loan, \
+        z_owned_source_info_t : z_source_info_loan, \
         z_owned_string_array_t : z_string_array_loan, \
         z_owned_string_t : z_string_loan, \
         z_owned_subscriber_t : z_subscriber_loan, \
         z_view_keyexpr_t : z_view_keyexpr_loan, \
         z_view_slice_t : z_view_slice_loan, \
         z_view_string_t : z_view_string_loan, \
-        zc_owned_closure_log_t : zc_closure_log_loan \
+        zc_owned_closure_log_t : zc_closure_log_loan, \
+        zc_owned_closure_matching_status_t : zc_closure_matching_status_loan, \
+        zc_owned_liveliness_token_t : zc_liveliness_token_loan, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_loan, \
+        ze_owned_querying_subscriber_t : ze_querying_subscriber_loan \
     )(&this_)
 
 #define z_loan_mut(this_) \
@@ -79,50 +108,72 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_encoding_t : z_encoding_loan_mut, \
         z_owned_mutex_t : z_mutex_loan_mut, \
         z_owned_publisher_t : z_publisher_loan_mut, \
-        z_owned_string_array_t : z_string_array_loan_mut \
+        z_owned_shm_t : z_shm_loan_mut, \
+        z_owned_shm_mut_t : z_shm_mut_loan_mut, \
+        z_owned_string_array_t : z_string_array_loan_mut, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_loan_mut \
     )(&this_)
 
 #define z_drop(this_) \
     _Generic((this_), \
-        z_moved_bytes_t : z_bytes_drop, \
-        z_moved_closure_hello_t : z_closure_hello_drop, \
-        z_moved_closure_query_t : z_closure_query_drop, \
-        z_moved_closure_reply_t : z_closure_reply_drop, \
-        z_moved_closure_sample_t : z_closure_sample_drop, \
-        z_moved_condvar_t : z_condvar_drop, \
-        z_moved_config_t : z_config_drop, \
-        z_moved_encoding_t : z_encoding_drop, \
-        z_moved_fifo_handler_query_t : z_fifo_handler_query_drop, \
-        z_moved_fifo_handler_reply_t : z_fifo_handler_reply_drop, \
-        z_moved_fifo_handler_sample_t : z_fifo_handler_sample_drop, \
-        z_moved_hello_t : z_hello_drop, \
-        z_moved_keyexpr_t : z_keyexpr_drop, \
-        z_moved_mutex_t : z_mutex_drop, \
-        z_moved_publisher_t : z_publisher_drop, \
-        z_moved_query_t : z_query_drop, \
-        z_moved_queryable_t : z_queryable_drop, \
-        z_moved_reply_t : z_reply_drop, \
-        z_moved_reply_err_t : z_reply_err_drop, \
-        z_moved_ring_handler_query_t : z_ring_handler_query_drop, \
-        z_moved_ring_handler_reply_t : z_ring_handler_reply_drop, \
-        z_moved_ring_handler_sample_t : z_ring_handler_sample_drop, \
-        z_moved_sample_t : z_sample_drop, \
-        z_moved_session_t : z_session_drop, \
-        z_moved_slice_t : z_slice_drop, \
-        z_moved_string_array_t : z_string_array_drop, \
-        z_moved_string_t : z_string_drop, \
-        z_moved_subscriber_t : z_subscriber_drop, \
-        z_moved_task_t : z_task_drop, \
-        zc_moved_closure_log_t : zc_closure_log_drop \
+        z_moved_alloc_layout_t* : z_alloc_layout_drop, \
+        z_moved_bytes_t* : z_bytes_drop, \
+        z_moved_chunk_alloc_result_t* : z_chunk_alloc_result_drop, \
+        z_moved_closure_hello_t* : z_closure_hello_drop, \
+        z_moved_closure_query_t* : z_closure_query_drop, \
+        z_moved_closure_reply_t* : z_closure_reply_drop, \
+        z_moved_closure_sample_t* : z_closure_sample_drop, \
+        z_moved_closure_zid_t* : z_closure_zid_drop, \
+        z_moved_condvar_t* : z_condvar_drop, \
+        z_moved_config_t* : z_config_drop, \
+        z_moved_encoding_t* : z_encoding_drop, \
+        z_moved_fifo_handler_query_t* : z_fifo_handler_query_drop, \
+        z_moved_fifo_handler_reply_t* : z_fifo_handler_reply_drop, \
+        z_moved_fifo_handler_sample_t* : z_fifo_handler_sample_drop, \
+        z_moved_hello_t* : z_hello_drop, \
+        z_moved_keyexpr_t* : z_keyexpr_drop, \
+        z_moved_memory_layout_t* : z_memory_layout_drop, \
+        z_moved_mutex_t* : z_mutex_drop, \
+        z_moved_publisher_t* : z_publisher_drop, \
+        z_moved_query_t* : z_query_drop, \
+        z_moved_queryable_t* : z_queryable_drop, \
+        z_moved_reply_t* : z_reply_drop, \
+        z_moved_reply_err_t* : z_reply_err_drop, \
+        z_moved_ring_handler_query_t* : z_ring_handler_query_drop, \
+        z_moved_ring_handler_reply_t* : z_ring_handler_reply_drop, \
+        z_moved_ring_handler_sample_t* : z_ring_handler_sample_drop, \
+        z_moved_sample_t* : z_sample_drop, \
+        z_moved_session_t* : z_session_drop, \
+        z_moved_shm_client_t* : z_shm_client_drop, \
+        z_moved_shm_client_storage_t* : z_shm_client_storage_drop, \
+        z_moved_shm_t* : z_shm_drop, \
+        z_moved_shm_mut_t* : z_shm_mut_drop, \
+        z_moved_shm_provider_t* : z_shm_provider_drop, \
+        z_moved_slice_t* : z_slice_drop, \
+        z_moved_source_info_t* : z_source_info_drop, \
+        z_moved_string_array_t* : z_string_array_drop, \
+        z_moved_string_t* : z_string_drop, \
+        z_moved_subscriber_t* : z_subscriber_drop, \
+        z_moved_task_t* : z_task_drop, \
+        zc_moved_closure_log_t* : zc_closure_log_drop, \
+        zc_moved_closure_matching_status_t* : zc_closure_matching_status_drop, \
+        zc_moved_liveliness_token_t* : zc_liveliness_token_drop, \
+        zc_moved_matching_listener_t* : zc_publisher_matching_listener_drop, \
+        zc_moved_shm_client_list_t* : zc_shm_client_list_drop, \
+        ze_moved_publication_cache_t* : ze_publication_cache_drop, \
+        ze_moved_querying_subscriber_t* : ze_querying_subscriber_drop \
     )(this_)
 
 #define z_move(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t : z_alloc_layout_move, \
         z_owned_bytes_t : z_bytes_move, \
+        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_move, \
         z_owned_closure_hello_t : z_closure_hello_move, \
         z_owned_closure_query_t : z_closure_query_move, \
         z_owned_closure_reply_t : z_closure_reply_move, \
         z_owned_closure_sample_t : z_closure_sample_move, \
+        z_owned_closure_zid_t : z_closure_zid_move, \
         z_owned_condvar_t : z_condvar_move, \
         z_owned_config_t : z_config_move, \
         z_owned_encoding_t : z_encoding_move, \
@@ -131,6 +182,7 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_move, \
         z_owned_hello_t : z_hello_move, \
         z_owned_keyexpr_t : z_keyexpr_move, \
+        z_owned_memory_layout_t : z_memory_layout_move, \
         z_owned_mutex_t : z_mutex_move, \
         z_owned_publisher_t : z_publisher_move, \
         z_owned_query_t : z_query_move, \
@@ -142,21 +194,36 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_ring_handler_sample_t : z_ring_handler_sample_move, \
         z_owned_sample_t : z_sample_move, \
         z_owned_session_t : z_session_move, \
+        z_owned_shm_client_t : z_shm_client_move, \
+        z_owned_shm_client_storage_t : z_shm_client_storage_move, \
+        z_owned_shm_t : z_shm_move, \
+        z_owned_shm_mut_t : z_shm_mut_move, \
+        z_owned_shm_provider_t : z_shm_provider_move, \
         z_owned_slice_t : z_slice_move, \
+        z_owned_source_info_t : z_source_info_move, \
         z_owned_string_array_t : z_string_array_move, \
         z_owned_string_t : z_string_move, \
         z_owned_subscriber_t : z_subscriber_move, \
         z_owned_task_t : z_task_move, \
-        zc_owned_closure_log_t : zc_closure_log_move \
+        zc_owned_closure_log_t : zc_closure_log_move, \
+        zc_owned_closure_matching_status_t : zc_closure_matching_status_move, \
+        zc_owned_liveliness_token_t : zc_liveliness_token_move, \
+        zc_owned_matching_listener_t : zc_publisher_matching_listener_move, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_move, \
+        ze_owned_publication_cache_t : ze_publication_cache_move, \
+        ze_owned_querying_subscriber_t : ze_querying_subscriber_move \
     )(&this_)
 
 #define z_null(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t* : z_alloc_layout_null, \
         z_owned_bytes_t* : z_bytes_null, \
+        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_null, \
         z_owned_closure_hello_t* : z_closure_hello_null, \
         z_owned_closure_query_t* : z_closure_query_null, \
         z_owned_closure_reply_t* : z_closure_reply_null, \
         z_owned_closure_sample_t* : z_closure_sample_null, \
+        z_owned_closure_zid_t* : z_closure_zid_null, \
         z_owned_condvar_t* : z_condvar_null, \
         z_owned_config_t* : z_config_null, \
         z_owned_encoding_t* : z_encoding_null, \
@@ -165,6 +232,7 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_null, \
         z_owned_hello_t* : z_hello_null, \
         z_owned_keyexpr_t* : z_keyexpr_null, \
+        z_owned_memory_layout_t* : z_memory_layout_null, \
         z_owned_mutex_t* : z_mutex_null, \
         z_owned_publisher_t* : z_publisher_null, \
         z_owned_query_t* : z_query_null, \
@@ -176,19 +244,34 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_null, \
         z_owned_sample_t* : z_sample_null, \
         z_owned_session_t* : z_session_null, \
+        z_owned_shm_client_t* : z_shm_client_null, \
+        z_owned_shm_client_storage_t* : z_shm_client_storage_null, \
+        z_owned_shm_mut_t* : z_shm_mut_null, \
+        z_owned_shm_t* : z_shm_null, \
+        z_owned_shm_provider_t* : z_shm_provider_null, \
         z_owned_slice_t* : z_slice_null, \
+        z_owned_source_info_t* : z_source_info_null, \
         z_owned_string_array_t* : z_string_array_null, \
         z_owned_string_t* : z_string_null, \
         z_owned_subscriber_t* : z_subscriber_null, \
         z_owned_task_t* : z_task_null, \
-        zc_owned_closure_log_t* : zc_closure_log_null \
+        zc_owned_closure_log_t* : zc_closure_log_null, \
+        zc_owned_closure_matching_status_t* : zc_closure_matching_status_null, \
+        zc_owned_liveliness_token_t* : zc_liveliness_token_null, \
+        zc_owned_matching_listener_t* : zc_matching_listener_null, \
+        zc_owned_shm_client_list_t* : zc_shm_client_list_null, \
+        ze_owned_publication_cache_t* : ze_publication_cache_null, \
+        ze_owned_querying_subscriber_t* : ze_querying_subscriber_null \
     )(this_)
 
+static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) { *this_ = x->_this; z_alloc_layout_null(&x->_this); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *this_ = x->_this; z_bytes_null(&x->_this); }
+static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) { *this_ = x->_this; z_chunk_alloc_result_null(&x->_this); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_closure_hello_null(&x->_this); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_closure_query_null(&x->_this); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_closure_reply_null(&x->_this); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_closure_sample_null(&x->_this); }
+static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) { *closure_ = x->_this; z_closure_zid_null(&x->_this); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) { *this_ = x->_this; z_condvar_null(&x->_this); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t* x) { *this_ = x->_this; z_config_null(&x->_this); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t* x) { *this_ = x->_this; z_encoding_null(&x->_this); }
@@ -197,6 +280,7 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t* x) { *this_ = x->_this; z_fifo_handler_sample_null(&x->_this); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_hello_null(&x->_this); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_keyexpr_null(&x->_this); }
+static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) { *this_ = x->_this; z_memory_layout_null(&x->_this); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_mutex_null(&x->_this); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_publisher_null(&x->_this); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t* x) { *this_ = x->_this; z_query_null(&x->_this); }
@@ -208,21 +292,36 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t* x) { *this_ = x->_this; z_ring_handler_sample_null(&x->_this); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t* x) { *this_ = x->_this; z_sample_null(&x->_this); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t* x) { *this_ = x->_this; z_session_null(&x->_this); }
+static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) { *this_ = x->_this; z_shm_client_null(&x->_this); }
+static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) { *this_ = x->_this; z_shm_client_storage_null(&x->_this); }
+static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t* x) { *this_ = x->_this; z_shm_null(&x->_this); }
+static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) { *this_ = x->_this; z_shm_mut_null(&x->_this); }
+static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) { *this_ = x->_this; z_shm_provider_null(&x->_this); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t* x) { *this_ = x->_this; z_slice_null(&x->_this); }
+static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) { *this_ = x->_this; z_source_info_null(&x->_this); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) { *this_ = x->_this; z_string_array_null(&x->_this); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) { *this_ = x->_this; z_string_null(&x->_this); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_subscriber_null(&x->_this); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_task_null(&x->_this); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_closure_log_null(&x->_this); }
+static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) { *closure_ = x->_this; zc_closure_matching_status_null(&x->_this); }
+static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) { *this_ = x->_this; zc_liveliness_token_null(&x->_this); }
+static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) { *this_ = x->_this; zc_matching_listener_null(&x->_this); }
+static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) { *this_ = x->_this; zc_shm_client_list_null(&x->_this); }
+static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) { *this_ = x->_this; ze_publication_cache_null(&x->_this); }
+static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) { *this_ = x->_this; ze_querying_subscriber_null(&x->_this); }
 
 
 #define z_take(this_, x) \
     _Generic((this_), \
+        z_owned_alloc_layout_t* : z_alloc_layout_take, \
         z_owned_bytes_t* : z_bytes_take, \
+        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_take, \
         z_owned_closure_hello_t* : z_closure_hello_take, \
         z_owned_closure_query_t* : z_closure_query_take, \
         z_owned_closure_reply_t* : z_closure_reply_take, \
         z_owned_closure_sample_t* : z_closure_sample_take, \
+        z_owned_closure_zid_t* : z_closure_zid_take, \
         z_owned_condvar_t* : z_condvar_take, \
         z_owned_config_t* : z_config_take, \
         z_owned_encoding_t* : z_encoding_take, \
@@ -231,6 +330,7 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_take, \
         z_owned_hello_t* : z_hello_take, \
         z_owned_keyexpr_t* : z_keyexpr_take, \
+        z_owned_memory_layout_t* : z_memory_layout_take, \
         z_owned_mutex_t* : z_mutex_take, \
         z_owned_publisher_t* : z_publisher_take, \
         z_owned_query_t* : z_query_take, \
@@ -242,21 +342,36 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_take, \
         z_owned_sample_t* : z_sample_take, \
         z_owned_session_t* : z_session_take, \
+        z_owned_shm_client_t* : z_shm_client_take, \
+        z_owned_shm_client_storage_t* : z_shm_client_storage_take, \
+        z_owned_shm_t* : z_shm_take, \
+        z_owned_shm_mut_t* : z_shm_mut_take, \
+        z_owned_shm_provider_t* : z_shm_provider_take, \
         z_owned_slice_t* : z_slice_take, \
+        z_owned_source_info_t* : z_source_info_take, \
         z_owned_string_array_t* : z_string_array_take, \
         z_owned_string_t* : z_string_take, \
         z_owned_subscriber_t* : z_subscriber_take, \
         z_owned_task_t* : z_task_take, \
-        zc_owned_closure_log_t* : zc_closure_log_take \
+        zc_owned_closure_log_t* : zc_closure_log_take, \
+        zc_owned_closure_matching_status_t* : zc_closure_matching_status_take, \
+        zc_owned_liveliness_token_t* : zc_liveliness_token_take, \
+        zc_owned_matching_listener_t* : zc_publisher_matching_listener_take, \
+        zc_owned_shm_client_list_t* : zc_shm_client_list_take, \
+        ze_owned_publication_cache_t* : ze_publication_cache_take, \
+        ze_owned_querying_subscriber_t* : ze_querying_subscriber_take \
     )(this_, x)
 
 #define z_check(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t : z_alloc_layout_check, \
         z_owned_bytes_t : z_bytes_check, \
+        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_check, \
         z_owned_closure_hello_t : z_closure_hello_check, \
         z_owned_closure_query_t : z_closure_query_check, \
         z_owned_closure_reply_t : z_closure_reply_check, \
         z_owned_closure_sample_t : z_closure_sample_check, \
+        z_owned_closure_zid_t : z_closure_zid_check, \
         z_owned_condvar_t : z_condvar_check, \
         z_owned_config_t : z_config_check, \
         z_owned_encoding_t : z_encoding_check, \
@@ -265,6 +380,7 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_check, \
         z_owned_hello_t : z_hello_check, \
         z_owned_keyexpr_t : z_keyexpr_check, \
+        z_owned_memory_layout_t : z_memory_layout_check, \
         z_owned_mutex_t : z_mutex_check, \
         z_owned_publisher_t : z_publisher_check, \
         z_owned_query_t : z_query_check, \
@@ -276,12 +392,24 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         z_owned_ring_handler_sample_t : z_ring_handler_sample_check, \
         z_owned_sample_t : z_sample_check, \
         z_owned_session_t : z_session_check, \
+        z_owned_shm_t : z_shm_check, \
+        z_owned_shm_client_t : z_shm_client_check, \
+        z_owned_shm_client_storage_t : z_shm_client_storage_check, \
+        z_owned_shm_mut_t : z_shm_mut_check, \
+        z_owned_shm_provider_t : z_shm_provider_check, \
         z_owned_slice_t : z_slice_check, \
+        z_owned_source_info_t : z_source_info_check, \
         z_owned_string_array_t : z_string_array_check, \
         z_owned_string_t : z_string_check, \
         z_owned_subscriber_t : z_subscriber_check, \
         z_owned_task_t : z_task_check, \
-        zc_owned_closure_log_t : zc_closure_log_check \
+        zc_owned_closure_log_t : zc_closure_log_check, \
+        zc_owned_closure_matching_status_t : zc_closure_matching_status_check, \
+        zc_owned_liveliness_token_t : zc_liveliness_token_check, \
+        zc_owned_matching_listener_t : zc_matching_listener_check, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_check, \
+        ze_owned_publication_cache_t : ze_publication_cache_check, \
+        ze_owned_querying_subscriber_t : ze_querying_subscriber_check \
     )(&this_)
 
 #define z_call(closure, hello) \
@@ -289,7 +417,9 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         const z_loaned_closure_hello_t* : z_closure_hello_call, \
         const z_loaned_closure_query_t* : z_closure_query_call, \
         const z_loaned_closure_reply_t* : z_closure_reply_call, \
-        const z_loaned_closure_sample_t* : z_closure_sample_call \
+        const z_loaned_closure_sample_t* : z_closure_sample_call, \
+        const z_loaned_closure_zid_t* : z_closure_zid_call, \
+        const zc_loaned_closure_matching_status_t* : zc_closure_matching_status_call \
     )(closure, hello)
 
 #define z_closure(x, callback, dropper, ctx) \
@@ -317,11 +447,14 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
 #else  // #ifndef __cplusplus
 
 
+static inline z_moved_alloc_layout_t* z_alloc_layout_move(z_owned_alloc_layout_t* x) { return reinterpret_cast<z_moved_alloc_layout_t*>(x); }
 static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return reinterpret_cast<z_moved_bytes_t*>(x); }
+static inline z_moved_chunk_alloc_result_t* z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return reinterpret_cast<z_moved_chunk_alloc_result_t*>(x); }
 static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return reinterpret_cast<z_moved_closure_hello_t*>(x); }
 static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return reinterpret_cast<z_moved_closure_query_t*>(x); }
 static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return reinterpret_cast<z_moved_closure_reply_t*>(x); }
 static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return reinterpret_cast<z_moved_closure_sample_t*>(x); }
+static inline z_moved_closure_zid_t* z_closure_zid_move(z_owned_closure_zid_t* x) { return reinterpret_cast<z_moved_closure_zid_t*>(x); }
 static inline z_moved_condvar_t* z_condvar_move(z_owned_condvar_t* x) { return reinterpret_cast<z_moved_condvar_t*>(x); }
 static inline z_moved_config_t* z_config_move(z_owned_config_t* x) { return reinterpret_cast<z_moved_config_t*>(x); }
 static inline z_moved_encoding_t* z_encoding_move(z_owned_encoding_t* x) { return reinterpret_cast<z_moved_encoding_t*>(x); }
@@ -330,6 +463,7 @@ static inline z_moved_fifo_handler_reply_t* z_fifo_handler_reply_move(z_owned_fi
 static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return reinterpret_cast<z_moved_fifo_handler_sample_t*>(x); }
 static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return reinterpret_cast<z_moved_hello_t*>(x); }
 static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return reinterpret_cast<z_moved_keyexpr_t*>(x); }
+static inline z_moved_memory_layout_t* z_memory_layout_move(z_owned_memory_layout_t* x) { return reinterpret_cast<z_moved_memory_layout_t*>(x); }
 static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return reinterpret_cast<z_moved_mutex_t*>(x); }
 static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return reinterpret_cast<z_moved_publisher_t*>(x); }
 static inline z_moved_query_t* z_query_move(z_owned_query_t* x) { return reinterpret_cast<z_moved_query_t*>(x); }
@@ -341,20 +475,35 @@ static inline z_moved_ring_handler_reply_t* z_ring_handler_reply_move(z_owned_ri
 static inline z_moved_ring_handler_sample_t* z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return reinterpret_cast<z_moved_ring_handler_sample_t*>(x); }
 static inline z_moved_sample_t* z_sample_move(z_owned_sample_t* x) { return reinterpret_cast<z_moved_sample_t*>(x); }
 static inline z_moved_session_t* z_session_move(z_owned_session_t* x) { return reinterpret_cast<z_moved_session_t*>(x); }
+static inline z_moved_shm_client_t* z_shm_client_move(z_owned_shm_client_t* x) { return reinterpret_cast<z_moved_shm_client_t*>(x); }
+static inline z_moved_shm_client_storage_t* z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return reinterpret_cast<z_moved_shm_client_storage_t*>(x); }
+static inline z_moved_shm_t* z_shm_move(z_owned_shm_t* x) { return reinterpret_cast<z_moved_shm_t*>(x); }
+static inline z_moved_shm_mut_t* z_shm_mut_move(z_owned_shm_mut_t* x) { return reinterpret_cast<z_moved_shm_mut_t*>(x); }
+static inline z_moved_shm_provider_t* z_shm_provider_move(z_owned_shm_provider_t* x) { return reinterpret_cast<z_moved_shm_provider_t*>(x); }
 static inline z_moved_slice_t* z_slice_move(z_owned_slice_t* x) { return reinterpret_cast<z_moved_slice_t*>(x); }
+static inline z_moved_source_info_t* z_source_info_move(z_owned_source_info_t* x) { return reinterpret_cast<z_moved_source_info_t*>(x); }
 static inline z_moved_string_array_t* z_string_array_move(z_owned_string_array_t* x) { return reinterpret_cast<z_moved_string_array_t*>(x); }
 static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return reinterpret_cast<z_moved_string_t*>(x); }
 static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return reinterpret_cast<z_moved_subscriber_t*>(x); }
 static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return reinterpret_cast<z_moved_task_t*>(x); }
 static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return reinterpret_cast<zc_moved_closure_log_t*>(x); }
+static inline zc_moved_closure_matching_status_t* zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return reinterpret_cast<zc_moved_closure_matching_status_t*>(x); }
+static inline zc_moved_liveliness_token_t* zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return reinterpret_cast<zc_moved_liveliness_token_t*>(x); }
+static inline zc_moved_matching_listener_t* zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return reinterpret_cast<zc_moved_matching_listener_t*>(x); }
+static inline zc_moved_shm_client_list_t* zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return reinterpret_cast<zc_moved_shm_client_list_t*>(x); }
+static inline ze_moved_publication_cache_t* ze_publication_cache_move(ze_owned_publication_cache_t* x) { return reinterpret_cast<ze_moved_publication_cache_t*>(x); }
+static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return reinterpret_cast<ze_moved_querying_subscriber_t*>(x); }
 
 
 
+inline const z_loaned_alloc_layout_t* z_loan(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_loan(&this_); };
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& this_) { return z_bytes_loan(&this_); };
+inline const z_loaned_chunk_alloc_result_t* z_loan(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_loan(&this_); };
 inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t& closure) { return z_closure_hello_loan(&closure); };
 inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t& closure) { return z_closure_query_loan(&closure); };
 inline const z_loaned_closure_reply_t* z_loan(const z_owned_closure_reply_t& closure) { return z_closure_reply_loan(&closure); };
 inline const z_loaned_closure_sample_t* z_loan(const z_owned_closure_sample_t& closure) { return z_closure_sample_loan(&closure); };
+inline const z_loaned_closure_zid_t* z_loan(const z_owned_closure_zid_t& closure) { return z_closure_zid_loan(&closure); };
 inline const z_loaned_condvar_t* z_loan(const z_owned_condvar_t& this_) { return z_condvar_loan(&this_); };
 inline const z_loaned_config_t* z_loan(const z_owned_config_t& this_) { return z_config_loan(&this_); };
 inline const z_loaned_encoding_t* z_loan(const z_owned_encoding_t& this_) { return z_encoding_loan(&this_); };
@@ -363,6 +512,7 @@ inline const z_loaned_fifo_handler_reply_t* z_loan(const z_owned_fifo_handler_re
 inline const z_loaned_fifo_handler_sample_t* z_loan(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_loan(&this_); };
 inline const z_loaned_hello_t* z_loan(const z_owned_hello_t& this_) { return z_hello_loan(&this_); };
 inline const z_loaned_keyexpr_t* z_loan(const z_owned_keyexpr_t& this_) { return z_keyexpr_loan(&this_); };
+inline const z_loaned_memory_layout_t* z_loan(const z_owned_memory_layout_t& this_) { return z_memory_layout_loan(&this_); };
 inline const z_loaned_publisher_t* z_loan(const z_owned_publisher_t& this_) { return z_publisher_loan(&this_); };
 inline const z_loaned_query_t* z_loan(const z_owned_query_t& this_) { return z_query_loan(&this_); };
 inline const z_loaned_queryable_t* z_loan(const z_owned_queryable_t& this_) { return z_queryable_loan(&this_); };
@@ -373,7 +523,12 @@ inline const z_loaned_ring_handler_reply_t* z_loan(const z_owned_ring_handler_re
 inline const z_loaned_ring_handler_sample_t* z_loan(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_loan(&this_); };
 inline const z_loaned_sample_t* z_loan(const z_owned_sample_t& this_) { return z_sample_loan(&this_); };
 inline const z_loaned_session_t* z_loan(const z_owned_session_t& this_) { return z_session_loan(&this_); };
+inline const z_loaned_shm_client_storage_t* z_loan(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_loan(&this_); };
+inline const z_loaned_shm_t* z_loan(const z_owned_shm_t& this_) { return z_shm_loan(&this_); };
+inline const z_loaned_shm_mut_t* z_loan(const z_owned_shm_mut_t& this_) { return z_shm_mut_loan(&this_); };
+inline const z_loaned_shm_provider_t* z_loan(const z_owned_shm_provider_t& this_) { return z_shm_provider_loan(&this_); };
 inline const z_loaned_slice_t* z_loan(const z_owned_slice_t& this_) { return z_slice_loan(&this_); };
+inline const z_loaned_source_info_t* z_loan(const z_owned_source_info_t& this_) { return z_source_info_loan(&this_); };
 inline const z_loaned_string_array_t* z_loan(const z_owned_string_array_t& this_) { return z_string_array_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_owned_string_t& this_) { return z_string_loan(&this_); };
 inline const z_loaned_subscriber_t* z_loan(const z_owned_subscriber_t& this_) { return z_subscriber_loan(&this_); };
@@ -381,6 +536,10 @@ inline const z_loaned_keyexpr_t* z_loan(const z_view_keyexpr_t& this_) { return 
 inline const z_loaned_slice_t* z_loan(const z_view_slice_t& this_) { return z_view_slice_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_view_string_t& this_) { return z_view_string_loan(&this_); };
 inline const zc_loaned_closure_log_t* z_loan(const zc_owned_closure_log_t& closure) { return zc_closure_log_loan(&closure); };
+inline const zc_loaned_closure_matching_status_t* z_loan(const zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_loan(&closure); };
+inline const zc_loaned_liveliness_token_t* z_loan(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_loan(&this_); };
+inline const zc_loaned_shm_client_list_t* z_loan(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan(&this_); };
+inline const ze_loaned_querying_subscriber_t* z_loan(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_loan(&this_); };
 
 
 inline z_loaned_bytes_t* z_loan_mut(z_owned_bytes_t& this_) { return z_bytes_loan_mut(&this_); };
@@ -389,46 +548,68 @@ inline z_loaned_config_t* z_loan_mut(z_owned_config_t& this_) { return z_config_
 inline z_loaned_encoding_t* z_loan_mut(z_owned_encoding_t& this_) { return z_encoding_loan_mut(&this_); };
 inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t& this_) { return z_mutex_loan_mut(&this_); };
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& this_) { return z_publisher_loan_mut(&this_); };
+inline z_loaned_shm_t* z_loan_mut(z_owned_shm_t& this_) { return z_shm_loan_mut(&this_); };
+inline z_loaned_shm_mut_t* z_loan_mut(z_owned_shm_mut_t& this_) { return z_shm_mut_loan_mut(&this_); };
 inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { return z_string_array_loan_mut(&this_); };
+inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan_mut(&this_); };
 
 
-inline void z_drop(z_moved_bytes_t this_) { z_bytes_drop(this_); };
-inline void z_drop(z_moved_closure_hello_t this_) { z_closure_hello_drop(this_); };
-inline void z_drop(z_moved_closure_query_t closure_) { z_closure_query_drop(closure_); };
-inline void z_drop(z_moved_closure_reply_t closure_) { z_closure_reply_drop(closure_); };
-inline void z_drop(z_moved_closure_sample_t closure_) { z_closure_sample_drop(closure_); };
-inline void z_drop(z_moved_condvar_t this_) { z_condvar_drop(this_); };
-inline void z_drop(z_moved_config_t this_) { z_config_drop(this_); };
-inline void z_drop(z_moved_encoding_t this_) { z_encoding_drop(this_); };
-inline void z_drop(z_moved_fifo_handler_query_t this_) { z_fifo_handler_query_drop(this_); };
-inline void z_drop(z_moved_fifo_handler_reply_t this_) { z_fifo_handler_reply_drop(this_); };
-inline void z_drop(z_moved_fifo_handler_sample_t this_) { z_fifo_handler_sample_drop(this_); };
-inline void z_drop(z_moved_hello_t this_) { z_hello_drop(this_); };
-inline void z_drop(z_moved_keyexpr_t this_) { z_keyexpr_drop(this_); };
-inline void z_drop(z_moved_mutex_t this_) { z_mutex_drop(this_); };
-inline void z_drop(z_moved_publisher_t this_) { z_publisher_drop(this_); };
-inline void z_drop(z_moved_query_t this_) { z_query_drop(this_); };
-inline void z_drop(z_moved_queryable_t this_) { z_queryable_drop(this_); };
-inline void z_drop(z_moved_reply_t this_) { z_reply_drop(this_); };
-inline void z_drop(z_moved_reply_err_t this_) { z_reply_err_drop(this_); };
-inline void z_drop(z_moved_ring_handler_query_t this_) { z_ring_handler_query_drop(this_); };
-inline void z_drop(z_moved_ring_handler_reply_t this_) { z_ring_handler_reply_drop(this_); };
-inline void z_drop(z_moved_ring_handler_sample_t this_) { z_ring_handler_sample_drop(this_); };
-inline void z_drop(z_moved_sample_t this_) { z_sample_drop(this_); };
-inline void z_drop(z_moved_session_t this_) { z_session_drop(this_); };
-inline void z_drop(z_moved_slice_t this_) { z_slice_drop(this_); };
-inline void z_drop(z_moved_string_array_t this_) { z_string_array_drop(this_); };
-inline void z_drop(z_moved_string_t this_) { z_string_drop(this_); };
-inline void z_drop(z_moved_subscriber_t this_) { z_subscriber_drop(this_); };
-inline void z_drop(z_moved_task_t this_) { z_task_drop(this_); };
-inline void z_drop(zc_moved_closure_log_t closure_) { zc_closure_log_drop(closure_); };
+inline void z_drop(z_moved_alloc_layout_t* this_) { z_alloc_layout_drop(this_); };
+inline void z_drop(z_moved_bytes_t* this_) { z_bytes_drop(this_); };
+inline void z_drop(z_moved_chunk_alloc_result_t* this_) { z_chunk_alloc_result_drop(this_); };
+inline void z_drop(z_moved_closure_hello_t* this_) { z_closure_hello_drop(this_); };
+inline void z_drop(z_moved_closure_query_t* closure_) { z_closure_query_drop(closure_); };
+inline void z_drop(z_moved_closure_reply_t* closure_) { z_closure_reply_drop(closure_); };
+inline void z_drop(z_moved_closure_sample_t* closure_) { z_closure_sample_drop(closure_); };
+inline void z_drop(z_moved_closure_zid_t* closure_) { z_closure_zid_drop(closure_); };
+inline void z_drop(z_moved_condvar_t* this_) { z_condvar_drop(this_); };
+inline void z_drop(z_moved_config_t* this_) { z_config_drop(this_); };
+inline void z_drop(z_moved_encoding_t* this_) { z_encoding_drop(this_); };
+inline void z_drop(z_moved_fifo_handler_query_t* this_) { z_fifo_handler_query_drop(this_); };
+inline void z_drop(z_moved_fifo_handler_reply_t* this_) { z_fifo_handler_reply_drop(this_); };
+inline void z_drop(z_moved_fifo_handler_sample_t* this_) { z_fifo_handler_sample_drop(this_); };
+inline void z_drop(z_moved_hello_t* this_) { z_hello_drop(this_); };
+inline void z_drop(z_moved_keyexpr_t* this_) { z_keyexpr_drop(this_); };
+inline void z_drop(z_moved_memory_layout_t* this_) { z_memory_layout_drop(this_); };
+inline void z_drop(z_moved_mutex_t* this_) { z_mutex_drop(this_); };
+inline void z_drop(z_moved_publisher_t* this_) { z_publisher_drop(this_); };
+inline void z_drop(z_moved_query_t* this_) { z_query_drop(this_); };
+inline void z_drop(z_moved_queryable_t* this_) { z_queryable_drop(this_); };
+inline void z_drop(z_moved_reply_t* this_) { z_reply_drop(this_); };
+inline void z_drop(z_moved_reply_err_t* this_) { z_reply_err_drop(this_); };
+inline void z_drop(z_moved_ring_handler_query_t* this_) { z_ring_handler_query_drop(this_); };
+inline void z_drop(z_moved_ring_handler_reply_t* this_) { z_ring_handler_reply_drop(this_); };
+inline void z_drop(z_moved_ring_handler_sample_t* this_) { z_ring_handler_sample_drop(this_); };
+inline void z_drop(z_moved_sample_t* this_) { z_sample_drop(this_); };
+inline void z_drop(z_moved_session_t* this_) { z_session_drop(this_); };
+inline void z_drop(z_moved_shm_client_t* this_) { z_shm_client_drop(this_); };
+inline void z_drop(z_moved_shm_client_storage_t* this_) { z_shm_client_storage_drop(this_); };
+inline void z_drop(z_moved_shm_t* this_) { z_shm_drop(this_); };
+inline void z_drop(z_moved_shm_mut_t* this_) { z_shm_mut_drop(this_); };
+inline void z_drop(z_moved_shm_provider_t* this_) { z_shm_provider_drop(this_); };
+inline void z_drop(z_moved_slice_t* this_) { z_slice_drop(this_); };
+inline void z_drop(z_moved_source_info_t* this_) { z_source_info_drop(this_); };
+inline void z_drop(z_moved_string_array_t* this_) { z_string_array_drop(this_); };
+inline void z_drop(z_moved_string_t* this_) { z_string_drop(this_); };
+inline void z_drop(z_moved_subscriber_t* this_) { z_subscriber_drop(this_); };
+inline void z_drop(z_moved_task_t* this_) { z_task_drop(this_); };
+inline void z_drop(zc_moved_closure_log_t* closure_) { zc_closure_log_drop(closure_); };
+inline void z_drop(zc_moved_closure_matching_status_t* closure_) { zc_closure_matching_status_drop(closure_); };
+inline void z_drop(zc_moved_liveliness_token_t* this_) { zc_liveliness_token_drop(this_); };
+inline z_result_t z_drop(zc_moved_matching_listener_t* this_) { return zc_publisher_matching_listener_drop(this_); };
+inline void z_drop(zc_moved_shm_client_list_t* this_) { zc_shm_client_list_drop(this_); };
+inline void z_drop(ze_moved_publication_cache_t* this_) { ze_publication_cache_drop(this_); };
+inline void z_drop(ze_moved_querying_subscriber_t* this_) { ze_querying_subscriber_drop(this_); };
 
 
+inline z_moved_alloc_layout_t* z_move(z_owned_alloc_layout_t& this_) { return z_alloc_layout_move(&this_); };
 inline z_moved_bytes_t* z_move(z_owned_bytes_t& this_) { return z_bytes_move(&this_); };
+inline z_moved_chunk_alloc_result_t* z_move(z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_move(&this_); };
 inline z_moved_closure_hello_t* z_move(z_owned_closure_hello_t& this_) { return z_closure_hello_move(&this_); };
 inline z_moved_closure_query_t* z_move(z_owned_closure_query_t& closure_) { return z_closure_query_move(&closure_); };
 inline z_moved_closure_reply_t* z_move(z_owned_closure_reply_t& closure_) { return z_closure_reply_move(&closure_); };
 inline z_moved_closure_sample_t* z_move(z_owned_closure_sample_t& closure_) { return z_closure_sample_move(&closure_); };
+inline z_moved_closure_zid_t* z_move(z_owned_closure_zid_t& closure_) { return z_closure_zid_move(&closure_); };
 inline z_moved_condvar_t* z_move(z_owned_condvar_t& this_) { return z_condvar_move(&this_); };
 inline z_moved_config_t* z_move(z_owned_config_t& this_) { return z_config_move(&this_); };
 inline z_moved_encoding_t* z_move(z_owned_encoding_t& this_) { return z_encoding_move(&this_); };
@@ -437,6 +618,7 @@ inline z_moved_fifo_handler_reply_t* z_move(z_owned_fifo_handler_reply_t& this_)
 inline z_moved_fifo_handler_sample_t* z_move(z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_move(&this_); };
 inline z_moved_hello_t* z_move(z_owned_hello_t& this_) { return z_hello_move(&this_); };
 inline z_moved_keyexpr_t* z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
+inline z_moved_memory_layout_t* z_move(z_owned_memory_layout_t& this_) { return z_memory_layout_move(&this_); };
 inline z_moved_mutex_t* z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
 inline z_moved_publisher_t* z_move(z_owned_publisher_t& this_) { return z_publisher_move(&this_); };
 inline z_moved_query_t* z_move(z_owned_query_t& this_) { return z_query_move(&this_); };
@@ -448,19 +630,34 @@ inline z_moved_ring_handler_reply_t* z_move(z_owned_ring_handler_reply_t& this_)
 inline z_moved_ring_handler_sample_t* z_move(z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_move(&this_); };
 inline z_moved_sample_t* z_move(z_owned_sample_t& this_) { return z_sample_move(&this_); };
 inline z_moved_session_t* z_move(z_owned_session_t& this_) { return z_session_move(&this_); };
+inline z_moved_shm_client_t* z_move(z_owned_shm_client_t& this_) { return z_shm_client_move(&this_); };
+inline z_moved_shm_client_storage_t* z_move(z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_move(&this_); };
+inline z_moved_shm_t* z_move(z_owned_shm_t& this_) { return z_shm_move(&this_); };
+inline z_moved_shm_mut_t* z_move(z_owned_shm_mut_t& this_) { return z_shm_mut_move(&this_); };
+inline z_moved_shm_provider_t* z_move(z_owned_shm_provider_t& this_) { return z_shm_provider_move(&this_); };
 inline z_moved_slice_t* z_move(z_owned_slice_t& this_) { return z_slice_move(&this_); };
+inline z_moved_source_info_t* z_move(z_owned_source_info_t& this_) { return z_source_info_move(&this_); };
 inline z_moved_string_array_t* z_move(z_owned_string_array_t& this_) { return z_string_array_move(&this_); };
 inline z_moved_string_t* z_move(z_owned_string_t& this_) { return z_string_move(&this_); };
 inline z_moved_subscriber_t* z_move(z_owned_subscriber_t& this_) { return z_subscriber_move(&this_); };
 inline z_moved_task_t* z_move(z_owned_task_t& this_) { return z_task_move(&this_); };
 inline zc_moved_closure_log_t* z_move(zc_owned_closure_log_t& closure_) { return zc_closure_log_move(&closure_); };
+inline zc_moved_closure_matching_status_t* z_move(zc_owned_closure_matching_status_t& closure_) { return zc_closure_matching_status_move(&closure_); };
+inline zc_moved_liveliness_token_t* z_move(zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_move(&this_); };
+inline zc_moved_matching_listener_t* z_move(zc_owned_matching_listener_t& this_) { return zc_publisher_matching_listener_move(&this_); };
+inline zc_moved_shm_client_list_t* z_move(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_move(&this_); };
+inline ze_moved_publication_cache_t* z_move(ze_owned_publication_cache_t& this_) { return ze_publication_cache_move(&this_); };
+inline ze_moved_querying_subscriber_t* z_move(ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_move(&this_); };
 
 
+inline void z_null(z_owned_alloc_layout_t* this_) { z_alloc_layout_null(this_); };
 inline void z_null(z_owned_bytes_t* this_) { z_bytes_null(this_); };
+inline void z_null(z_owned_chunk_alloc_result_t* this_) { z_chunk_alloc_result_null(this_); };
 inline void z_null(z_owned_closure_hello_t* this_) { z_closure_hello_null(this_); };
 inline void z_null(z_owned_closure_query_t* this_) { z_closure_query_null(this_); };
 inline void z_null(z_owned_closure_reply_t* this_) { z_closure_reply_null(this_); };
 inline void z_null(z_owned_closure_sample_t* this_) { z_closure_sample_null(this_); };
+inline void z_null(z_owned_closure_zid_t* this_) { z_closure_zid_null(this_); };
 inline void z_null(z_owned_condvar_t* this_) { z_condvar_null(this_); };
 inline void z_null(z_owned_config_t* this_) { z_config_null(this_); };
 inline void z_null(z_owned_encoding_t* this_) { z_encoding_null(this_); };
@@ -469,6 +666,7 @@ inline void z_null(z_owned_fifo_handler_reply_t* this_) { z_fifo_handler_reply_n
 inline void z_null(z_owned_fifo_handler_sample_t* this_) { z_fifo_handler_sample_null(this_); };
 inline void z_null(z_owned_hello_t* this_) { z_hello_null(this_); };
 inline void z_null(z_owned_keyexpr_t* this_) { z_keyexpr_null(this_); };
+inline void z_null(z_owned_memory_layout_t* this_) { z_memory_layout_null(this_); };
 inline void z_null(z_owned_mutex_t* this_) { z_mutex_null(this_); };
 inline void z_null(z_owned_publisher_t* this_) { z_publisher_null(this_); };
 inline void z_null(z_owned_query_t* this_) { z_query_null(this_); };
@@ -480,18 +678,33 @@ inline void z_null(z_owned_ring_handler_reply_t* this_) { z_ring_handler_reply_n
 inline void z_null(z_owned_ring_handler_sample_t* this_) { z_ring_handler_sample_null(this_); };
 inline void z_null(z_owned_sample_t* this_) { z_sample_null(this_); };
 inline void z_null(z_owned_session_t* this_) { z_session_null(this_); };
+inline void z_null(z_owned_shm_client_t* this_) { z_shm_client_null(this_); };
+inline void z_null(z_owned_shm_client_storage_t* this_) { z_shm_client_storage_null(this_); };
+inline void z_null(z_owned_shm_mut_t* this_) { z_shm_mut_null(this_); };
+inline void z_null(z_owned_shm_t* this_) { z_shm_null(this_); };
+inline void z_null(z_owned_shm_provider_t* this_) { z_shm_provider_null(this_); };
 inline void z_null(z_owned_slice_t* this_) { z_slice_null(this_); };
+inline void z_null(z_owned_source_info_t* this_) { z_source_info_null(this_); };
 inline void z_null(z_owned_string_array_t* this_) { z_string_array_null(this_); };
 inline void z_null(z_owned_string_t* this_) { z_string_null(this_); };
 inline void z_null(z_owned_subscriber_t* this_) { z_subscriber_null(this_); };
 inline void z_null(z_owned_task_t* this_) { z_task_null(this_); };
 inline void z_null(zc_owned_closure_log_t* this_) { zc_closure_log_null(this_); };
+inline void z_null(zc_owned_closure_matching_status_t* this_) { zc_closure_matching_status_null(this_); };
+inline void z_null(zc_owned_liveliness_token_t* this_) { zc_liveliness_token_null(this_); };
+inline void z_null(zc_owned_matching_listener_t* this_) { zc_matching_listener_null(this_); };
+inline void z_null(zc_owned_shm_client_list_t* this_) { zc_shm_client_list_null(this_); };
+inline void z_null(ze_owned_publication_cache_t* this_) { ze_publication_cache_null(this_); };
+inline void z_null(ze_owned_querying_subscriber_t* this_) { ze_querying_subscriber_null(this_); };
 
+static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) { *this_ = x->_this; z_alloc_layout_null(&x->_this); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *this_ = x->_this; z_bytes_null(&x->_this); }
+static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) { *this_ = x->_this; z_chunk_alloc_result_null(&x->_this); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_closure_hello_null(&x->_this); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_closure_query_null(&x->_this); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_closure_reply_null(&x->_this); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_closure_sample_null(&x->_this); }
+static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) { *closure_ = x->_this; z_closure_zid_null(&x->_this); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) { *this_ = x->_this; z_condvar_null(&x->_this); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t* x) { *this_ = x->_this; z_config_null(&x->_this); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t* x) { *this_ = x->_this; z_encoding_null(&x->_this); }
@@ -500,6 +713,7 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t* x) { *this_ = x->_this; z_fifo_handler_sample_null(&x->_this); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_hello_null(&x->_this); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_keyexpr_null(&x->_this); }
+static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) { *this_ = x->_this; z_memory_layout_null(&x->_this); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_mutex_null(&x->_this); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_publisher_null(&x->_this); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t* x) { *this_ = x->_this; z_query_null(&x->_this); }
@@ -511,17 +725,35 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t* x) { *this_ = x->_this; z_ring_handler_sample_null(&x->_this); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t* x) { *this_ = x->_this; z_sample_null(&x->_this); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t* x) { *this_ = x->_this; z_session_null(&x->_this); }
+static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) { *this_ = x->_this; z_shm_client_null(&x->_this); }
+static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) { *this_ = x->_this; z_shm_client_storage_null(&x->_this); }
+static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t* x) { *this_ = x->_this; z_shm_null(&x->_this); }
+static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) { *this_ = x->_this; z_shm_mut_null(&x->_this); }
+static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) { *this_ = x->_this; z_shm_provider_null(&x->_this); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t* x) { *this_ = x->_this; z_slice_null(&x->_this); }
+static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) { *this_ = x->_this; z_source_info_null(&x->_this); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) { *this_ = x->_this; z_string_array_null(&x->_this); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) { *this_ = x->_this; z_string_null(&x->_this); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_subscriber_null(&x->_this); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_task_null(&x->_this); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_closure_log_null(&x->_this); }
+static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) { *closure_ = x->_this; zc_closure_matching_status_null(&x->_this); }
+static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) { *this_ = x->_this; zc_liveliness_token_null(&x->_this); }
+static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) { *this_ = x->_this; zc_matching_listener_null(&x->_this); }
+static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) { *this_ = x->_this; zc_shm_client_list_null(&x->_this); }
+static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) { *this_ = x->_this; ze_publication_cache_null(&x->_this); }
+static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) { *this_ = x->_this; ze_querying_subscriber_null(&x->_this); }
 
 
 
+inline void z_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) {
+    z_alloc_layout_take(this_, x);
+};
 inline void z_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) {
     z_bytes_take(this_, x);
+};
+inline void z_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) {
+    z_chunk_alloc_result_take(this_, x);
 };
 inline void z_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) {
     z_closure_hello_take(this_, x);
@@ -534,6 +766,9 @@ inline void z_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x
 };
 inline void z_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) {
     z_closure_sample_take(closure_, x);
+};
+inline void z_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) {
+    z_closure_zid_take(closure_, x);
 };
 inline void z_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) {
     z_condvar_take(this_, x);
@@ -558,6 +793,9 @@ inline void z_take(z_owned_hello_t* this_, z_moved_hello_t* x) {
 };
 inline void z_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) {
     z_keyexpr_take(this_, x);
+};
+inline void z_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) {
+    z_memory_layout_take(this_, x);
 };
 inline void z_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) {
     z_mutex_take(this_, x);
@@ -592,8 +830,26 @@ inline void z_take(z_owned_sample_t* this_, z_moved_sample_t* x) {
 inline void z_take(z_owned_session_t* this_, z_moved_session_t* x) {
     z_session_take(this_, x);
 };
+inline void z_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) {
+    z_shm_client_take(this_, x);
+};
+inline void z_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) {
+    z_shm_client_storage_take(this_, x);
+};
+inline void z_take(z_owned_shm_t* this_, z_moved_shm_t* x) {
+    z_shm_take(this_, x);
+};
+inline void z_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) {
+    z_shm_mut_take(this_, x);
+};
+inline void z_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) {
+    z_shm_provider_take(this_, x);
+};
 inline void z_take(z_owned_slice_t* this_, z_moved_slice_t* x) {
     z_slice_take(this_, x);
+};
+inline void z_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) {
+    z_source_info_take(this_, x);
 };
 inline void z_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) {
     z_string_array_take(this_, x);
@@ -610,13 +866,34 @@ inline void z_take(z_owned_task_t* this_, z_moved_task_t* x) {
 inline void z_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) {
     zc_closure_log_take(closure_, x);
 };
+inline void z_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) {
+    zc_closure_matching_status_take(closure_, x);
+};
+inline void z_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) {
+    zc_liveliness_token_take(this_, x);
+};
+inline void z_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) {
+    zc_publisher_matching_listener_take(this_, x);
+};
+inline void z_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) {
+    zc_shm_client_list_take(this_, x);
+};
+inline void z_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) {
+    ze_publication_cache_take(this_, x);
+};
+inline void z_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) {
+    ze_querying_subscriber_take(this_, x);
+};
 
 
+inline bool z_check(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_check(&this_); };
 inline bool z_check(const z_owned_bytes_t& this_) { return z_bytes_check(&this_); };
+inline bool z_check(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_check(&this_); };
 inline bool z_check(const z_owned_closure_hello_t& this_) { return z_closure_hello_check(&this_); };
 inline bool z_check(const z_owned_closure_query_t& this_) { return z_closure_query_check(&this_); };
 inline bool z_check(const z_owned_closure_reply_t& this_) { return z_closure_reply_check(&this_); };
 inline bool z_check(const z_owned_closure_sample_t& this_) { return z_closure_sample_check(&this_); };
+inline bool z_check(const z_owned_closure_zid_t& this_) { return z_closure_zid_check(&this_); };
 inline bool z_check(const z_owned_condvar_t& this_) { return z_condvar_check(&this_); };
 inline bool z_check(const z_owned_config_t& this_) { return z_config_check(&this_); };
 inline bool z_check(const z_owned_encoding_t& this_) { return z_encoding_check(&this_); };
@@ -625,6 +902,7 @@ inline bool z_check(const z_owned_fifo_handler_reply_t& this_) { return z_fifo_h
 inline bool z_check(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_hello_t& this_) { return z_hello_check(&this_); };
 inline bool z_check(const z_owned_keyexpr_t& this_) { return z_keyexpr_check(&this_); };
+inline bool z_check(const z_owned_memory_layout_t& this_) { return z_memory_layout_check(&this_); };
 inline bool z_check(const z_owned_mutex_t& this_) { return z_mutex_check(&this_); };
 inline bool z_check(const z_owned_publisher_t& this_) { return z_publisher_check(&this_); };
 inline bool z_check(const z_owned_query_t& query) { return z_query_check(&query); };
@@ -636,12 +914,24 @@ inline bool z_check(const z_owned_ring_handler_reply_t& this_) { return z_ring_h
 inline bool z_check(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_sample_t& this_) { return z_sample_check(&this_); };
 inline bool z_check(const z_owned_session_t& this_) { return z_session_check(&this_); };
+inline bool z_check(const z_owned_shm_t& this_) { return z_shm_check(&this_); };
+inline bool z_check(const z_owned_shm_client_t& this_) { return z_shm_client_check(&this_); };
+inline bool z_check(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_check(&this_); };
+inline bool z_check(const z_owned_shm_mut_t& this_) { return z_shm_mut_check(&this_); };
+inline bool z_check(const z_owned_shm_provider_t& this_) { return z_shm_provider_check(&this_); };
 inline bool z_check(const z_owned_slice_t& this_) { return z_slice_check(&this_); };
+inline bool z_check(const z_owned_source_info_t& this_) { return z_source_info_check(&this_); };
 inline bool z_check(const z_owned_string_array_t& this_) { return z_string_array_check(&this_); };
 inline bool z_check(const z_owned_string_t& this_) { return z_string_check(&this_); };
 inline bool z_check(const z_owned_subscriber_t& this_) { return z_subscriber_check(&this_); };
 inline bool z_check(const z_owned_task_t& this_) { return z_task_check(&this_); };
 inline bool z_check(const zc_owned_closure_log_t& this_) { return zc_closure_log_check(&this_); };
+inline bool z_check(const zc_owned_closure_matching_status_t& this_) { return zc_closure_matching_status_check(&this_); };
+inline bool z_check(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_check(&this_); };
+inline bool z_check(const zc_owned_matching_listener_t& this_) { return zc_matching_listener_check(&this_); };
+inline bool z_check(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_check(&this_); };
+inline bool z_check(const ze_owned_publication_cache_t& this_) { return ze_publication_cache_check(&this_); };
+inline bool z_check(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_check(&this_); };
 
 
 inline void z_call(const z_loaned_closure_hello_t* closure, const z_loaned_hello_t* hello) {
@@ -655,6 +945,12 @@ inline void z_call(const z_loaned_closure_reply_t* closure, const z_loaned_reply
 };
 inline void z_call(const z_loaned_closure_sample_t* closure, const z_loaned_sample_t* sample) {
     z_closure_sample_call(closure, sample);
+};
+inline void z_call(const z_loaned_closure_zid_t* closure, const z_id_t* z_id) {
+    z_closure_zid_call(closure, z_id);
+};
+inline void z_call(const zc_loaned_closure_matching_status_t* closure, const zc_matching_status_t* mathing_status) {
+    zc_closure_matching_status_call(closure, mathing_status);
 };
 
 
@@ -688,6 +984,24 @@ inline void z_closure(
 inline void z_closure(
     z_owned_closure_sample_t* closure,
     void (*call)(const z_loaned_sample_t*, void*),
+    void (*drop)(void*),
+    void *context) {
+    closure->context = context;
+    closure->drop = drop;
+    closure->call = call;
+};
+inline void z_closure(
+    z_owned_closure_zid_t* closure,
+    void (*call)(const z_id_t*, void*),
+    void (*drop)(void*),
+    void *context) {
+    closure->context = context;
+    closure->drop = drop;
+    closure->call = call;
+};
+inline void z_closure(
+    zc_owned_closure_matching_status_t* closure,
+    void (*call)(const zc_matching_status_t*, void*),
     void (*drop)(void*),
     void *context) {
     closure->context = context;
@@ -737,8 +1051,12 @@ inline z_result_t z_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sa
 
 template<class T> struct z_loaned_to_owned_type_t {};
 template<class T> struct z_owned_to_loaned_type_t {};
+template<> struct z_loaned_to_owned_type_t<z_loaned_alloc_layout_t> { typedef z_owned_alloc_layout_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_alloc_layout_t> { typedef z_loaned_alloc_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_t> { typedef z_owned_bytes_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_t> { typedef z_loaned_bytes_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_chunk_alloc_result_t> { typedef z_owned_chunk_alloc_result_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_chunk_alloc_result_t> { typedef z_loaned_chunk_alloc_result_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_hello_t> { typedef z_owned_closure_hello_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_hello_t> { typedef z_loaned_closure_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_query_t> { typedef z_owned_closure_query_t type; };
@@ -747,6 +1065,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_closure_reply_t> { typedef z
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_reply_t> { typedef z_loaned_closure_reply_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_sample_t> { typedef z_owned_closure_sample_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_sample_t> { typedef z_loaned_closure_sample_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_closure_zid_t> { typedef z_owned_closure_zid_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_closure_zid_t> { typedef z_loaned_closure_zid_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_condvar_t> { typedef z_owned_condvar_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_condvar_t> { typedef z_loaned_condvar_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_config_t> { typedef z_owned_config_t type; };
@@ -763,6 +1083,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_hello_t> { typedef z_owned_h
 template<> struct z_owned_to_loaned_type_t<z_owned_hello_t> { typedef z_loaned_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_keyexpr_t> { typedef z_owned_keyexpr_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_keyexpr_t> { typedef z_loaned_keyexpr_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_memory_layout_t> { typedef z_owned_memory_layout_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_memory_layout_t> { typedef z_loaned_memory_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_publisher_t> { typedef z_owned_publisher_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_publisher_t> { typedef z_loaned_publisher_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_query_t> { typedef z_owned_query_t type; };
@@ -783,8 +1105,18 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_sample_t> { typedef z_owned_
 template<> struct z_owned_to_loaned_type_t<z_owned_sample_t> { typedef z_loaned_sample_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_session_t> { typedef z_owned_session_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_session_t> { typedef z_loaned_session_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_client_storage_t> { typedef z_owned_shm_client_storage_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_client_storage_t> { typedef z_loaned_shm_client_storage_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_t> { typedef z_owned_shm_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_t> { typedef z_loaned_shm_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_mut_t> { typedef z_owned_shm_mut_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_mut_t> { typedef z_loaned_shm_mut_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_provider_t> { typedef z_owned_shm_provider_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_provider_t> { typedef z_loaned_shm_provider_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_slice_t> { typedef z_owned_slice_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_slice_t> { typedef z_loaned_slice_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_source_info_t> { typedef z_owned_source_info_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_source_info_t> { typedef z_loaned_source_info_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_array_t> { typedef z_owned_string_array_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_string_array_t> { typedef z_loaned_string_array_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_t> { typedef z_owned_string_t type; };
@@ -793,6 +1125,14 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_subscriber_t> { typedef z_ow
 template<> struct z_owned_to_loaned_type_t<z_owned_subscriber_t> { typedef z_loaned_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_log_t> { typedef zc_owned_closure_log_t type; };
 template<> struct z_owned_to_loaned_type_t<zc_owned_closure_log_t> { typedef zc_loaned_closure_log_t type; };
+template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_matching_status_t> { typedef zc_owned_closure_matching_status_t type; };
+template<> struct z_owned_to_loaned_type_t<zc_owned_closure_matching_status_t> { typedef zc_loaned_closure_matching_status_t type; };
+template<> struct z_loaned_to_owned_type_t<zc_loaned_liveliness_token_t> { typedef zc_owned_liveliness_token_t type; };
+template<> struct z_owned_to_loaned_type_t<zc_owned_liveliness_token_t> { typedef zc_loaned_liveliness_token_t type; };
+template<> struct z_loaned_to_owned_type_t<zc_loaned_shm_client_list_t> { typedef zc_owned_shm_client_list_t type; };
+template<> struct z_owned_to_loaned_type_t<zc_owned_shm_client_list_t> { typedef zc_loaned_shm_client_list_t type; };
+template<> struct z_loaned_to_owned_type_t<ze_loaned_querying_subscriber_t> { typedef ze_owned_querying_subscriber_t type; };
+template<> struct z_owned_to_loaned_type_t<ze_owned_querying_subscriber_t> { typedef ze_loaned_querying_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_mutex_t> { typedef z_owned_mutex_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_mutex_t> { typedef z_loaned_mutex_t type; };
 #endif  // #ifndef __cplusplus

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -44,8 +44,6 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
 static inline zc_moved_closure_matching_status_t zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return (zc_moved_closure_matching_status_t){x}; }
 static inline zc_moved_liveliness_token_t zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return (zc_moved_liveliness_token_t){x}; }
 static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return (zc_moved_shm_client_list_t){x}; }
-static inline ze_moved_publication_cache_t ze_publication_cache_move(ze_owned_publication_cache_t* x) { return (ze_moved_publication_cache_t){x}; }
-static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return (ze_moved_querying_subscriber_t){x}; }
 
 
 #define z_loan(this_) \
@@ -151,9 +149,7 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         zc_moved_closure_log_t : zc_closure_log_drop, \
         zc_moved_closure_matching_status_t : zc_closure_matching_status_drop, \
         zc_moved_liveliness_token_t : zc_liveliness_token_drop, \
-        zc_moved_shm_client_list_t : zc_shm_client_list_drop, \
-        ze_moved_publication_cache_t : ze_publication_cache_drop, \
-        ze_moved_querying_subscriber_t : ze_querying_subscriber_drop \
+        zc_moved_shm_client_list_t : zc_shm_client_list_drop \
     )(this_)
 
 #define z_move(this_) \
@@ -197,9 +193,7 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         zc_owned_closure_log_t : zc_closure_log_move, \
         zc_owned_closure_matching_status_t : zc_closure_matching_status_move, \
         zc_owned_liveliness_token_t : zc_liveliness_token_move, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_move, \
-        ze_owned_publication_cache_t : ze_publication_cache_move, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_move \
+        zc_owned_shm_client_list_t : zc_shm_client_list_move \
     )(&this_)
 
 #define z_null(this_) \
@@ -292,8 +286,6 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved
 static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure, zc_moved_closure_matching_status_t x) { *closure = *x._ptr; zc_closure_matching_status_null(x._ptr); }
 static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
 static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) { *this_ = *x._ptr; ze_publication_cache_null(x._ptr); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) { *this_ = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 #define z_take(this_, x) \
@@ -337,9 +329,7 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         zc_owned_closure_log_t* : zc_closure_log_take, \
         zc_owned_closure_matching_status_t* : zc_closure_matching_status_take, \
         zc_owned_liveliness_token_t* : zc_liveliness_token_take, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_take, \
-        ze_owned_publication_cache_t* : ze_publication_cache_take, \
-        ze_owned_querying_subscriber_t* : ze_querying_subscriber_take \
+        zc_owned_shm_client_list_t* : zc_shm_client_list_take \
     )(this_, x)
 
 #define z_check(this_) \
@@ -467,8 +457,6 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
 static inline zc_moved_closure_matching_status_t zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return zc_moved_closure_matching_status_t{x}; }
 static inline zc_moved_liveliness_token_t zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return zc_moved_liveliness_token_t{x}; }
 static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return zc_moved_shm_client_list_t{x}; }
-static inline ze_moved_publication_cache_t ze_publication_cache_move(ze_owned_publication_cache_t* x) { return ze_moved_publication_cache_t{x}; }
-static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return ze_moved_querying_subscriber_t{x}; }
 
 
 
@@ -570,8 +558,6 @@ inline void z_drop(zc_moved_closure_log_t closure) { zc_closure_log_drop(closure
 inline void z_drop(zc_moved_closure_matching_status_t closure) { zc_closure_matching_status_drop(closure); };
 inline void z_drop(zc_moved_liveliness_token_t this_) { zc_liveliness_token_drop(this_); };
 inline void z_drop(zc_moved_shm_client_list_t this_) { zc_shm_client_list_drop(this_); };
-inline void z_drop(ze_moved_publication_cache_t this_) { ze_publication_cache_drop(this_); };
-inline void z_drop(ze_moved_querying_subscriber_t this_) { ze_querying_subscriber_drop(this_); };
 
 
 inline z_moved_alloc_layout_t z_move(z_owned_alloc_layout_t& this_) { return z_alloc_layout_move(&this_); };
@@ -614,8 +600,6 @@ inline zc_moved_closure_log_t z_move(zc_owned_closure_log_t& closure) { return z
 inline zc_moved_closure_matching_status_t z_move(zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_move(&closure); };
 inline zc_moved_liveliness_token_t z_move(zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_move(&this_); };
 inline zc_moved_shm_client_list_t z_move(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_move(&this_); };
-inline ze_moved_publication_cache_t z_move(ze_owned_publication_cache_t& this_) { return ze_publication_cache_move(&this_); };
-inline ze_moved_querying_subscriber_t z_move(ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_move(&this_); };
 
 
 inline void z_null(z_owned_alloc_layout_t* this_) { z_alloc_layout_null(this_); };
@@ -705,8 +689,6 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved
 static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure, zc_moved_closure_matching_status_t x) { *closure = *x._ptr; zc_closure_matching_status_null(x._ptr); }
 static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
 static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) { *this_ = *x._ptr; ze_publication_cache_null(x._ptr); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) { *this_ = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 
@@ -829,12 +811,6 @@ inline void z_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token
 };
 inline void z_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) {
     zc_shm_client_list_take(this_, x);
-};
-inline void z_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) {
-    ze_publication_cache_take(this_, x);
-};
-inline void z_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) {
-    ze_querying_subscriber_take(this_, x);
 };
 
 

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -4,14 +4,11 @@
 
 #ifndef __cplusplus
 
-static inline z_moved_alloc_layout_t z_alloc_layout_move(z_owned_alloc_layout_t* x) { return (z_moved_alloc_layout_t){x}; }
 static inline z_moved_bytes_t z_bytes_move(z_owned_bytes_t* x) { return (z_moved_bytes_t){x}; }
-static inline z_moved_chunk_alloc_result_t z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return (z_moved_chunk_alloc_result_t){x}; }
 static inline z_moved_closure_hello_t z_closure_hello_move(z_owned_closure_hello_t* x) { return (z_moved_closure_hello_t){x}; }
 static inline z_moved_closure_query_t z_closure_query_move(z_owned_closure_query_t* x) { return (z_moved_closure_query_t){x}; }
 static inline z_moved_closure_reply_t z_closure_reply_move(z_owned_closure_reply_t* x) { return (z_moved_closure_reply_t){x}; }
 static inline z_moved_closure_sample_t z_closure_sample_move(z_owned_closure_sample_t* x) { return (z_moved_closure_sample_t){x}; }
-static inline z_moved_closure_zid_t z_closure_zid_move(z_owned_closure_zid_t* x) { return (z_moved_closure_zid_t){x}; }
 static inline z_moved_condvar_t z_condvar_move(z_owned_condvar_t* x) { return (z_moved_condvar_t){x}; }
 static inline z_moved_config_t z_config_move(z_owned_config_t* x) { return (z_moved_config_t){x}; }
 static inline z_moved_encoding_t z_encoding_move(z_owned_encoding_t* x) { return (z_moved_encoding_t){x}; }
@@ -20,7 +17,6 @@ static inline z_moved_fifo_handler_reply_t z_fifo_handler_reply_move(z_owned_fif
 static inline z_moved_fifo_handler_sample_t z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return (z_moved_fifo_handler_sample_t){x}; }
 static inline z_moved_hello_t z_hello_move(z_owned_hello_t* x) { return (z_moved_hello_t){x}; }
 static inline z_moved_keyexpr_t z_keyexpr_move(z_owned_keyexpr_t* x) { return (z_moved_keyexpr_t){x}; }
-static inline z_moved_memory_layout_t z_memory_layout_move(z_owned_memory_layout_t* x) { return (z_moved_memory_layout_t){x}; }
 static inline z_moved_mutex_t z_mutex_move(z_owned_mutex_t* x) { return (z_moved_mutex_t){x}; }
 static inline z_moved_publisher_t z_publisher_move(z_owned_publisher_t* x) { return (z_moved_publisher_t){x}; }
 static inline z_moved_query_t z_query_move(z_owned_query_t* x) { return (z_moved_query_t){x}; }
@@ -32,36 +28,21 @@ static inline z_moved_ring_handler_reply_t z_ring_handler_reply_move(z_owned_rin
 static inline z_moved_ring_handler_sample_t z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return (z_moved_ring_handler_sample_t){x}; }
 static inline z_moved_sample_t z_sample_move(z_owned_sample_t* x) { return (z_moved_sample_t){x}; }
 static inline z_moved_session_t z_session_move(z_owned_session_t* x) { return (z_moved_session_t){x}; }
-static inline z_moved_shm_client_t z_shm_client_move(z_owned_shm_client_t* x) { return (z_moved_shm_client_t){x}; }
-static inline z_moved_shm_client_storage_t z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return (z_moved_shm_client_storage_t){x}; }
-static inline z_moved_shm_t z_shm_move(z_owned_shm_t* x) { return (z_moved_shm_t){x}; }
-static inline z_moved_shm_mut_t z_shm_mut_move(z_owned_shm_mut_t* x) { return (z_moved_shm_mut_t){x}; }
-static inline z_moved_shm_provider_t z_shm_provider_move(z_owned_shm_provider_t* x) { return (z_moved_shm_provider_t){x}; }
 static inline z_moved_slice_t z_slice_move(z_owned_slice_t* x) { return (z_moved_slice_t){x}; }
-static inline z_moved_source_info_t z_source_info_move(z_owned_source_info_t* x) { return (z_moved_source_info_t){x}; }
 static inline z_moved_string_array_t z_string_array_move(z_owned_string_array_t* x) { return (z_moved_string_array_t){x}; }
 static inline z_moved_string_t z_string_move(z_owned_string_t* x) { return (z_moved_string_t){x}; }
 static inline z_moved_subscriber_t z_subscriber_move(z_owned_subscriber_t* x) { return (z_moved_subscriber_t){x}; }
 static inline z_moved_task_t z_task_move(z_owned_task_t* x) { return (z_moved_task_t){x}; }
 static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t* x) { return (zc_moved_closure_log_t){x}; }
-static inline zc_moved_closure_matching_status_t zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return (zc_moved_closure_matching_status_t){x}; }
-static inline zc_moved_liveliness_token_t zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return (zc_moved_liveliness_token_t){x}; }
-static inline zc_moved_matching_listener_t zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return (zc_moved_matching_listener_t){x}; }
-static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return (zc_moved_shm_client_list_t){x}; }
-static inline ze_moved_publication_cache_t ze_publication_cache_move(ze_owned_publication_cache_t* x) { return (ze_moved_publication_cache_t){x}; }
-static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return (ze_moved_querying_subscriber_t){x}; }
 
 
 #define z_loan(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_alloc_layout_loan, \
         z_owned_bytes_t : z_bytes_loan, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_loan, \
         z_owned_closure_hello_t : z_closure_hello_loan, \
         z_owned_closure_query_t : z_closure_query_loan, \
         z_owned_closure_reply_t : z_closure_reply_loan, \
         z_owned_closure_sample_t : z_closure_sample_loan, \
-        z_owned_closure_zid_t : z_closure_zid_loan, \
         z_owned_condvar_t : z_condvar_loan, \
         z_owned_config_t : z_config_loan, \
         z_owned_encoding_t : z_encoding_loan, \
@@ -70,7 +51,6 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_loan, \
         z_owned_hello_t : z_hello_loan, \
         z_owned_keyexpr_t : z_keyexpr_loan, \
-        z_owned_memory_layout_t : z_memory_layout_loan, \
         z_owned_publisher_t : z_publisher_loan, \
         z_owned_query_t : z_query_loan, \
         z_owned_queryable_t : z_queryable_loan, \
@@ -81,23 +61,14 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_ring_handler_sample_t : z_ring_handler_sample_loan, \
         z_owned_sample_t : z_sample_loan, \
         z_owned_session_t : z_session_loan, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_loan, \
-        z_owned_shm_t : z_shm_loan, \
-        z_owned_shm_mut_t : z_shm_mut_loan, \
-        z_owned_shm_provider_t : z_shm_provider_loan, \
         z_owned_slice_t : z_slice_loan, \
-        z_owned_source_info_t : z_source_info_loan, \
         z_owned_string_array_t : z_string_array_loan, \
         z_owned_string_t : z_string_loan, \
         z_owned_subscriber_t : z_subscriber_loan, \
         z_view_keyexpr_t : z_view_keyexpr_loan, \
         z_view_slice_t : z_view_slice_loan, \
         z_view_string_t : z_view_string_loan, \
-        zc_owned_closure_log_t : zc_closure_log_loan, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_loan, \
-        zc_owned_liveliness_token_t : zc_liveliness_token_loan, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_loan, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_loan \
+        zc_owned_closure_log_t : zc_closure_log_loan \
     )(&this_)
 
 #define z_loan_mut(this_) \
@@ -108,22 +79,16 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_encoding_t : z_encoding_loan_mut, \
         z_owned_mutex_t : z_mutex_loan_mut, \
         z_owned_publisher_t : z_publisher_loan_mut, \
-        z_owned_shm_t : z_shm_loan_mut, \
-        z_owned_shm_mut_t : z_shm_mut_loan_mut, \
-        z_owned_string_array_t : z_string_array_loan_mut, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_loan_mut \
+        z_owned_string_array_t : z_string_array_loan_mut \
     )(&this_)
 
 #define z_drop(this_) \
     _Generic((this_), \
-        z_moved_alloc_layout_t : z_alloc_layout_drop, \
         z_moved_bytes_t : z_bytes_drop, \
-        z_moved_chunk_alloc_result_t : z_chunk_alloc_result_drop, \
         z_moved_closure_hello_t : z_closure_hello_drop, \
         z_moved_closure_query_t : z_closure_query_drop, \
         z_moved_closure_reply_t : z_closure_reply_drop, \
         z_moved_closure_sample_t : z_closure_sample_drop, \
-        z_moved_closure_zid_t : z_closure_zid_drop, \
         z_moved_condvar_t : z_condvar_drop, \
         z_moved_config_t : z_config_drop, \
         z_moved_encoding_t : z_encoding_drop, \
@@ -132,7 +97,6 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_moved_fifo_handler_sample_t : z_fifo_handler_sample_drop, \
         z_moved_hello_t : z_hello_drop, \
         z_moved_keyexpr_t : z_keyexpr_drop, \
-        z_moved_memory_layout_t : z_memory_layout_drop, \
         z_moved_mutex_t : z_mutex_drop, \
         z_moved_publisher_t : z_publisher_drop, \
         z_moved_query_t : z_query_drop, \
@@ -144,36 +108,21 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_moved_ring_handler_sample_t : z_ring_handler_sample_drop, \
         z_moved_sample_t : z_sample_drop, \
         z_moved_session_t : z_session_drop, \
-        z_moved_shm_client_t : z_shm_client_drop, \
-        z_moved_shm_client_storage_t : z_shm_client_storage_drop, \
-        z_moved_shm_t : z_shm_drop, \
-        z_moved_shm_mut_t : z_shm_mut_drop, \
-        z_moved_shm_provider_t : z_shm_provider_drop, \
         z_moved_slice_t : z_slice_drop, \
-        z_moved_source_info_t : z_source_info_drop, \
         z_moved_string_array_t : z_string_array_drop, \
         z_moved_string_t : z_string_drop, \
         z_moved_subscriber_t : z_subscriber_drop, \
         z_moved_task_t : z_task_drop, \
-        zc_moved_closure_log_t : zc_closure_log_drop, \
-        zc_moved_closure_matching_status_t : zc_closure_matching_status_drop, \
-        zc_moved_liveliness_token_t : zc_liveliness_token_drop, \
-        zc_moved_matching_listener_t : zc_publisher_matching_listener_drop, \
-        zc_moved_shm_client_list_t : zc_shm_client_list_drop, \
-        ze_moved_publication_cache_t : ze_publication_cache_drop, \
-        ze_moved_querying_subscriber_t : ze_querying_subscriber_drop \
+        zc_moved_closure_log_t : zc_closure_log_drop \
     )(this_)
 
 #define z_move(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_alloc_layout_move, \
         z_owned_bytes_t : z_bytes_move, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_move, \
         z_owned_closure_hello_t : z_closure_hello_move, \
         z_owned_closure_query_t : z_closure_query_move, \
         z_owned_closure_reply_t : z_closure_reply_move, \
         z_owned_closure_sample_t : z_closure_sample_move, \
-        z_owned_closure_zid_t : z_closure_zid_move, \
         z_owned_condvar_t : z_condvar_move, \
         z_owned_config_t : z_config_move, \
         z_owned_encoding_t : z_encoding_move, \
@@ -182,7 +131,6 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_move, \
         z_owned_hello_t : z_hello_move, \
         z_owned_keyexpr_t : z_keyexpr_move, \
-        z_owned_memory_layout_t : z_memory_layout_move, \
         z_owned_mutex_t : z_mutex_move, \
         z_owned_publisher_t : z_publisher_move, \
         z_owned_query_t : z_query_move, \
@@ -194,36 +142,21 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_ring_handler_sample_t : z_ring_handler_sample_move, \
         z_owned_sample_t : z_sample_move, \
         z_owned_session_t : z_session_move, \
-        z_owned_shm_client_t : z_shm_client_move, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_move, \
-        z_owned_shm_t : z_shm_move, \
-        z_owned_shm_mut_t : z_shm_mut_move, \
-        z_owned_shm_provider_t : z_shm_provider_move, \
         z_owned_slice_t : z_slice_move, \
-        z_owned_source_info_t : z_source_info_move, \
         z_owned_string_array_t : z_string_array_move, \
         z_owned_string_t : z_string_move, \
         z_owned_subscriber_t : z_subscriber_move, \
         z_owned_task_t : z_task_move, \
-        zc_owned_closure_log_t : zc_closure_log_move, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_move, \
-        zc_owned_liveliness_token_t : zc_liveliness_token_move, \
-        zc_owned_matching_listener_t : zc_publisher_matching_listener_move, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_move, \
-        ze_owned_publication_cache_t : ze_publication_cache_move, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_move \
+        zc_owned_closure_log_t : zc_closure_log_move \
     )(&this_)
 
 #define z_null(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t* : z_alloc_layout_null, \
         z_owned_bytes_t* : z_bytes_null, \
-        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_null, \
         z_owned_closure_hello_t* : z_closure_hello_null, \
         z_owned_closure_query_t* : z_closure_query_null, \
         z_owned_closure_reply_t* : z_closure_reply_null, \
         z_owned_closure_sample_t* : z_closure_sample_null, \
-        z_owned_closure_zid_t* : z_closure_zid_null, \
         z_owned_condvar_t* : z_condvar_null, \
         z_owned_config_t* : z_config_null, \
         z_owned_encoding_t* : z_encoding_null, \
@@ -232,7 +165,6 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_null, \
         z_owned_hello_t* : z_hello_null, \
         z_owned_keyexpr_t* : z_keyexpr_null, \
-        z_owned_memory_layout_t* : z_memory_layout_null, \
         z_owned_mutex_t* : z_mutex_null, \
         z_owned_publisher_t* : z_publisher_null, \
         z_owned_query_t* : z_query_null, \
@@ -244,34 +176,19 @@ static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owne
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_null, \
         z_owned_sample_t* : z_sample_null, \
         z_owned_session_t* : z_session_null, \
-        z_owned_shm_client_t* : z_shm_client_null, \
-        z_owned_shm_client_storage_t* : z_shm_client_storage_null, \
-        z_owned_shm_mut_t* : z_shm_mut_null, \
-        z_owned_shm_t* : z_shm_null, \
-        z_owned_shm_provider_t* : z_shm_provider_null, \
         z_owned_slice_t* : z_slice_null, \
-        z_owned_source_info_t* : z_source_info_null, \
         z_owned_string_array_t* : z_string_array_null, \
         z_owned_string_t* : z_string_null, \
         z_owned_subscriber_t* : z_subscriber_null, \
         z_owned_task_t* : z_task_null, \
-        zc_owned_closure_log_t* : zc_closure_log_null, \
-        zc_owned_closure_matching_status_t* : zc_closure_matching_status_null, \
-        zc_owned_liveliness_token_t* : zc_liveliness_token_null, \
-        zc_owned_matching_listener_t* : zc_matching_listener_null, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_null, \
-        ze_owned_publication_cache_t* : ze_publication_cache_null, \
-        ze_owned_querying_subscriber_t* : ze_querying_subscriber_null \
+        zc_owned_closure_log_t* : zc_closure_log_null \
     )(this_)
 
-static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t x) { *this_ = *x._ptr; z_alloc_layout_null(x._ptr); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t x) { *this_ = *x._ptr; z_bytes_null(x._ptr); }
-static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) { *this_ = *x._ptr; z_chunk_alloc_result_null(x._ptr); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* _closure, z_moved_closure_hello_t x) { *_closure = *x._ptr; z_closure_hello_null(x._ptr); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure, z_moved_closure_query_t x) { *closure = *x._ptr; z_closure_query_null(x._ptr); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure, z_moved_closure_reply_t x) { *closure = *x._ptr; z_closure_reply_null(x._ptr); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure, z_moved_closure_sample_t x) { *closure = *x._ptr; z_closure_sample_null(x._ptr); }
-static inline void z_closure_zid_take(z_owned_closure_zid_t* closure, z_moved_closure_zid_t x) { *closure = *x._ptr; z_closure_zid_null(x._ptr); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t x) { *this_ = *x._ptr; z_condvar_null(x._ptr); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t x) { *this_ = *x._ptr; z_config_null(x._ptr); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t x) { *this_ = *x._ptr; z_encoding_null(x._ptr); }
@@ -280,7 +197,6 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t x) { *this_ = *x._ptr; z_fifo_handler_sample_null(x._ptr); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *this_ = *x._ptr; z_hello_null(x._ptr); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
-static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) { *this_ = *x._ptr; z_memory_layout_null(x._ptr); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t x) { *this_ = *x._ptr; z_publisher_null(x._ptr); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
@@ -292,36 +208,21 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t x) { *this_ = *x._ptr; z_ring_handler_sample_null(x._ptr); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t x) { *this_ = *x._ptr; z_sample_null(x._ptr); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t x) { *this_ = *x._ptr; z_session_null(x._ptr); }
-static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t x) { *this_ = *x._ptr; z_shm_client_null(x._ptr); }
-static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t x) { *this_ = *x._ptr; z_shm_client_storage_null(x._ptr); }
-static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t x) { *this_ = *x._ptr; z_shm_null(x._ptr); }
-static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t x) { *this_ = *x._ptr; z_shm_mut_null(x._ptr); }
-static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t x) { *this_ = *x._ptr; z_shm_provider_null(x._ptr); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t x) { *this_ = *x._ptr; z_slice_null(x._ptr); }
-static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t x) { *this_ = *x._ptr; z_source_info_null(x._ptr); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t x) { *this_ = *x._ptr; z_string_array_null(x._ptr); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t x) { *this_ = *x._ptr; z_string_null(x._ptr); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) { *this_ = *x._ptr; z_subscriber_null(x._ptr); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t x) { *this_ = *x._ptr; z_task_null(x._ptr); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved_closure_log_t x) { *closure = *x._ptr; zc_closure_log_null(x._ptr); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure, zc_moved_closure_matching_status_t x) { *closure = *x._ptr; zc_closure_matching_status_null(x._ptr); }
-static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
-static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t x) { *this_ = *x._ptr; zc_matching_listener_null(x._ptr); }
-static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) { *this_ = *x._ptr; ze_publication_cache_null(x._ptr); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) { *this_ = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 #define z_take(this_, x) \
     _Generic((this_), \
-        z_owned_alloc_layout_t* : z_alloc_layout_take, \
         z_owned_bytes_t* : z_bytes_take, \
-        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_take, \
         z_owned_closure_hello_t* : z_closure_hello_take, \
         z_owned_closure_query_t* : z_closure_query_take, \
         z_owned_closure_reply_t* : z_closure_reply_take, \
         z_owned_closure_sample_t* : z_closure_sample_take, \
-        z_owned_closure_zid_t* : z_closure_zid_take, \
         z_owned_condvar_t* : z_condvar_take, \
         z_owned_config_t* : z_config_take, \
         z_owned_encoding_t* : z_encoding_take, \
@@ -330,7 +231,6 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_take, \
         z_owned_hello_t* : z_hello_take, \
         z_owned_keyexpr_t* : z_keyexpr_take, \
-        z_owned_memory_layout_t* : z_memory_layout_take, \
         z_owned_mutex_t* : z_mutex_take, \
         z_owned_publisher_t* : z_publisher_take, \
         z_owned_query_t* : z_query_take, \
@@ -342,36 +242,21 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_take, \
         z_owned_sample_t* : z_sample_take, \
         z_owned_session_t* : z_session_take, \
-        z_owned_shm_client_t* : z_shm_client_take, \
-        z_owned_shm_client_storage_t* : z_shm_client_storage_take, \
-        z_owned_shm_t* : z_shm_take, \
-        z_owned_shm_mut_t* : z_shm_mut_take, \
-        z_owned_shm_provider_t* : z_shm_provider_take, \
         z_owned_slice_t* : z_slice_take, \
-        z_owned_source_info_t* : z_source_info_take, \
         z_owned_string_array_t* : z_string_array_take, \
         z_owned_string_t* : z_string_take, \
         z_owned_subscriber_t* : z_subscriber_take, \
         z_owned_task_t* : z_task_take, \
-        zc_owned_closure_log_t* : zc_closure_log_take, \
-        zc_owned_closure_matching_status_t* : zc_closure_matching_status_take, \
-        zc_owned_liveliness_token_t* : zc_liveliness_token_take, \
-        zc_owned_matching_listener_t* : zc_publisher_matching_listener_take, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_take, \
-        ze_owned_publication_cache_t* : ze_publication_cache_take, \
-        ze_owned_querying_subscriber_t* : ze_querying_subscriber_take \
+        zc_owned_closure_log_t* : zc_closure_log_take \
     )(this_, x)
 
 #define z_check(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_alloc_layout_check, \
         z_owned_bytes_t : z_bytes_check, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_check, \
         z_owned_closure_hello_t : z_closure_hello_check, \
         z_owned_closure_query_t : z_closure_query_check, \
         z_owned_closure_reply_t : z_closure_reply_check, \
         z_owned_closure_sample_t : z_closure_sample_check, \
-        z_owned_closure_zid_t : z_closure_zid_check, \
         z_owned_condvar_t : z_condvar_check, \
         z_owned_config_t : z_config_check, \
         z_owned_encoding_t : z_encoding_check, \
@@ -380,7 +265,6 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_check, \
         z_owned_hello_t : z_hello_check, \
         z_owned_keyexpr_t : z_keyexpr_check, \
-        z_owned_memory_layout_t : z_memory_layout_check, \
         z_owned_mutex_t : z_mutex_check, \
         z_owned_publisher_t : z_publisher_check, \
         z_owned_query_t : z_query_check, \
@@ -392,24 +276,12 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_ring_handler_sample_t : z_ring_handler_sample_check, \
         z_owned_sample_t : z_sample_check, \
         z_owned_session_t : z_session_check, \
-        z_owned_shm_t : z_shm_check, \
-        z_owned_shm_client_t : z_shm_client_check, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_check, \
-        z_owned_shm_mut_t : z_shm_mut_check, \
-        z_owned_shm_provider_t : z_shm_provider_check, \
         z_owned_slice_t : z_slice_check, \
-        z_owned_source_info_t : z_source_info_check, \
         z_owned_string_array_t : z_string_array_check, \
         z_owned_string_t : z_string_check, \
         z_owned_subscriber_t : z_subscriber_check, \
         z_owned_task_t : z_task_check, \
-        zc_owned_closure_log_t : zc_closure_log_check, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_check, \
-        zc_owned_liveliness_token_t : zc_liveliness_token_check, \
-        zc_owned_matching_listener_t : zc_matching_listener_check, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_check, \
-        ze_owned_publication_cache_t : ze_publication_cache_check, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_check \
+        zc_owned_closure_log_t : zc_closure_log_check \
     )(&this_)
 
 #define z_call(closure, hello) \
@@ -417,9 +289,7 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         const z_loaned_closure_hello_t* : z_closure_hello_call, \
         const z_loaned_closure_query_t* : z_closure_query_call, \
         const z_loaned_closure_reply_t* : z_closure_reply_call, \
-        const z_loaned_closure_sample_t* : z_closure_sample_call, \
-        const z_loaned_closure_zid_t* : z_closure_zid_call, \
-        const zc_loaned_closure_matching_status_t* : zc_closure_matching_status_call \
+        const z_loaned_closure_sample_t* : z_closure_sample_call \
     )(closure, hello)
 
 #define z_closure(x, callback, dropper, ctx) \
@@ -447,14 +317,11 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
 #else  // #ifndef __cplusplus
 
 
-static inline z_moved_alloc_layout_t z_alloc_layout_move(z_owned_alloc_layout_t* x) { return z_moved_alloc_layout_t{x}; }
 static inline z_moved_bytes_t z_bytes_move(z_owned_bytes_t* x) { return z_moved_bytes_t{x}; }
-static inline z_moved_chunk_alloc_result_t z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return z_moved_chunk_alloc_result_t{x}; }
 static inline z_moved_closure_hello_t z_closure_hello_move(z_owned_closure_hello_t* x) { return z_moved_closure_hello_t{x}; }
 static inline z_moved_closure_query_t z_closure_query_move(z_owned_closure_query_t* x) { return z_moved_closure_query_t{x}; }
 static inline z_moved_closure_reply_t z_closure_reply_move(z_owned_closure_reply_t* x) { return z_moved_closure_reply_t{x}; }
 static inline z_moved_closure_sample_t z_closure_sample_move(z_owned_closure_sample_t* x) { return z_moved_closure_sample_t{x}; }
-static inline z_moved_closure_zid_t z_closure_zid_move(z_owned_closure_zid_t* x) { return z_moved_closure_zid_t{x}; }
 static inline z_moved_condvar_t z_condvar_move(z_owned_condvar_t* x) { return z_moved_condvar_t{x}; }
 static inline z_moved_config_t z_config_move(z_owned_config_t* x) { return z_moved_config_t{x}; }
 static inline z_moved_encoding_t z_encoding_move(z_owned_encoding_t* x) { return z_moved_encoding_t{x}; }
@@ -463,7 +330,6 @@ static inline z_moved_fifo_handler_reply_t z_fifo_handler_reply_move(z_owned_fif
 static inline z_moved_fifo_handler_sample_t z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return z_moved_fifo_handler_sample_t{x}; }
 static inline z_moved_hello_t z_hello_move(z_owned_hello_t* x) { return z_moved_hello_t{x}; }
 static inline z_moved_keyexpr_t z_keyexpr_move(z_owned_keyexpr_t* x) { return z_moved_keyexpr_t{x}; }
-static inline z_moved_memory_layout_t z_memory_layout_move(z_owned_memory_layout_t* x) { return z_moved_memory_layout_t{x}; }
 static inline z_moved_mutex_t z_mutex_move(z_owned_mutex_t* x) { return z_moved_mutex_t{x}; }
 static inline z_moved_publisher_t z_publisher_move(z_owned_publisher_t* x) { return z_moved_publisher_t{x}; }
 static inline z_moved_query_t z_query_move(z_owned_query_t* x) { return z_moved_query_t{x}; }
@@ -475,35 +341,20 @@ static inline z_moved_ring_handler_reply_t z_ring_handler_reply_move(z_owned_rin
 static inline z_moved_ring_handler_sample_t z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return z_moved_ring_handler_sample_t{x}; }
 static inline z_moved_sample_t z_sample_move(z_owned_sample_t* x) { return z_moved_sample_t{x}; }
 static inline z_moved_session_t z_session_move(z_owned_session_t* x) { return z_moved_session_t{x}; }
-static inline z_moved_shm_client_t z_shm_client_move(z_owned_shm_client_t* x) { return z_moved_shm_client_t{x}; }
-static inline z_moved_shm_client_storage_t z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return z_moved_shm_client_storage_t{x}; }
-static inline z_moved_shm_t z_shm_move(z_owned_shm_t* x) { return z_moved_shm_t{x}; }
-static inline z_moved_shm_mut_t z_shm_mut_move(z_owned_shm_mut_t* x) { return z_moved_shm_mut_t{x}; }
-static inline z_moved_shm_provider_t z_shm_provider_move(z_owned_shm_provider_t* x) { return z_moved_shm_provider_t{x}; }
 static inline z_moved_slice_t z_slice_move(z_owned_slice_t* x) { return z_moved_slice_t{x}; }
-static inline z_moved_source_info_t z_source_info_move(z_owned_source_info_t* x) { return z_moved_source_info_t{x}; }
 static inline z_moved_string_array_t z_string_array_move(z_owned_string_array_t* x) { return z_moved_string_array_t{x}; }
 static inline z_moved_string_t z_string_move(z_owned_string_t* x) { return z_moved_string_t{x}; }
 static inline z_moved_subscriber_t z_subscriber_move(z_owned_subscriber_t* x) { return z_moved_subscriber_t{x}; }
 static inline z_moved_task_t z_task_move(z_owned_task_t* x) { return z_moved_task_t{x}; }
 static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t* x) { return zc_moved_closure_log_t{x}; }
-static inline zc_moved_closure_matching_status_t zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return zc_moved_closure_matching_status_t{x}; }
-static inline zc_moved_liveliness_token_t zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return zc_moved_liveliness_token_t{x}; }
-static inline zc_moved_matching_listener_t zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return zc_moved_matching_listener_t{x}; }
-static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return zc_moved_shm_client_list_t{x}; }
-static inline ze_moved_publication_cache_t ze_publication_cache_move(ze_owned_publication_cache_t* x) { return ze_moved_publication_cache_t{x}; }
-static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return ze_moved_querying_subscriber_t{x}; }
 
 
 
-inline const z_loaned_alloc_layout_t* z_loan(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_loan(&this_); };
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& this_) { return z_bytes_loan(&this_); };
-inline const z_loaned_chunk_alloc_result_t* z_loan(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_loan(&this_); };
 inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t& closure) { return z_closure_hello_loan(&closure); };
 inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t& closure) { return z_closure_query_loan(&closure); };
 inline const z_loaned_closure_reply_t* z_loan(const z_owned_closure_reply_t& closure) { return z_closure_reply_loan(&closure); };
 inline const z_loaned_closure_sample_t* z_loan(const z_owned_closure_sample_t& closure) { return z_closure_sample_loan(&closure); };
-inline const z_loaned_closure_zid_t* z_loan(const z_owned_closure_zid_t& closure) { return z_closure_zid_loan(&closure); };
 inline const z_loaned_condvar_t* z_loan(const z_owned_condvar_t& this_) { return z_condvar_loan(&this_); };
 inline const z_loaned_config_t* z_loan(const z_owned_config_t& this_) { return z_config_loan(&this_); };
 inline const z_loaned_encoding_t* z_loan(const z_owned_encoding_t& this_) { return z_encoding_loan(&this_); };
@@ -512,7 +363,6 @@ inline const z_loaned_fifo_handler_reply_t* z_loan(const z_owned_fifo_handler_re
 inline const z_loaned_fifo_handler_sample_t* z_loan(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_loan(&this_); };
 inline const z_loaned_hello_t* z_loan(const z_owned_hello_t& this_) { return z_hello_loan(&this_); };
 inline const z_loaned_keyexpr_t* z_loan(const z_owned_keyexpr_t& this_) { return z_keyexpr_loan(&this_); };
-inline const z_loaned_memory_layout_t* z_loan(const z_owned_memory_layout_t& this_) { return z_memory_layout_loan(&this_); };
 inline const z_loaned_publisher_t* z_loan(const z_owned_publisher_t& this_) { return z_publisher_loan(&this_); };
 inline const z_loaned_query_t* z_loan(const z_owned_query_t& this_) { return z_query_loan(&this_); };
 inline const z_loaned_queryable_t* z_loan(const z_owned_queryable_t& this_) { return z_queryable_loan(&this_); };
@@ -523,12 +373,7 @@ inline const z_loaned_ring_handler_reply_t* z_loan(const z_owned_ring_handler_re
 inline const z_loaned_ring_handler_sample_t* z_loan(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_loan(&this_); };
 inline const z_loaned_sample_t* z_loan(const z_owned_sample_t& this_) { return z_sample_loan(&this_); };
 inline const z_loaned_session_t* z_loan(const z_owned_session_t& this_) { return z_session_loan(&this_); };
-inline const z_loaned_shm_client_storage_t* z_loan(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_loan(&this_); };
-inline const z_loaned_shm_t* z_loan(const z_owned_shm_t& this_) { return z_shm_loan(&this_); };
-inline const z_loaned_shm_mut_t* z_loan(const z_owned_shm_mut_t& this_) { return z_shm_mut_loan(&this_); };
-inline const z_loaned_shm_provider_t* z_loan(const z_owned_shm_provider_t& this_) { return z_shm_provider_loan(&this_); };
 inline const z_loaned_slice_t* z_loan(const z_owned_slice_t& this_) { return z_slice_loan(&this_); };
-inline const z_loaned_source_info_t* z_loan(const z_owned_source_info_t& this_) { return z_source_info_loan(&this_); };
 inline const z_loaned_string_array_t* z_loan(const z_owned_string_array_t& this_) { return z_string_array_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_owned_string_t& this_) { return z_string_loan(&this_); };
 inline const z_loaned_subscriber_t* z_loan(const z_owned_subscriber_t& this_) { return z_subscriber_loan(&this_); };
@@ -536,10 +381,6 @@ inline const z_loaned_keyexpr_t* z_loan(const z_view_keyexpr_t& this_) { return 
 inline const z_loaned_slice_t* z_loan(const z_view_slice_t& this_) { return z_view_slice_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_view_string_t& this_) { return z_view_string_loan(&this_); };
 inline const zc_loaned_closure_log_t* z_loan(const zc_owned_closure_log_t& closure) { return zc_closure_log_loan(&closure); };
-inline const zc_loaned_closure_matching_status_t* z_loan(const zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_loan(&closure); };
-inline const zc_loaned_liveliness_token_t* z_loan(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_loan(&this_); };
-inline const zc_loaned_shm_client_list_t* z_loan(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan(&this_); };
-inline const ze_loaned_querying_subscriber_t* z_loan(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_loan(&this_); };
 
 
 inline z_loaned_bytes_t* z_loan_mut(z_owned_bytes_t& this_) { return z_bytes_loan_mut(&this_); };
@@ -548,20 +389,14 @@ inline z_loaned_config_t* z_loan_mut(z_owned_config_t& this_) { return z_config_
 inline z_loaned_encoding_t* z_loan_mut(z_owned_encoding_t& this_) { return z_encoding_loan_mut(&this_); };
 inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t& this_) { return z_mutex_loan_mut(&this_); };
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& this_) { return z_publisher_loan_mut(&this_); };
-inline z_loaned_shm_t* z_loan_mut(z_owned_shm_t& this_) { return z_shm_loan_mut(&this_); };
-inline z_loaned_shm_mut_t* z_loan_mut(z_owned_shm_mut_t& this_) { return z_shm_mut_loan_mut(&this_); };
 inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { return z_string_array_loan_mut(&this_); };
-inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan_mut(&this_); };
 
 
-inline void z_drop(z_moved_alloc_layout_t this_) { z_alloc_layout_drop(this_); };
 inline void z_drop(z_moved_bytes_t this_) { z_bytes_drop(this_); };
-inline void z_drop(z_moved_chunk_alloc_result_t this_) { z_chunk_alloc_result_drop(this_); };
 inline void z_drop(z_moved_closure_hello_t _closure) { z_closure_hello_drop(_closure); };
 inline void z_drop(z_moved_closure_query_t closure) { z_closure_query_drop(closure); };
 inline void z_drop(z_moved_closure_reply_t closure) { z_closure_reply_drop(closure); };
 inline void z_drop(z_moved_closure_sample_t closure) { z_closure_sample_drop(closure); };
-inline void z_drop(z_moved_closure_zid_t closure) { z_closure_zid_drop(closure); };
 inline void z_drop(z_moved_condvar_t this_) { z_condvar_drop(this_); };
 inline void z_drop(z_moved_config_t this_) { z_config_drop(this_); };
 inline void z_drop(z_moved_encoding_t this_) { z_encoding_drop(this_); };
@@ -570,7 +405,6 @@ inline void z_drop(z_moved_fifo_handler_reply_t this_) { z_fifo_handler_reply_dr
 inline void z_drop(z_moved_fifo_handler_sample_t this_) { z_fifo_handler_sample_drop(this_); };
 inline void z_drop(z_moved_hello_t this_) { z_hello_drop(this_); };
 inline void z_drop(z_moved_keyexpr_t this_) { z_keyexpr_drop(this_); };
-inline void z_drop(z_moved_memory_layout_t this_) { z_memory_layout_drop(this_); };
 inline void z_drop(z_moved_mutex_t this_) { z_mutex_drop(this_); };
 inline void z_drop(z_moved_publisher_t this_) { z_publisher_drop(this_); };
 inline void z_drop(z_moved_query_t this_) { z_query_drop(this_); };
@@ -582,34 +416,19 @@ inline void z_drop(z_moved_ring_handler_reply_t this_) { z_ring_handler_reply_dr
 inline void z_drop(z_moved_ring_handler_sample_t this_) { z_ring_handler_sample_drop(this_); };
 inline void z_drop(z_moved_sample_t this_) { z_sample_drop(this_); };
 inline void z_drop(z_moved_session_t this_) { z_session_drop(this_); };
-inline void z_drop(z_moved_shm_client_t this_) { z_shm_client_drop(this_); };
-inline void z_drop(z_moved_shm_client_storage_t this_) { z_shm_client_storage_drop(this_); };
-inline void z_drop(z_moved_shm_t this_) { z_shm_drop(this_); };
-inline void z_drop(z_moved_shm_mut_t this_) { z_shm_mut_drop(this_); };
-inline void z_drop(z_moved_shm_provider_t this_) { z_shm_provider_drop(this_); };
 inline void z_drop(z_moved_slice_t this_) { z_slice_drop(this_); };
-inline void z_drop(z_moved_source_info_t this_) { z_source_info_drop(this_); };
 inline void z_drop(z_moved_string_array_t this_) { z_string_array_drop(this_); };
 inline void z_drop(z_moved_string_t this_) { z_string_drop(this_); };
 inline void z_drop(z_moved_subscriber_t this_) { z_subscriber_drop(this_); };
 inline void z_drop(z_moved_task_t this_) { z_task_drop(this_); };
 inline void z_drop(zc_moved_closure_log_t closure) { zc_closure_log_drop(closure); };
-inline void z_drop(zc_moved_closure_matching_status_t closure) { zc_closure_matching_status_drop(closure); };
-inline void z_drop(zc_moved_liveliness_token_t this_) { zc_liveliness_token_drop(this_); };
-inline z_result_t z_drop(zc_moved_matching_listener_t this_) { return zc_publisher_matching_listener_drop(this_); };
-inline void z_drop(zc_moved_shm_client_list_t this_) { zc_shm_client_list_drop(this_); };
-inline void z_drop(ze_moved_publication_cache_t this_) { ze_publication_cache_drop(this_); };
-inline void z_drop(ze_moved_querying_subscriber_t this_) { ze_querying_subscriber_drop(this_); };
 
 
-inline z_moved_alloc_layout_t z_move(z_owned_alloc_layout_t& this_) { return z_alloc_layout_move(&this_); };
 inline z_moved_bytes_t z_move(z_owned_bytes_t& this_) { return z_bytes_move(&this_); };
-inline z_moved_chunk_alloc_result_t z_move(z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_move(&this_); };
 inline z_moved_closure_hello_t z_move(z_owned_closure_hello_t& _closure) { return z_closure_hello_move(&_closure); };
 inline z_moved_closure_query_t z_move(z_owned_closure_query_t& closure) { return z_closure_query_move(&closure); };
 inline z_moved_closure_reply_t z_move(z_owned_closure_reply_t& closure) { return z_closure_reply_move(&closure); };
 inline z_moved_closure_sample_t z_move(z_owned_closure_sample_t& closure) { return z_closure_sample_move(&closure); };
-inline z_moved_closure_zid_t z_move(z_owned_closure_zid_t& closure) { return z_closure_zid_move(&closure); };
 inline z_moved_condvar_t z_move(z_owned_condvar_t& this_) { return z_condvar_move(&this_); };
 inline z_moved_config_t z_move(z_owned_config_t& this_) { return z_config_move(&this_); };
 inline z_moved_encoding_t z_move(z_owned_encoding_t& this_) { return z_encoding_move(&this_); };
@@ -618,7 +437,6 @@ inline z_moved_fifo_handler_reply_t z_move(z_owned_fifo_handler_reply_t& this_) 
 inline z_moved_fifo_handler_sample_t z_move(z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_move(&this_); };
 inline z_moved_hello_t z_move(z_owned_hello_t& this_) { return z_hello_move(&this_); };
 inline z_moved_keyexpr_t z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
-inline z_moved_memory_layout_t z_move(z_owned_memory_layout_t& this_) { return z_memory_layout_move(&this_); };
 inline z_moved_mutex_t z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
 inline z_moved_publisher_t z_move(z_owned_publisher_t& this_) { return z_publisher_move(&this_); };
 inline z_moved_query_t z_move(z_owned_query_t& this_) { return z_query_move(&this_); };
@@ -630,34 +448,19 @@ inline z_moved_ring_handler_reply_t z_move(z_owned_ring_handler_reply_t& this_) 
 inline z_moved_ring_handler_sample_t z_move(z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_move(&this_); };
 inline z_moved_sample_t z_move(z_owned_sample_t& this_) { return z_sample_move(&this_); };
 inline z_moved_session_t z_move(z_owned_session_t& this_) { return z_session_move(&this_); };
-inline z_moved_shm_client_t z_move(z_owned_shm_client_t& this_) { return z_shm_client_move(&this_); };
-inline z_moved_shm_client_storage_t z_move(z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_move(&this_); };
-inline z_moved_shm_t z_move(z_owned_shm_t& this_) { return z_shm_move(&this_); };
-inline z_moved_shm_mut_t z_move(z_owned_shm_mut_t& this_) { return z_shm_mut_move(&this_); };
-inline z_moved_shm_provider_t z_move(z_owned_shm_provider_t& this_) { return z_shm_provider_move(&this_); };
 inline z_moved_slice_t z_move(z_owned_slice_t& this_) { return z_slice_move(&this_); };
-inline z_moved_source_info_t z_move(z_owned_source_info_t& this_) { return z_source_info_move(&this_); };
 inline z_moved_string_array_t z_move(z_owned_string_array_t& this_) { return z_string_array_move(&this_); };
 inline z_moved_string_t z_move(z_owned_string_t& this_) { return z_string_move(&this_); };
 inline z_moved_subscriber_t z_move(z_owned_subscriber_t& this_) { return z_subscriber_move(&this_); };
 inline z_moved_task_t z_move(z_owned_task_t& this_) { return z_task_move(&this_); };
 inline zc_moved_closure_log_t z_move(zc_owned_closure_log_t& closure) { return zc_closure_log_move(&closure); };
-inline zc_moved_closure_matching_status_t z_move(zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_move(&closure); };
-inline zc_moved_liveliness_token_t z_move(zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_move(&this_); };
-inline zc_moved_matching_listener_t z_move(zc_owned_matching_listener_t& this_) { return zc_publisher_matching_listener_move(&this_); };
-inline zc_moved_shm_client_list_t z_move(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_move(&this_); };
-inline ze_moved_publication_cache_t z_move(ze_owned_publication_cache_t& this_) { return ze_publication_cache_move(&this_); };
-inline ze_moved_querying_subscriber_t z_move(ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_move(&this_); };
 
 
-inline void z_null(z_owned_alloc_layout_t* this_) { z_alloc_layout_null(this_); };
 inline void z_null(z_owned_bytes_t* this_) { z_bytes_null(this_); };
-inline void z_null(z_owned_chunk_alloc_result_t* this_) { z_chunk_alloc_result_null(this_); };
 inline void z_null(z_owned_closure_hello_t* this_) { z_closure_hello_null(this_); };
 inline void z_null(z_owned_closure_query_t* this_) { z_closure_query_null(this_); };
 inline void z_null(z_owned_closure_reply_t* this_) { z_closure_reply_null(this_); };
 inline void z_null(z_owned_closure_sample_t* this_) { z_closure_sample_null(this_); };
-inline void z_null(z_owned_closure_zid_t* this_) { z_closure_zid_null(this_); };
 inline void z_null(z_owned_condvar_t* this_) { z_condvar_null(this_); };
 inline void z_null(z_owned_config_t* this_) { z_config_null(this_); };
 inline void z_null(z_owned_encoding_t* this_) { z_encoding_null(this_); };
@@ -666,7 +469,6 @@ inline void z_null(z_owned_fifo_handler_reply_t* this_) { z_fifo_handler_reply_n
 inline void z_null(z_owned_fifo_handler_sample_t* this_) { z_fifo_handler_sample_null(this_); };
 inline void z_null(z_owned_hello_t* this_) { z_hello_null(this_); };
 inline void z_null(z_owned_keyexpr_t* this_) { z_keyexpr_null(this_); };
-inline void z_null(z_owned_memory_layout_t* this_) { z_memory_layout_null(this_); };
 inline void z_null(z_owned_mutex_t* this_) { z_mutex_null(this_); };
 inline void z_null(z_owned_publisher_t* this_) { z_publisher_null(this_); };
 inline void z_null(z_owned_query_t* this_) { z_query_null(this_); };
@@ -678,33 +480,18 @@ inline void z_null(z_owned_ring_handler_reply_t* this_) { z_ring_handler_reply_n
 inline void z_null(z_owned_ring_handler_sample_t* this_) { z_ring_handler_sample_null(this_); };
 inline void z_null(z_owned_sample_t* this_) { z_sample_null(this_); };
 inline void z_null(z_owned_session_t* this_) { z_session_null(this_); };
-inline void z_null(z_owned_shm_client_t* this_) { z_shm_client_null(this_); };
-inline void z_null(z_owned_shm_client_storage_t* this_) { z_shm_client_storage_null(this_); };
-inline void z_null(z_owned_shm_mut_t* this_) { z_shm_mut_null(this_); };
-inline void z_null(z_owned_shm_t* this_) { z_shm_null(this_); };
-inline void z_null(z_owned_shm_provider_t* this_) { z_shm_provider_null(this_); };
 inline void z_null(z_owned_slice_t* this_) { z_slice_null(this_); };
-inline void z_null(z_owned_source_info_t* this_) { z_source_info_null(this_); };
 inline void z_null(z_owned_string_array_t* this_) { z_string_array_null(this_); };
 inline void z_null(z_owned_string_t* this_) { z_string_null(this_); };
 inline void z_null(z_owned_subscriber_t* this_) { z_subscriber_null(this_); };
 inline void z_null(z_owned_task_t* this_) { z_task_null(this_); };
 inline void z_null(zc_owned_closure_log_t* this_) { zc_closure_log_null(this_); };
-inline void z_null(zc_owned_closure_matching_status_t* this_) { zc_closure_matching_status_null(this_); };
-inline void z_null(zc_owned_liveliness_token_t* this_) { zc_liveliness_token_null(this_); };
-inline void z_null(zc_owned_matching_listener_t* this_) { zc_matching_listener_null(this_); };
-inline void z_null(zc_owned_shm_client_list_t* this_) { zc_shm_client_list_null(this_); };
-inline void z_null(ze_owned_publication_cache_t* this_) { ze_publication_cache_null(this_); };
-inline void z_null(ze_owned_querying_subscriber_t* this_) { ze_querying_subscriber_null(this_); };
 
-static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t x) { *this_ = *x._ptr; z_alloc_layout_null(x._ptr); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t x) { *this_ = *x._ptr; z_bytes_null(x._ptr); }
-static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) { *this_ = *x._ptr; z_chunk_alloc_result_null(x._ptr); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* _closure, z_moved_closure_hello_t x) { *_closure = *x._ptr; z_closure_hello_null(x._ptr); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure, z_moved_closure_query_t x) { *closure = *x._ptr; z_closure_query_null(x._ptr); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure, z_moved_closure_reply_t x) { *closure = *x._ptr; z_closure_reply_null(x._ptr); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure, z_moved_closure_sample_t x) { *closure = *x._ptr; z_closure_sample_null(x._ptr); }
-static inline void z_closure_zid_take(z_owned_closure_zid_t* closure, z_moved_closure_zid_t x) { *closure = *x._ptr; z_closure_zid_null(x._ptr); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t x) { *this_ = *x._ptr; z_condvar_null(x._ptr); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t x) { *this_ = *x._ptr; z_config_null(x._ptr); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t x) { *this_ = *x._ptr; z_encoding_null(x._ptr); }
@@ -713,7 +500,6 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t x) { *this_ = *x._ptr; z_fifo_handler_sample_null(x._ptr); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *this_ = *x._ptr; z_hello_null(x._ptr); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
-static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) { *this_ = *x._ptr; z_memory_layout_null(x._ptr); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t x) { *this_ = *x._ptr; z_publisher_null(x._ptr); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
@@ -725,35 +511,17 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t x) { *this_ = *x._ptr; z_ring_handler_sample_null(x._ptr); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t x) { *this_ = *x._ptr; z_sample_null(x._ptr); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t x) { *this_ = *x._ptr; z_session_null(x._ptr); }
-static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t x) { *this_ = *x._ptr; z_shm_client_null(x._ptr); }
-static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t x) { *this_ = *x._ptr; z_shm_client_storage_null(x._ptr); }
-static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t x) { *this_ = *x._ptr; z_shm_null(x._ptr); }
-static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t x) { *this_ = *x._ptr; z_shm_mut_null(x._ptr); }
-static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t x) { *this_ = *x._ptr; z_shm_provider_null(x._ptr); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t x) { *this_ = *x._ptr; z_slice_null(x._ptr); }
-static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t x) { *this_ = *x._ptr; z_source_info_null(x._ptr); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t x) { *this_ = *x._ptr; z_string_array_null(x._ptr); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t x) { *this_ = *x._ptr; z_string_null(x._ptr); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) { *this_ = *x._ptr; z_subscriber_null(x._ptr); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t x) { *this_ = *x._ptr; z_task_null(x._ptr); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved_closure_log_t x) { *closure = *x._ptr; zc_closure_log_null(x._ptr); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure, zc_moved_closure_matching_status_t x) { *closure = *x._ptr; zc_closure_matching_status_null(x._ptr); }
-static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
-static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t x) { *this_ = *x._ptr; zc_matching_listener_null(x._ptr); }
-static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) { *this_ = *x._ptr; ze_publication_cache_null(x._ptr); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) { *this_ = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 
-inline void z_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t x) {
-    z_alloc_layout_take(this_, x);
-};
 inline void z_take(z_owned_bytes_t* this_, z_moved_bytes_t x) {
     z_bytes_take(this_, x);
-};
-inline void z_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) {
-    z_chunk_alloc_result_take(this_, x);
 };
 inline void z_take(z_owned_closure_hello_t* _closure, z_moved_closure_hello_t x) {
     z_closure_hello_take(_closure, x);
@@ -766,9 +534,6 @@ inline void z_take(z_owned_closure_reply_t* closure, z_moved_closure_reply_t x) 
 };
 inline void z_take(z_owned_closure_sample_t* closure, z_moved_closure_sample_t x) {
     z_closure_sample_take(closure, x);
-};
-inline void z_take(z_owned_closure_zid_t* closure, z_moved_closure_zid_t x) {
-    z_closure_zid_take(closure, x);
 };
 inline void z_take(z_owned_condvar_t* this_, z_moved_condvar_t x) {
     z_condvar_take(this_, x);
@@ -793,9 +558,6 @@ inline void z_take(z_owned_hello_t* this_, z_moved_hello_t x) {
 };
 inline void z_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) {
     z_keyexpr_take(this_, x);
-};
-inline void z_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) {
-    z_memory_layout_take(this_, x);
 };
 inline void z_take(z_owned_mutex_t* this_, z_moved_mutex_t x) {
     z_mutex_take(this_, x);
@@ -830,26 +592,8 @@ inline void z_take(z_owned_sample_t* this_, z_moved_sample_t x) {
 inline void z_take(z_owned_session_t* this_, z_moved_session_t x) {
     z_session_take(this_, x);
 };
-inline void z_take(z_owned_shm_client_t* this_, z_moved_shm_client_t x) {
-    z_shm_client_take(this_, x);
-};
-inline void z_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t x) {
-    z_shm_client_storage_take(this_, x);
-};
-inline void z_take(z_owned_shm_t* this_, z_moved_shm_t x) {
-    z_shm_take(this_, x);
-};
-inline void z_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t x) {
-    z_shm_mut_take(this_, x);
-};
-inline void z_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t x) {
-    z_shm_provider_take(this_, x);
-};
 inline void z_take(z_owned_slice_t* this_, z_moved_slice_t x) {
     z_slice_take(this_, x);
-};
-inline void z_take(z_owned_source_info_t* this_, z_moved_source_info_t x) {
-    z_source_info_take(this_, x);
 };
 inline void z_take(z_owned_string_array_t* this_, z_moved_string_array_t x) {
     z_string_array_take(this_, x);
@@ -866,34 +610,13 @@ inline void z_take(z_owned_task_t* this_, z_moved_task_t x) {
 inline void z_take(zc_owned_closure_log_t* closure, zc_moved_closure_log_t x) {
     zc_closure_log_take(closure, x);
 };
-inline void z_take(zc_owned_closure_matching_status_t* closure, zc_moved_closure_matching_status_t x) {
-    zc_closure_matching_status_take(closure, x);
-};
-inline void z_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) {
-    zc_liveliness_token_take(this_, x);
-};
-inline void z_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t x) {
-    zc_publisher_matching_listener_take(this_, x);
-};
-inline void z_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) {
-    zc_shm_client_list_take(this_, x);
-};
-inline void z_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t x) {
-    ze_publication_cache_take(this_, x);
-};
-inline void z_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t x) {
-    ze_querying_subscriber_take(this_, x);
-};
 
 
-inline bool z_check(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_check(&this_); };
 inline bool z_check(const z_owned_bytes_t& this_) { return z_bytes_check(&this_); };
-inline bool z_check(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_check(&this_); };
 inline bool z_check(const z_owned_closure_hello_t& this_) { return z_closure_hello_check(&this_); };
 inline bool z_check(const z_owned_closure_query_t& this_) { return z_closure_query_check(&this_); };
 inline bool z_check(const z_owned_closure_reply_t& this_) { return z_closure_reply_check(&this_); };
 inline bool z_check(const z_owned_closure_sample_t& this_) { return z_closure_sample_check(&this_); };
-inline bool z_check(const z_owned_closure_zid_t& this_) { return z_closure_zid_check(&this_); };
 inline bool z_check(const z_owned_condvar_t& this_) { return z_condvar_check(&this_); };
 inline bool z_check(const z_owned_config_t& this_) { return z_config_check(&this_); };
 inline bool z_check(const z_owned_encoding_t& this_) { return z_encoding_check(&this_); };
@@ -902,7 +625,6 @@ inline bool z_check(const z_owned_fifo_handler_reply_t& this_) { return z_fifo_h
 inline bool z_check(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_hello_t& this_) { return z_hello_check(&this_); };
 inline bool z_check(const z_owned_keyexpr_t& this_) { return z_keyexpr_check(&this_); };
-inline bool z_check(const z_owned_memory_layout_t& this_) { return z_memory_layout_check(&this_); };
 inline bool z_check(const z_owned_mutex_t& this_) { return z_mutex_check(&this_); };
 inline bool z_check(const z_owned_publisher_t& this_) { return z_publisher_check(&this_); };
 inline bool z_check(const z_owned_query_t& query) { return z_query_check(&query); };
@@ -914,24 +636,12 @@ inline bool z_check(const z_owned_ring_handler_reply_t& this_) { return z_ring_h
 inline bool z_check(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_sample_t& this_) { return z_sample_check(&this_); };
 inline bool z_check(const z_owned_session_t& this_) { return z_session_check(&this_); };
-inline bool z_check(const z_owned_shm_t& this_) { return z_shm_check(&this_); };
-inline bool z_check(const z_owned_shm_client_t& this_) { return z_shm_client_check(&this_); };
-inline bool z_check(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_check(&this_); };
-inline bool z_check(const z_owned_shm_mut_t& this_) { return z_shm_mut_check(&this_); };
-inline bool z_check(const z_owned_shm_provider_t& this_) { return z_shm_provider_check(&this_); };
 inline bool z_check(const z_owned_slice_t& this_) { return z_slice_check(&this_); };
-inline bool z_check(const z_owned_source_info_t& this_) { return z_source_info_check(&this_); };
 inline bool z_check(const z_owned_string_array_t& this_) { return z_string_array_check(&this_); };
 inline bool z_check(const z_owned_string_t& this_) { return z_string_check(&this_); };
 inline bool z_check(const z_owned_subscriber_t& this_) { return z_subscriber_check(&this_); };
 inline bool z_check(const z_owned_task_t& this_) { return z_task_check(&this_); };
 inline bool z_check(const zc_owned_closure_log_t& this_) { return zc_closure_log_check(&this_); };
-inline bool z_check(const zc_owned_closure_matching_status_t& this_) { return zc_closure_matching_status_check(&this_); };
-inline bool z_check(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_check(&this_); };
-inline bool z_check(const zc_owned_matching_listener_t& this_) { return zc_matching_listener_check(&this_); };
-inline bool z_check(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_check(&this_); };
-inline bool z_check(const ze_owned_publication_cache_t& this_) { return ze_publication_cache_check(&this_); };
-inline bool z_check(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_check(&this_); };
 
 
 inline void z_call(const z_loaned_closure_hello_t* closure, const z_loaned_hello_t* hello) {
@@ -945,12 +655,6 @@ inline void z_call(const z_loaned_closure_reply_t* closure, const z_loaned_reply
 };
 inline void z_call(const z_loaned_closure_sample_t* closure, const z_loaned_sample_t* sample) {
     z_closure_sample_call(closure, sample);
-};
-inline void z_call(const z_loaned_closure_zid_t* closure, const z_id_t* z_id) {
-    z_closure_zid_call(closure, z_id);
-};
-inline void z_call(const zc_loaned_closure_matching_status_t* closure, const zc_matching_status_t* mathing_status) {
-    zc_closure_matching_status_call(closure, mathing_status);
 };
 
 
@@ -984,24 +688,6 @@ inline void z_closure(
 inline void z_closure(
     z_owned_closure_sample_t* closure,
     void (*call)(const z_loaned_sample_t*, void*),
-    void (*drop)(void*),
-    void *context) {
-    closure->context = context;
-    closure->drop = drop;
-    closure->call = call;
-};
-inline void z_closure(
-    z_owned_closure_zid_t* closure,
-    void (*call)(const z_id_t*, void*),
-    void (*drop)(void*),
-    void *context) {
-    closure->context = context;
-    closure->drop = drop;
-    closure->call = call;
-};
-inline void z_closure(
-    zc_owned_closure_matching_status_t* closure,
-    void (*call)(const zc_matching_status_t*, void*),
     void (*drop)(void*),
     void *context) {
     closure->context = context;
@@ -1051,12 +737,8 @@ inline z_result_t z_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sa
 
 template<class T> struct z_loaned_to_owned_type_t {};
 template<class T> struct z_owned_to_loaned_type_t {};
-template<> struct z_loaned_to_owned_type_t<z_loaned_alloc_layout_t> { typedef z_owned_alloc_layout_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_alloc_layout_t> { typedef z_loaned_alloc_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_t> { typedef z_owned_bytes_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_t> { typedef z_loaned_bytes_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_chunk_alloc_result_t> { typedef z_owned_chunk_alloc_result_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_chunk_alloc_result_t> { typedef z_loaned_chunk_alloc_result_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_hello_t> { typedef z_owned_closure_hello_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_hello_t> { typedef z_loaned_closure_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_query_t> { typedef z_owned_closure_query_t type; };
@@ -1065,8 +747,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_closure_reply_t> { typedef z
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_reply_t> { typedef z_loaned_closure_reply_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_sample_t> { typedef z_owned_closure_sample_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_sample_t> { typedef z_loaned_closure_sample_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_closure_zid_t> { typedef z_owned_closure_zid_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_closure_zid_t> { typedef z_loaned_closure_zid_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_condvar_t> { typedef z_owned_condvar_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_condvar_t> { typedef z_loaned_condvar_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_config_t> { typedef z_owned_config_t type; };
@@ -1083,8 +763,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_hello_t> { typedef z_owned_h
 template<> struct z_owned_to_loaned_type_t<z_owned_hello_t> { typedef z_loaned_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_keyexpr_t> { typedef z_owned_keyexpr_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_keyexpr_t> { typedef z_loaned_keyexpr_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_memory_layout_t> { typedef z_owned_memory_layout_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_memory_layout_t> { typedef z_loaned_memory_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_publisher_t> { typedef z_owned_publisher_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_publisher_t> { typedef z_loaned_publisher_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_query_t> { typedef z_owned_query_t type; };
@@ -1105,18 +783,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_sample_t> { typedef z_owned_
 template<> struct z_owned_to_loaned_type_t<z_owned_sample_t> { typedef z_loaned_sample_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_session_t> { typedef z_owned_session_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_session_t> { typedef z_loaned_session_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_client_storage_t> { typedef z_owned_shm_client_storage_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_client_storage_t> { typedef z_loaned_shm_client_storage_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_t> { typedef z_owned_shm_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_t> { typedef z_loaned_shm_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_mut_t> { typedef z_owned_shm_mut_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_mut_t> { typedef z_loaned_shm_mut_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_provider_t> { typedef z_owned_shm_provider_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_provider_t> { typedef z_loaned_shm_provider_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_slice_t> { typedef z_owned_slice_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_slice_t> { typedef z_loaned_slice_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_source_info_t> { typedef z_owned_source_info_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_source_info_t> { typedef z_loaned_source_info_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_array_t> { typedef z_owned_string_array_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_string_array_t> { typedef z_loaned_string_array_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_t> { typedef z_owned_string_t type; };
@@ -1125,14 +793,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_subscriber_t> { typedef z_ow
 template<> struct z_owned_to_loaned_type_t<z_owned_subscriber_t> { typedef z_loaned_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_log_t> { typedef zc_owned_closure_log_t type; };
 template<> struct z_owned_to_loaned_type_t<zc_owned_closure_log_t> { typedef zc_loaned_closure_log_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_matching_status_t> { typedef zc_owned_closure_matching_status_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_closure_matching_status_t> { typedef zc_loaned_closure_matching_status_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_liveliness_token_t> { typedef zc_owned_liveliness_token_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_liveliness_token_t> { typedef zc_loaned_liveliness_token_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_shm_client_list_t> { typedef zc_owned_shm_client_list_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_shm_client_list_t> { typedef zc_loaned_shm_client_list_t type; };
-template<> struct z_loaned_to_owned_type_t<ze_loaned_querying_subscriber_t> { typedef ze_owned_querying_subscriber_t type; };
-template<> struct z_owned_to_loaned_type_t<ze_owned_querying_subscriber_t> { typedef ze_loaned_querying_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_mutex_t> { typedef z_owned_mutex_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_mutex_t> { typedef z_loaned_mutex_t type; };
 #endif  // #ifndef __cplusplus

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -4,36 +4,36 @@
 
 #ifndef __cplusplus
 
-static inline z_moved_bytes_t z_bytes_move(z_owned_bytes_t* x) { return (z_moved_bytes_t){x}; }
-static inline z_moved_closure_hello_t z_closure_hello_move(z_owned_closure_hello_t* x) { return (z_moved_closure_hello_t){x}; }
-static inline z_moved_closure_query_t z_closure_query_move(z_owned_closure_query_t* x) { return (z_moved_closure_query_t){x}; }
-static inline z_moved_closure_reply_t z_closure_reply_move(z_owned_closure_reply_t* x) { return (z_moved_closure_reply_t){x}; }
-static inline z_moved_closure_sample_t z_closure_sample_move(z_owned_closure_sample_t* x) { return (z_moved_closure_sample_t){x}; }
-static inline z_moved_condvar_t z_condvar_move(z_owned_condvar_t* x) { return (z_moved_condvar_t){x}; }
-static inline z_moved_config_t z_config_move(z_owned_config_t* x) { return (z_moved_config_t){x}; }
-static inline z_moved_encoding_t z_encoding_move(z_owned_encoding_t* x) { return (z_moved_encoding_t){x}; }
-static inline z_moved_fifo_handler_query_t z_fifo_handler_query_move(z_owned_fifo_handler_query_t* x) { return (z_moved_fifo_handler_query_t){x}; }
-static inline z_moved_fifo_handler_reply_t z_fifo_handler_reply_move(z_owned_fifo_handler_reply_t* x) { return (z_moved_fifo_handler_reply_t){x}; }
-static inline z_moved_fifo_handler_sample_t z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return (z_moved_fifo_handler_sample_t){x}; }
-static inline z_moved_hello_t z_hello_move(z_owned_hello_t* x) { return (z_moved_hello_t){x}; }
-static inline z_moved_keyexpr_t z_keyexpr_move(z_owned_keyexpr_t* x) { return (z_moved_keyexpr_t){x}; }
-static inline z_moved_mutex_t z_mutex_move(z_owned_mutex_t* x) { return (z_moved_mutex_t){x}; }
-static inline z_moved_publisher_t z_publisher_move(z_owned_publisher_t* x) { return (z_moved_publisher_t){x}; }
-static inline z_moved_query_t z_query_move(z_owned_query_t* x) { return (z_moved_query_t){x}; }
-static inline z_moved_queryable_t z_queryable_move(z_owned_queryable_t* x) { return (z_moved_queryable_t){x}; }
-static inline z_moved_reply_t z_reply_move(z_owned_reply_t* x) { return (z_moved_reply_t){x}; }
-static inline z_moved_reply_err_t z_reply_err_move(z_owned_reply_err_t* x) { return (z_moved_reply_err_t){x}; }
-static inline z_moved_ring_handler_query_t z_ring_handler_query_move(z_owned_ring_handler_query_t* x) { return (z_moved_ring_handler_query_t){x}; }
-static inline z_moved_ring_handler_reply_t z_ring_handler_reply_move(z_owned_ring_handler_reply_t* x) { return (z_moved_ring_handler_reply_t){x}; }
-static inline z_moved_ring_handler_sample_t z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return (z_moved_ring_handler_sample_t){x}; }
-static inline z_moved_sample_t z_sample_move(z_owned_sample_t* x) { return (z_moved_sample_t){x}; }
-static inline z_moved_session_t z_session_move(z_owned_session_t* x) { return (z_moved_session_t){x}; }
-static inline z_moved_slice_t z_slice_move(z_owned_slice_t* x) { return (z_moved_slice_t){x}; }
-static inline z_moved_string_array_t z_string_array_move(z_owned_string_array_t* x) { return (z_moved_string_array_t){x}; }
-static inline z_moved_string_t z_string_move(z_owned_string_t* x) { return (z_moved_string_t){x}; }
-static inline z_moved_subscriber_t z_subscriber_move(z_owned_subscriber_t* x) { return (z_moved_subscriber_t){x}; }
-static inline z_moved_task_t z_task_move(z_owned_task_t* x) { return (z_moved_task_t){x}; }
-static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t* x) { return (zc_moved_closure_log_t){x}; }
+static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return (z_moved_bytes_t*)(x); }
+static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return (z_moved_closure_hello_t*)(x); }
+static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return (z_moved_closure_query_t*)(x); }
+static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return (z_moved_closure_reply_t*)(x); }
+static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return (z_moved_closure_sample_t*)(x); }
+static inline z_moved_condvar_t* z_condvar_move(z_owned_condvar_t* x) { return (z_moved_condvar_t*)(x); }
+static inline z_moved_config_t* z_config_move(z_owned_config_t* x) { return (z_moved_config_t*)(x); }
+static inline z_moved_encoding_t* z_encoding_move(z_owned_encoding_t* x) { return (z_moved_encoding_t*)(x); }
+static inline z_moved_fifo_handler_query_t* z_fifo_handler_query_move(z_owned_fifo_handler_query_t* x) { return (z_moved_fifo_handler_query_t*)(x); }
+static inline z_moved_fifo_handler_reply_t* z_fifo_handler_reply_move(z_owned_fifo_handler_reply_t* x) { return (z_moved_fifo_handler_reply_t*)(x); }
+static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return (z_moved_fifo_handler_sample_t*)(x); }
+static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return (z_moved_hello_t*)(x); }
+static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return (z_moved_keyexpr_t*)(x); }
+static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return (z_moved_mutex_t*)(x); }
+static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return (z_moved_publisher_t*)(x); }
+static inline z_moved_query_t* z_query_move(z_owned_query_t* x) { return (z_moved_query_t*)(x); }
+static inline z_moved_queryable_t* z_queryable_move(z_owned_queryable_t* x) { return (z_moved_queryable_t*)(x); }
+static inline z_moved_reply_t* z_reply_move(z_owned_reply_t* x) { return (z_moved_reply_t*)(x); }
+static inline z_moved_reply_err_t* z_reply_err_move(z_owned_reply_err_t* x) { return (z_moved_reply_err_t*)(x); }
+static inline z_moved_ring_handler_query_t* z_ring_handler_query_move(z_owned_ring_handler_query_t* x) { return (z_moved_ring_handler_query_t*)(x); }
+static inline z_moved_ring_handler_reply_t* z_ring_handler_reply_move(z_owned_ring_handler_reply_t* x) { return (z_moved_ring_handler_reply_t*)(x); }
+static inline z_moved_ring_handler_sample_t* z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return (z_moved_ring_handler_sample_t*)(x); }
+static inline z_moved_sample_t* z_sample_move(z_owned_sample_t* x) { return (z_moved_sample_t*)(x); }
+static inline z_moved_session_t* z_session_move(z_owned_session_t* x) { return (z_moved_session_t*)(x); }
+static inline z_moved_slice_t* z_slice_move(z_owned_slice_t* x) { return (z_moved_slice_t*)(x); }
+static inline z_moved_string_array_t* z_string_array_move(z_owned_string_array_t* x) { return (z_moved_string_array_t*)(x); }
+static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return (z_moved_string_t*)(x); }
+static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return (z_moved_subscriber_t*)(x); }
+static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return (z_moved_task_t*)(x); }
+static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return (zc_moved_closure_log_t*)(x); }
 
 
 #define z_loan(this_) \
@@ -184,36 +184,36 @@ static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t*
         zc_owned_closure_log_t* : zc_closure_log_null \
     )(this_)
 
-static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t x) { *this_ = *x._ptr; z_bytes_null(x._ptr); }
-static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t x) { *this_ = *x._ptr; z_closure_hello_null(x._ptr); }
-static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t x) { *closure_ = *x._ptr; z_closure_query_null(x._ptr); }
-static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t x) { *closure_ = *x._ptr; z_closure_reply_null(x._ptr); }
-static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t x) { *closure_ = *x._ptr; z_closure_sample_null(x._ptr); }
-static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t x) { *this_ = *x._ptr; z_condvar_null(x._ptr); }
-static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t x) { *this_ = *x._ptr; z_config_null(x._ptr); }
-static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t x) { *this_ = *x._ptr; z_encoding_null(x._ptr); }
-static inline void z_fifo_handler_query_take(z_owned_fifo_handler_query_t* this_, z_moved_fifo_handler_query_t x) { *this_ = *x._ptr; z_fifo_handler_query_null(x._ptr); }
-static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_, z_moved_fifo_handler_reply_t x) { *this_ = *x._ptr; z_fifo_handler_reply_null(x._ptr); }
-static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t x) { *this_ = *x._ptr; z_fifo_handler_sample_null(x._ptr); }
-static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *this_ = *x._ptr; z_hello_null(x._ptr); }
-static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
-static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
-static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t x) { *this_ = *x._ptr; z_publisher_null(x._ptr); }
-static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
-static inline void z_queryable_take(z_owned_queryable_t* this_, z_moved_queryable_t x) { *this_ = *x._ptr; z_queryable_null(x._ptr); }
-static inline void z_reply_take(z_owned_reply_t* this_, z_moved_reply_t x) { *this_ = *x._ptr; z_reply_null(x._ptr); }
-static inline void z_reply_err_take(z_owned_reply_err_t* this_, z_moved_reply_err_t x) { *this_ = *x._ptr; z_reply_err_null(x._ptr); }
-static inline void z_ring_handler_query_take(z_owned_ring_handler_query_t* this_, z_moved_ring_handler_query_t x) { *this_ = *x._ptr; z_ring_handler_query_null(x._ptr); }
-static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_, z_moved_ring_handler_reply_t x) { *this_ = *x._ptr; z_ring_handler_reply_null(x._ptr); }
-static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t x) { *this_ = *x._ptr; z_ring_handler_sample_null(x._ptr); }
-static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t x) { *this_ = *x._ptr; z_sample_null(x._ptr); }
-static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t x) { *this_ = *x._ptr; z_session_null(x._ptr); }
-static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t x) { *this_ = *x._ptr; z_slice_null(x._ptr); }
-static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t x) { *this_ = *x._ptr; z_string_array_null(x._ptr); }
-static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t x) { *this_ = *x._ptr; z_string_null(x._ptr); }
-static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) { *this_ = *x._ptr; z_subscriber_null(x._ptr); }
-static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t x) { *this_ = *x._ptr; z_task_null(x._ptr); }
-static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t x) { *closure_ = *x._ptr; zc_closure_log_null(x._ptr); }
+static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *this_ = x->_this; z_bytes_null(&x->_this); }
+static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_closure_hello_null(&x->_this); }
+static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_closure_query_null(&x->_this); }
+static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_closure_reply_null(&x->_this); }
+static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_closure_sample_null(&x->_this); }
+static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) { *this_ = x->_this; z_condvar_null(&x->_this); }
+static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t* x) { *this_ = x->_this; z_config_null(&x->_this); }
+static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t* x) { *this_ = x->_this; z_encoding_null(&x->_this); }
+static inline void z_fifo_handler_query_take(z_owned_fifo_handler_query_t* this_, z_moved_fifo_handler_query_t* x) { *this_ = x->_this; z_fifo_handler_query_null(&x->_this); }
+static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_, z_moved_fifo_handler_reply_t* x) { *this_ = x->_this; z_fifo_handler_reply_null(&x->_this); }
+static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t* x) { *this_ = x->_this; z_fifo_handler_sample_null(&x->_this); }
+static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_hello_null(&x->_this); }
+static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_keyexpr_null(&x->_this); }
+static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_mutex_null(&x->_this); }
+static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_publisher_null(&x->_this); }
+static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t* x) { *this_ = x->_this; z_query_null(&x->_this); }
+static inline void z_queryable_take(z_owned_queryable_t* this_, z_moved_queryable_t* x) { *this_ = x->_this; z_queryable_null(&x->_this); }
+static inline void z_reply_take(z_owned_reply_t* this_, z_moved_reply_t* x) { *this_ = x->_this; z_reply_null(&x->_this); }
+static inline void z_reply_err_take(z_owned_reply_err_t* this_, z_moved_reply_err_t* x) { *this_ = x->_this; z_reply_err_null(&x->_this); }
+static inline void z_ring_handler_query_take(z_owned_ring_handler_query_t* this_, z_moved_ring_handler_query_t* x) { *this_ = x->_this; z_ring_handler_query_null(&x->_this); }
+static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_, z_moved_ring_handler_reply_t* x) { *this_ = x->_this; z_ring_handler_reply_null(&x->_this); }
+static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t* x) { *this_ = x->_this; z_ring_handler_sample_null(&x->_this); }
+static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t* x) { *this_ = x->_this; z_sample_null(&x->_this); }
+static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t* x) { *this_ = x->_this; z_session_null(&x->_this); }
+static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t* x) { *this_ = x->_this; z_slice_null(&x->_this); }
+static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) { *this_ = x->_this; z_string_array_null(&x->_this); }
+static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) { *this_ = x->_this; z_string_null(&x->_this); }
+static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_subscriber_null(&x->_this); }
+static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_task_null(&x->_this); }
+static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_closure_log_null(&x->_this); }
 
 
 #define z_take(this_, x) \
@@ -317,36 +317,36 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
 #else  // #ifndef __cplusplus
 
 
-static inline z_moved_bytes_t z_bytes_move(z_owned_bytes_t* x) { return z_moved_bytes_t{x}; }
-static inline z_moved_closure_hello_t z_closure_hello_move(z_owned_closure_hello_t* x) { return z_moved_closure_hello_t{x}; }
-static inline z_moved_closure_query_t z_closure_query_move(z_owned_closure_query_t* x) { return z_moved_closure_query_t{x}; }
-static inline z_moved_closure_reply_t z_closure_reply_move(z_owned_closure_reply_t* x) { return z_moved_closure_reply_t{x}; }
-static inline z_moved_closure_sample_t z_closure_sample_move(z_owned_closure_sample_t* x) { return z_moved_closure_sample_t{x}; }
-static inline z_moved_condvar_t z_condvar_move(z_owned_condvar_t* x) { return z_moved_condvar_t{x}; }
-static inline z_moved_config_t z_config_move(z_owned_config_t* x) { return z_moved_config_t{x}; }
-static inline z_moved_encoding_t z_encoding_move(z_owned_encoding_t* x) { return z_moved_encoding_t{x}; }
-static inline z_moved_fifo_handler_query_t z_fifo_handler_query_move(z_owned_fifo_handler_query_t* x) { return z_moved_fifo_handler_query_t{x}; }
-static inline z_moved_fifo_handler_reply_t z_fifo_handler_reply_move(z_owned_fifo_handler_reply_t* x) { return z_moved_fifo_handler_reply_t{x}; }
-static inline z_moved_fifo_handler_sample_t z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return z_moved_fifo_handler_sample_t{x}; }
-static inline z_moved_hello_t z_hello_move(z_owned_hello_t* x) { return z_moved_hello_t{x}; }
-static inline z_moved_keyexpr_t z_keyexpr_move(z_owned_keyexpr_t* x) { return z_moved_keyexpr_t{x}; }
-static inline z_moved_mutex_t z_mutex_move(z_owned_mutex_t* x) { return z_moved_mutex_t{x}; }
-static inline z_moved_publisher_t z_publisher_move(z_owned_publisher_t* x) { return z_moved_publisher_t{x}; }
-static inline z_moved_query_t z_query_move(z_owned_query_t* x) { return z_moved_query_t{x}; }
-static inline z_moved_queryable_t z_queryable_move(z_owned_queryable_t* x) { return z_moved_queryable_t{x}; }
-static inline z_moved_reply_t z_reply_move(z_owned_reply_t* x) { return z_moved_reply_t{x}; }
-static inline z_moved_reply_err_t z_reply_err_move(z_owned_reply_err_t* x) { return z_moved_reply_err_t{x}; }
-static inline z_moved_ring_handler_query_t z_ring_handler_query_move(z_owned_ring_handler_query_t* x) { return z_moved_ring_handler_query_t{x}; }
-static inline z_moved_ring_handler_reply_t z_ring_handler_reply_move(z_owned_ring_handler_reply_t* x) { return z_moved_ring_handler_reply_t{x}; }
-static inline z_moved_ring_handler_sample_t z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return z_moved_ring_handler_sample_t{x}; }
-static inline z_moved_sample_t z_sample_move(z_owned_sample_t* x) { return z_moved_sample_t{x}; }
-static inline z_moved_session_t z_session_move(z_owned_session_t* x) { return z_moved_session_t{x}; }
-static inline z_moved_slice_t z_slice_move(z_owned_slice_t* x) { return z_moved_slice_t{x}; }
-static inline z_moved_string_array_t z_string_array_move(z_owned_string_array_t* x) { return z_moved_string_array_t{x}; }
-static inline z_moved_string_t z_string_move(z_owned_string_t* x) { return z_moved_string_t{x}; }
-static inline z_moved_subscriber_t z_subscriber_move(z_owned_subscriber_t* x) { return z_moved_subscriber_t{x}; }
-static inline z_moved_task_t z_task_move(z_owned_task_t* x) { return z_moved_task_t{x}; }
-static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t* x) { return zc_moved_closure_log_t{x}; }
+static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return reinterpret_cast<z_moved_bytes_t*>(x); }
+static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return reinterpret_cast<z_moved_closure_hello_t*>(x); }
+static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return reinterpret_cast<z_moved_closure_query_t*>(x); }
+static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return reinterpret_cast<z_moved_closure_reply_t*>(x); }
+static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return reinterpret_cast<z_moved_closure_sample_t*>(x); }
+static inline z_moved_condvar_t* z_condvar_move(z_owned_condvar_t* x) { return reinterpret_cast<z_moved_condvar_t*>(x); }
+static inline z_moved_config_t* z_config_move(z_owned_config_t* x) { return reinterpret_cast<z_moved_config_t*>(x); }
+static inline z_moved_encoding_t* z_encoding_move(z_owned_encoding_t* x) { return reinterpret_cast<z_moved_encoding_t*>(x); }
+static inline z_moved_fifo_handler_query_t* z_fifo_handler_query_move(z_owned_fifo_handler_query_t* x) { return reinterpret_cast<z_moved_fifo_handler_query_t*>(x); }
+static inline z_moved_fifo_handler_reply_t* z_fifo_handler_reply_move(z_owned_fifo_handler_reply_t* x) { return reinterpret_cast<z_moved_fifo_handler_reply_t*>(x); }
+static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return reinterpret_cast<z_moved_fifo_handler_sample_t*>(x); }
+static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return reinterpret_cast<z_moved_hello_t*>(x); }
+static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return reinterpret_cast<z_moved_keyexpr_t*>(x); }
+static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return reinterpret_cast<z_moved_mutex_t*>(x); }
+static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return reinterpret_cast<z_moved_publisher_t*>(x); }
+static inline z_moved_query_t* z_query_move(z_owned_query_t* x) { return reinterpret_cast<z_moved_query_t*>(x); }
+static inline z_moved_queryable_t* z_queryable_move(z_owned_queryable_t* x) { return reinterpret_cast<z_moved_queryable_t*>(x); }
+static inline z_moved_reply_t* z_reply_move(z_owned_reply_t* x) { return reinterpret_cast<z_moved_reply_t*>(x); }
+static inline z_moved_reply_err_t* z_reply_err_move(z_owned_reply_err_t* x) { return reinterpret_cast<z_moved_reply_err_t*>(x); }
+static inline z_moved_ring_handler_query_t* z_ring_handler_query_move(z_owned_ring_handler_query_t* x) { return reinterpret_cast<z_moved_ring_handler_query_t*>(x); }
+static inline z_moved_ring_handler_reply_t* z_ring_handler_reply_move(z_owned_ring_handler_reply_t* x) { return reinterpret_cast<z_moved_ring_handler_reply_t*>(x); }
+static inline z_moved_ring_handler_sample_t* z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return reinterpret_cast<z_moved_ring_handler_sample_t*>(x); }
+static inline z_moved_sample_t* z_sample_move(z_owned_sample_t* x) { return reinterpret_cast<z_moved_sample_t*>(x); }
+static inline z_moved_session_t* z_session_move(z_owned_session_t* x) { return reinterpret_cast<z_moved_session_t*>(x); }
+static inline z_moved_slice_t* z_slice_move(z_owned_slice_t* x) { return reinterpret_cast<z_moved_slice_t*>(x); }
+static inline z_moved_string_array_t* z_string_array_move(z_owned_string_array_t* x) { return reinterpret_cast<z_moved_string_array_t*>(x); }
+static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return reinterpret_cast<z_moved_string_t*>(x); }
+static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return reinterpret_cast<z_moved_subscriber_t*>(x); }
+static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return reinterpret_cast<z_moved_task_t*>(x); }
+static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return reinterpret_cast<zc_moved_closure_log_t*>(x); }
 
 
 
@@ -424,36 +424,36 @@ inline void z_drop(z_moved_task_t this_) { z_task_drop(this_); };
 inline void z_drop(zc_moved_closure_log_t closure_) { zc_closure_log_drop(closure_); };
 
 
-inline z_moved_bytes_t z_move(z_owned_bytes_t& this_) { return z_bytes_move(&this_); };
-inline z_moved_closure_hello_t z_move(z_owned_closure_hello_t& this_) { return z_closure_hello_move(&this_); };
-inline z_moved_closure_query_t z_move(z_owned_closure_query_t& closure_) { return z_closure_query_move(&closure_); };
-inline z_moved_closure_reply_t z_move(z_owned_closure_reply_t& closure_) { return z_closure_reply_move(&closure_); };
-inline z_moved_closure_sample_t z_move(z_owned_closure_sample_t& closure_) { return z_closure_sample_move(&closure_); };
-inline z_moved_condvar_t z_move(z_owned_condvar_t& this_) { return z_condvar_move(&this_); };
-inline z_moved_config_t z_move(z_owned_config_t& this_) { return z_config_move(&this_); };
-inline z_moved_encoding_t z_move(z_owned_encoding_t& this_) { return z_encoding_move(&this_); };
-inline z_moved_fifo_handler_query_t z_move(z_owned_fifo_handler_query_t& this_) { return z_fifo_handler_query_move(&this_); };
-inline z_moved_fifo_handler_reply_t z_move(z_owned_fifo_handler_reply_t& this_) { return z_fifo_handler_reply_move(&this_); };
-inline z_moved_fifo_handler_sample_t z_move(z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_move(&this_); };
-inline z_moved_hello_t z_move(z_owned_hello_t& this_) { return z_hello_move(&this_); };
-inline z_moved_keyexpr_t z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
-inline z_moved_mutex_t z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
-inline z_moved_publisher_t z_move(z_owned_publisher_t& this_) { return z_publisher_move(&this_); };
-inline z_moved_query_t z_move(z_owned_query_t& this_) { return z_query_move(&this_); };
-inline z_moved_queryable_t z_move(z_owned_queryable_t& this_) { return z_queryable_move(&this_); };
-inline z_moved_reply_t z_move(z_owned_reply_t& this_) { return z_reply_move(&this_); };
-inline z_moved_reply_err_t z_move(z_owned_reply_err_t& this_) { return z_reply_err_move(&this_); };
-inline z_moved_ring_handler_query_t z_move(z_owned_ring_handler_query_t& this_) { return z_ring_handler_query_move(&this_); };
-inline z_moved_ring_handler_reply_t z_move(z_owned_ring_handler_reply_t& this_) { return z_ring_handler_reply_move(&this_); };
-inline z_moved_ring_handler_sample_t z_move(z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_move(&this_); };
-inline z_moved_sample_t z_move(z_owned_sample_t& this_) { return z_sample_move(&this_); };
-inline z_moved_session_t z_move(z_owned_session_t& this_) { return z_session_move(&this_); };
-inline z_moved_slice_t z_move(z_owned_slice_t& this_) { return z_slice_move(&this_); };
-inline z_moved_string_array_t z_move(z_owned_string_array_t& this_) { return z_string_array_move(&this_); };
-inline z_moved_string_t z_move(z_owned_string_t& this_) { return z_string_move(&this_); };
-inline z_moved_subscriber_t z_move(z_owned_subscriber_t& this_) { return z_subscriber_move(&this_); };
-inline z_moved_task_t z_move(z_owned_task_t& this_) { return z_task_move(&this_); };
-inline zc_moved_closure_log_t z_move(zc_owned_closure_log_t& closure_) { return zc_closure_log_move(&closure_); };
+inline z_moved_bytes_t* z_move(z_owned_bytes_t& this_) { return z_bytes_move(&this_); };
+inline z_moved_closure_hello_t* z_move(z_owned_closure_hello_t& this_) { return z_closure_hello_move(&this_); };
+inline z_moved_closure_query_t* z_move(z_owned_closure_query_t& closure_) { return z_closure_query_move(&closure_); };
+inline z_moved_closure_reply_t* z_move(z_owned_closure_reply_t& closure_) { return z_closure_reply_move(&closure_); };
+inline z_moved_closure_sample_t* z_move(z_owned_closure_sample_t& closure_) { return z_closure_sample_move(&closure_); };
+inline z_moved_condvar_t* z_move(z_owned_condvar_t& this_) { return z_condvar_move(&this_); };
+inline z_moved_config_t* z_move(z_owned_config_t& this_) { return z_config_move(&this_); };
+inline z_moved_encoding_t* z_move(z_owned_encoding_t& this_) { return z_encoding_move(&this_); };
+inline z_moved_fifo_handler_query_t* z_move(z_owned_fifo_handler_query_t& this_) { return z_fifo_handler_query_move(&this_); };
+inline z_moved_fifo_handler_reply_t* z_move(z_owned_fifo_handler_reply_t& this_) { return z_fifo_handler_reply_move(&this_); };
+inline z_moved_fifo_handler_sample_t* z_move(z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_move(&this_); };
+inline z_moved_hello_t* z_move(z_owned_hello_t& this_) { return z_hello_move(&this_); };
+inline z_moved_keyexpr_t* z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
+inline z_moved_mutex_t* z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
+inline z_moved_publisher_t* z_move(z_owned_publisher_t& this_) { return z_publisher_move(&this_); };
+inline z_moved_query_t* z_move(z_owned_query_t& this_) { return z_query_move(&this_); };
+inline z_moved_queryable_t* z_move(z_owned_queryable_t& this_) { return z_queryable_move(&this_); };
+inline z_moved_reply_t* z_move(z_owned_reply_t& this_) { return z_reply_move(&this_); };
+inline z_moved_reply_err_t* z_move(z_owned_reply_err_t& this_) { return z_reply_err_move(&this_); };
+inline z_moved_ring_handler_query_t* z_move(z_owned_ring_handler_query_t& this_) { return z_ring_handler_query_move(&this_); };
+inline z_moved_ring_handler_reply_t* z_move(z_owned_ring_handler_reply_t& this_) { return z_ring_handler_reply_move(&this_); };
+inline z_moved_ring_handler_sample_t* z_move(z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_move(&this_); };
+inline z_moved_sample_t* z_move(z_owned_sample_t& this_) { return z_sample_move(&this_); };
+inline z_moved_session_t* z_move(z_owned_session_t& this_) { return z_session_move(&this_); };
+inline z_moved_slice_t* z_move(z_owned_slice_t& this_) { return z_slice_move(&this_); };
+inline z_moved_string_array_t* z_move(z_owned_string_array_t& this_) { return z_string_array_move(&this_); };
+inline z_moved_string_t* z_move(z_owned_string_t& this_) { return z_string_move(&this_); };
+inline z_moved_subscriber_t* z_move(z_owned_subscriber_t& this_) { return z_subscriber_move(&this_); };
+inline z_moved_task_t* z_move(z_owned_task_t& this_) { return z_task_move(&this_); };
+inline zc_moved_closure_log_t* z_move(zc_owned_closure_log_t& closure_) { return zc_closure_log_move(&closure_); };
 
 
 inline void z_null(z_owned_bytes_t* this_) { z_bytes_null(this_); };
@@ -487,127 +487,127 @@ inline void z_null(z_owned_subscriber_t* this_) { z_subscriber_null(this_); };
 inline void z_null(z_owned_task_t* this_) { z_task_null(this_); };
 inline void z_null(zc_owned_closure_log_t* this_) { zc_closure_log_null(this_); };
 
-static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t x) { *this_ = *x._ptr; z_bytes_null(x._ptr); }
-static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t x) { *this_ = *x._ptr; z_closure_hello_null(x._ptr); }
-static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t x) { *closure_ = *x._ptr; z_closure_query_null(x._ptr); }
-static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t x) { *closure_ = *x._ptr; z_closure_reply_null(x._ptr); }
-static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t x) { *closure_ = *x._ptr; z_closure_sample_null(x._ptr); }
-static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t x) { *this_ = *x._ptr; z_condvar_null(x._ptr); }
-static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t x) { *this_ = *x._ptr; z_config_null(x._ptr); }
-static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t x) { *this_ = *x._ptr; z_encoding_null(x._ptr); }
-static inline void z_fifo_handler_query_take(z_owned_fifo_handler_query_t* this_, z_moved_fifo_handler_query_t x) { *this_ = *x._ptr; z_fifo_handler_query_null(x._ptr); }
-static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_, z_moved_fifo_handler_reply_t x) { *this_ = *x._ptr; z_fifo_handler_reply_null(x._ptr); }
-static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t x) { *this_ = *x._ptr; z_fifo_handler_sample_null(x._ptr); }
-static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *this_ = *x._ptr; z_hello_null(x._ptr); }
-static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
-static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
-static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t x) { *this_ = *x._ptr; z_publisher_null(x._ptr); }
-static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
-static inline void z_queryable_take(z_owned_queryable_t* this_, z_moved_queryable_t x) { *this_ = *x._ptr; z_queryable_null(x._ptr); }
-static inline void z_reply_take(z_owned_reply_t* this_, z_moved_reply_t x) { *this_ = *x._ptr; z_reply_null(x._ptr); }
-static inline void z_reply_err_take(z_owned_reply_err_t* this_, z_moved_reply_err_t x) { *this_ = *x._ptr; z_reply_err_null(x._ptr); }
-static inline void z_ring_handler_query_take(z_owned_ring_handler_query_t* this_, z_moved_ring_handler_query_t x) { *this_ = *x._ptr; z_ring_handler_query_null(x._ptr); }
-static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_, z_moved_ring_handler_reply_t x) { *this_ = *x._ptr; z_ring_handler_reply_null(x._ptr); }
-static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t x) { *this_ = *x._ptr; z_ring_handler_sample_null(x._ptr); }
-static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t x) { *this_ = *x._ptr; z_sample_null(x._ptr); }
-static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t x) { *this_ = *x._ptr; z_session_null(x._ptr); }
-static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t x) { *this_ = *x._ptr; z_slice_null(x._ptr); }
-static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t x) { *this_ = *x._ptr; z_string_array_null(x._ptr); }
-static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t x) { *this_ = *x._ptr; z_string_null(x._ptr); }
-static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) { *this_ = *x._ptr; z_subscriber_null(x._ptr); }
-static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t x) { *this_ = *x._ptr; z_task_null(x._ptr); }
-static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t x) { *closure_ = *x._ptr; zc_closure_log_null(x._ptr); }
+static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *this_ = x->_this; z_bytes_null(&x->_this); }
+static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_closure_hello_null(&x->_this); }
+static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_closure_query_null(&x->_this); }
+static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_closure_reply_null(&x->_this); }
+static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_closure_sample_null(&x->_this); }
+static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) { *this_ = x->_this; z_condvar_null(&x->_this); }
+static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t* x) { *this_ = x->_this; z_config_null(&x->_this); }
+static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t* x) { *this_ = x->_this; z_encoding_null(&x->_this); }
+static inline void z_fifo_handler_query_take(z_owned_fifo_handler_query_t* this_, z_moved_fifo_handler_query_t* x) { *this_ = x->_this; z_fifo_handler_query_null(&x->_this); }
+static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_, z_moved_fifo_handler_reply_t* x) { *this_ = x->_this; z_fifo_handler_reply_null(&x->_this); }
+static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t* x) { *this_ = x->_this; z_fifo_handler_sample_null(&x->_this); }
+static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_hello_null(&x->_this); }
+static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_keyexpr_null(&x->_this); }
+static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_mutex_null(&x->_this); }
+static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_publisher_null(&x->_this); }
+static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t* x) { *this_ = x->_this; z_query_null(&x->_this); }
+static inline void z_queryable_take(z_owned_queryable_t* this_, z_moved_queryable_t* x) { *this_ = x->_this; z_queryable_null(&x->_this); }
+static inline void z_reply_take(z_owned_reply_t* this_, z_moved_reply_t* x) { *this_ = x->_this; z_reply_null(&x->_this); }
+static inline void z_reply_err_take(z_owned_reply_err_t* this_, z_moved_reply_err_t* x) { *this_ = x->_this; z_reply_err_null(&x->_this); }
+static inline void z_ring_handler_query_take(z_owned_ring_handler_query_t* this_, z_moved_ring_handler_query_t* x) { *this_ = x->_this; z_ring_handler_query_null(&x->_this); }
+static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_, z_moved_ring_handler_reply_t* x) { *this_ = x->_this; z_ring_handler_reply_null(&x->_this); }
+static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t* x) { *this_ = x->_this; z_ring_handler_sample_null(&x->_this); }
+static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t* x) { *this_ = x->_this; z_sample_null(&x->_this); }
+static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t* x) { *this_ = x->_this; z_session_null(&x->_this); }
+static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t* x) { *this_ = x->_this; z_slice_null(&x->_this); }
+static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) { *this_ = x->_this; z_string_array_null(&x->_this); }
+static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) { *this_ = x->_this; z_string_null(&x->_this); }
+static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_subscriber_null(&x->_this); }
+static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_task_null(&x->_this); }
+static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_closure_log_null(&x->_this); }
 
 
 
-inline void z_take(z_owned_bytes_t* this_, z_moved_bytes_t x) {
+inline void z_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) {
     z_bytes_take(this_, x);
 };
-inline void z_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t x) {
+inline void z_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) {
     z_closure_hello_take(this_, x);
 };
-inline void z_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t x) {
+inline void z_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) {
     z_closure_query_take(closure_, x);
 };
-inline void z_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t x) {
+inline void z_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) {
     z_closure_reply_take(closure_, x);
 };
-inline void z_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t x) {
+inline void z_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) {
     z_closure_sample_take(closure_, x);
 };
-inline void z_take(z_owned_condvar_t* this_, z_moved_condvar_t x) {
+inline void z_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) {
     z_condvar_take(this_, x);
 };
-inline void z_take(z_owned_config_t* this_, z_moved_config_t x) {
+inline void z_take(z_owned_config_t* this_, z_moved_config_t* x) {
     z_config_take(this_, x);
 };
-inline void z_take(z_owned_encoding_t* this_, z_moved_encoding_t x) {
+inline void z_take(z_owned_encoding_t* this_, z_moved_encoding_t* x) {
     z_encoding_take(this_, x);
 };
-inline void z_take(z_owned_fifo_handler_query_t* this_, z_moved_fifo_handler_query_t x) {
+inline void z_take(z_owned_fifo_handler_query_t* this_, z_moved_fifo_handler_query_t* x) {
     z_fifo_handler_query_take(this_, x);
 };
-inline void z_take(z_owned_fifo_handler_reply_t* this_, z_moved_fifo_handler_reply_t x) {
+inline void z_take(z_owned_fifo_handler_reply_t* this_, z_moved_fifo_handler_reply_t* x) {
     z_fifo_handler_reply_take(this_, x);
 };
-inline void z_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t x) {
+inline void z_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t* x) {
     z_fifo_handler_sample_take(this_, x);
 };
-inline void z_take(z_owned_hello_t* this_, z_moved_hello_t x) {
+inline void z_take(z_owned_hello_t* this_, z_moved_hello_t* x) {
     z_hello_take(this_, x);
 };
-inline void z_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) {
+inline void z_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) {
     z_keyexpr_take(this_, x);
 };
-inline void z_take(z_owned_mutex_t* this_, z_moved_mutex_t x) {
+inline void z_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) {
     z_mutex_take(this_, x);
 };
-inline void z_take(z_owned_publisher_t* this_, z_moved_publisher_t x) {
+inline void z_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) {
     z_publisher_take(this_, x);
 };
-inline void z_take(z_owned_query_t* this_, z_moved_query_t x) {
+inline void z_take(z_owned_query_t* this_, z_moved_query_t* x) {
     z_query_take(this_, x);
 };
-inline void z_take(z_owned_queryable_t* this_, z_moved_queryable_t x) {
+inline void z_take(z_owned_queryable_t* this_, z_moved_queryable_t* x) {
     z_queryable_take(this_, x);
 };
-inline void z_take(z_owned_reply_t* this_, z_moved_reply_t x) {
+inline void z_take(z_owned_reply_t* this_, z_moved_reply_t* x) {
     z_reply_take(this_, x);
 };
-inline void z_take(z_owned_reply_err_t* this_, z_moved_reply_err_t x) {
+inline void z_take(z_owned_reply_err_t* this_, z_moved_reply_err_t* x) {
     z_reply_err_take(this_, x);
 };
-inline void z_take(z_owned_ring_handler_query_t* this_, z_moved_ring_handler_query_t x) {
+inline void z_take(z_owned_ring_handler_query_t* this_, z_moved_ring_handler_query_t* x) {
     z_ring_handler_query_take(this_, x);
 };
-inline void z_take(z_owned_ring_handler_reply_t* this_, z_moved_ring_handler_reply_t x) {
+inline void z_take(z_owned_ring_handler_reply_t* this_, z_moved_ring_handler_reply_t* x) {
     z_ring_handler_reply_take(this_, x);
 };
-inline void z_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t x) {
+inline void z_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t* x) {
     z_ring_handler_sample_take(this_, x);
 };
-inline void z_take(z_owned_sample_t* this_, z_moved_sample_t x) {
+inline void z_take(z_owned_sample_t* this_, z_moved_sample_t* x) {
     z_sample_take(this_, x);
 };
-inline void z_take(z_owned_session_t* this_, z_moved_session_t x) {
+inline void z_take(z_owned_session_t* this_, z_moved_session_t* x) {
     z_session_take(this_, x);
 };
-inline void z_take(z_owned_slice_t* this_, z_moved_slice_t x) {
+inline void z_take(z_owned_slice_t* this_, z_moved_slice_t* x) {
     z_slice_take(this_, x);
 };
-inline void z_take(z_owned_string_array_t* this_, z_moved_string_array_t x) {
+inline void z_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) {
     z_string_array_take(this_, x);
 };
-inline void z_take(z_owned_string_t* this_, z_moved_string_t x) {
+inline void z_take(z_owned_string_t* this_, z_moved_string_t* x) {
     z_string_take(this_, x);
 };
-inline void z_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) {
+inline void z_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) {
     z_subscriber_take(this_, x);
 };
-inline void z_take(z_owned_task_t* this_, z_moved_task_t x) {
+inline void z_take(z_owned_task_t* this_, z_moved_task_t* x) {
     z_task_take(this_, x);
 };
-inline void z_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t x) {
+inline void z_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) {
     zc_closure_log_take(closure_, x);
 };
 

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -4,14 +4,11 @@
 
 #ifndef __cplusplus
 
-static inline z_moved_alloc_layout_t* z_alloc_layout_move(z_owned_alloc_layout_t* x) { return (z_moved_alloc_layout_t*)(x); }
 static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return (z_moved_bytes_t*)(x); }
-static inline z_moved_chunk_alloc_result_t* z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return (z_moved_chunk_alloc_result_t*)(x); }
 static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return (z_moved_closure_hello_t*)(x); }
 static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return (z_moved_closure_query_t*)(x); }
 static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return (z_moved_closure_reply_t*)(x); }
 static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return (z_moved_closure_sample_t*)(x); }
-static inline z_moved_closure_zid_t* z_closure_zid_move(z_owned_closure_zid_t* x) { return (z_moved_closure_zid_t*)(x); }
 static inline z_moved_condvar_t* z_condvar_move(z_owned_condvar_t* x) { return (z_moved_condvar_t*)(x); }
 static inline z_moved_config_t* z_config_move(z_owned_config_t* x) { return (z_moved_config_t*)(x); }
 static inline z_moved_encoding_t* z_encoding_move(z_owned_encoding_t* x) { return (z_moved_encoding_t*)(x); }
@@ -20,7 +17,6 @@ static inline z_moved_fifo_handler_reply_t* z_fifo_handler_reply_move(z_owned_fi
 static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return (z_moved_fifo_handler_sample_t*)(x); }
 static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return (z_moved_hello_t*)(x); }
 static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return (z_moved_keyexpr_t*)(x); }
-static inline z_moved_memory_layout_t* z_memory_layout_move(z_owned_memory_layout_t* x) { return (z_moved_memory_layout_t*)(x); }
 static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return (z_moved_mutex_t*)(x); }
 static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return (z_moved_publisher_t*)(x); }
 static inline z_moved_query_t* z_query_move(z_owned_query_t* x) { return (z_moved_query_t*)(x); }
@@ -32,36 +28,21 @@ static inline z_moved_ring_handler_reply_t* z_ring_handler_reply_move(z_owned_ri
 static inline z_moved_ring_handler_sample_t* z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return (z_moved_ring_handler_sample_t*)(x); }
 static inline z_moved_sample_t* z_sample_move(z_owned_sample_t* x) { return (z_moved_sample_t*)(x); }
 static inline z_moved_session_t* z_session_move(z_owned_session_t* x) { return (z_moved_session_t*)(x); }
-static inline z_moved_shm_client_t* z_shm_client_move(z_owned_shm_client_t* x) { return (z_moved_shm_client_t*)(x); }
-static inline z_moved_shm_client_storage_t* z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return (z_moved_shm_client_storage_t*)(x); }
-static inline z_moved_shm_t* z_shm_move(z_owned_shm_t* x) { return (z_moved_shm_t*)(x); }
-static inline z_moved_shm_mut_t* z_shm_mut_move(z_owned_shm_mut_t* x) { return (z_moved_shm_mut_t*)(x); }
-static inline z_moved_shm_provider_t* z_shm_provider_move(z_owned_shm_provider_t* x) { return (z_moved_shm_provider_t*)(x); }
 static inline z_moved_slice_t* z_slice_move(z_owned_slice_t* x) { return (z_moved_slice_t*)(x); }
-static inline z_moved_source_info_t* z_source_info_move(z_owned_source_info_t* x) { return (z_moved_source_info_t*)(x); }
 static inline z_moved_string_array_t* z_string_array_move(z_owned_string_array_t* x) { return (z_moved_string_array_t*)(x); }
 static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return (z_moved_string_t*)(x); }
 static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return (z_moved_subscriber_t*)(x); }
 static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return (z_moved_task_t*)(x); }
 static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return (zc_moved_closure_log_t*)(x); }
-static inline zc_moved_closure_matching_status_t* zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return (zc_moved_closure_matching_status_t*)(x); }
-static inline zc_moved_liveliness_token_t* zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return (zc_moved_liveliness_token_t*)(x); }
-static inline zc_moved_matching_listener_t* zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return (zc_moved_matching_listener_t*)(x); }
-static inline zc_moved_shm_client_list_t* zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return (zc_moved_shm_client_list_t*)(x); }
-static inline ze_moved_publication_cache_t* ze_publication_cache_move(ze_owned_publication_cache_t* x) { return (ze_moved_publication_cache_t*)(x); }
-static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return (ze_moved_querying_subscriber_t*)(x); }
 
 
 #define z_loan(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_alloc_layout_loan, \
         z_owned_bytes_t : z_bytes_loan, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_loan, \
         z_owned_closure_hello_t : z_closure_hello_loan, \
         z_owned_closure_query_t : z_closure_query_loan, \
         z_owned_closure_reply_t : z_closure_reply_loan, \
         z_owned_closure_sample_t : z_closure_sample_loan, \
-        z_owned_closure_zid_t : z_closure_zid_loan, \
         z_owned_condvar_t : z_condvar_loan, \
         z_owned_config_t : z_config_loan, \
         z_owned_encoding_t : z_encoding_loan, \
@@ -70,7 +51,6 @@ static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_own
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_loan, \
         z_owned_hello_t : z_hello_loan, \
         z_owned_keyexpr_t : z_keyexpr_loan, \
-        z_owned_memory_layout_t : z_memory_layout_loan, \
         z_owned_publisher_t : z_publisher_loan, \
         z_owned_query_t : z_query_loan, \
         z_owned_queryable_t : z_queryable_loan, \
@@ -81,23 +61,14 @@ static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_own
         z_owned_ring_handler_sample_t : z_ring_handler_sample_loan, \
         z_owned_sample_t : z_sample_loan, \
         z_owned_session_t : z_session_loan, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_loan, \
-        z_owned_shm_t : z_shm_loan, \
-        z_owned_shm_mut_t : z_shm_mut_loan, \
-        z_owned_shm_provider_t : z_shm_provider_loan, \
         z_owned_slice_t : z_slice_loan, \
-        z_owned_source_info_t : z_source_info_loan, \
         z_owned_string_array_t : z_string_array_loan, \
         z_owned_string_t : z_string_loan, \
         z_owned_subscriber_t : z_subscriber_loan, \
         z_view_keyexpr_t : z_view_keyexpr_loan, \
         z_view_slice_t : z_view_slice_loan, \
         z_view_string_t : z_view_string_loan, \
-        zc_owned_closure_log_t : zc_closure_log_loan, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_loan, \
-        zc_owned_liveliness_token_t : zc_liveliness_token_loan, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_loan, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_loan \
+        zc_owned_closure_log_t : zc_closure_log_loan \
     )(&this_)
 
 #define z_loan_mut(this_) \
@@ -108,22 +79,16 @@ static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_own
         z_owned_encoding_t : z_encoding_loan_mut, \
         z_owned_mutex_t : z_mutex_loan_mut, \
         z_owned_publisher_t : z_publisher_loan_mut, \
-        z_owned_shm_t : z_shm_loan_mut, \
-        z_owned_shm_mut_t : z_shm_mut_loan_mut, \
-        z_owned_string_array_t : z_string_array_loan_mut, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_loan_mut \
+        z_owned_string_array_t : z_string_array_loan_mut \
     )(&this_)
 
 #define z_drop(this_) \
     _Generic((this_), \
-        z_moved_alloc_layout_t* : z_alloc_layout_drop, \
         z_moved_bytes_t* : z_bytes_drop, \
-        z_moved_chunk_alloc_result_t* : z_chunk_alloc_result_drop, \
         z_moved_closure_hello_t* : z_closure_hello_drop, \
         z_moved_closure_query_t* : z_closure_query_drop, \
         z_moved_closure_reply_t* : z_closure_reply_drop, \
         z_moved_closure_sample_t* : z_closure_sample_drop, \
-        z_moved_closure_zid_t* : z_closure_zid_drop, \
         z_moved_condvar_t* : z_condvar_drop, \
         z_moved_config_t* : z_config_drop, \
         z_moved_encoding_t* : z_encoding_drop, \
@@ -132,7 +97,6 @@ static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_own
         z_moved_fifo_handler_sample_t* : z_fifo_handler_sample_drop, \
         z_moved_hello_t* : z_hello_drop, \
         z_moved_keyexpr_t* : z_keyexpr_drop, \
-        z_moved_memory_layout_t* : z_memory_layout_drop, \
         z_moved_mutex_t* : z_mutex_drop, \
         z_moved_publisher_t* : z_publisher_drop, \
         z_moved_query_t* : z_query_drop, \
@@ -144,36 +108,21 @@ static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_own
         z_moved_ring_handler_sample_t* : z_ring_handler_sample_drop, \
         z_moved_sample_t* : z_sample_drop, \
         z_moved_session_t* : z_session_drop, \
-        z_moved_shm_client_t* : z_shm_client_drop, \
-        z_moved_shm_client_storage_t* : z_shm_client_storage_drop, \
-        z_moved_shm_t* : z_shm_drop, \
-        z_moved_shm_mut_t* : z_shm_mut_drop, \
-        z_moved_shm_provider_t* : z_shm_provider_drop, \
         z_moved_slice_t* : z_slice_drop, \
-        z_moved_source_info_t* : z_source_info_drop, \
         z_moved_string_array_t* : z_string_array_drop, \
         z_moved_string_t* : z_string_drop, \
         z_moved_subscriber_t* : z_subscriber_drop, \
         z_moved_task_t* : z_task_drop, \
-        zc_moved_closure_log_t* : zc_closure_log_drop, \
-        zc_moved_closure_matching_status_t* : zc_closure_matching_status_drop, \
-        zc_moved_liveliness_token_t* : zc_liveliness_token_drop, \
-        zc_moved_matching_listener_t* : zc_publisher_matching_listener_drop, \
-        zc_moved_shm_client_list_t* : zc_shm_client_list_drop, \
-        ze_moved_publication_cache_t* : ze_publication_cache_drop, \
-        ze_moved_querying_subscriber_t* : ze_querying_subscriber_drop \
+        zc_moved_closure_log_t* : zc_closure_log_drop \
     )(this_)
 
 #define z_move(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_alloc_layout_move, \
         z_owned_bytes_t : z_bytes_move, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_move, \
         z_owned_closure_hello_t : z_closure_hello_move, \
         z_owned_closure_query_t : z_closure_query_move, \
         z_owned_closure_reply_t : z_closure_reply_move, \
         z_owned_closure_sample_t : z_closure_sample_move, \
-        z_owned_closure_zid_t : z_closure_zid_move, \
         z_owned_condvar_t : z_condvar_move, \
         z_owned_config_t : z_config_move, \
         z_owned_encoding_t : z_encoding_move, \
@@ -182,7 +131,6 @@ static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_own
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_move, \
         z_owned_hello_t : z_hello_move, \
         z_owned_keyexpr_t : z_keyexpr_move, \
-        z_owned_memory_layout_t : z_memory_layout_move, \
         z_owned_mutex_t : z_mutex_move, \
         z_owned_publisher_t : z_publisher_move, \
         z_owned_query_t : z_query_move, \
@@ -194,36 +142,21 @@ static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_own
         z_owned_ring_handler_sample_t : z_ring_handler_sample_move, \
         z_owned_sample_t : z_sample_move, \
         z_owned_session_t : z_session_move, \
-        z_owned_shm_client_t : z_shm_client_move, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_move, \
-        z_owned_shm_t : z_shm_move, \
-        z_owned_shm_mut_t : z_shm_mut_move, \
-        z_owned_shm_provider_t : z_shm_provider_move, \
         z_owned_slice_t : z_slice_move, \
-        z_owned_source_info_t : z_source_info_move, \
         z_owned_string_array_t : z_string_array_move, \
         z_owned_string_t : z_string_move, \
         z_owned_subscriber_t : z_subscriber_move, \
         z_owned_task_t : z_task_move, \
-        zc_owned_closure_log_t : zc_closure_log_move, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_move, \
-        zc_owned_liveliness_token_t : zc_liveliness_token_move, \
-        zc_owned_matching_listener_t : zc_publisher_matching_listener_move, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_move, \
-        ze_owned_publication_cache_t : ze_publication_cache_move, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_move \
+        zc_owned_closure_log_t : zc_closure_log_move \
     )(&this_)
 
 #define z_null(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t* : z_alloc_layout_null, \
         z_owned_bytes_t* : z_bytes_null, \
-        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_null, \
         z_owned_closure_hello_t* : z_closure_hello_null, \
         z_owned_closure_query_t* : z_closure_query_null, \
         z_owned_closure_reply_t* : z_closure_reply_null, \
         z_owned_closure_sample_t* : z_closure_sample_null, \
-        z_owned_closure_zid_t* : z_closure_zid_null, \
         z_owned_condvar_t* : z_condvar_null, \
         z_owned_config_t* : z_config_null, \
         z_owned_encoding_t* : z_encoding_null, \
@@ -232,7 +165,6 @@ static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_own
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_null, \
         z_owned_hello_t* : z_hello_null, \
         z_owned_keyexpr_t* : z_keyexpr_null, \
-        z_owned_memory_layout_t* : z_memory_layout_null, \
         z_owned_mutex_t* : z_mutex_null, \
         z_owned_publisher_t* : z_publisher_null, \
         z_owned_query_t* : z_query_null, \
@@ -244,34 +176,19 @@ static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_own
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_null, \
         z_owned_sample_t* : z_sample_null, \
         z_owned_session_t* : z_session_null, \
-        z_owned_shm_client_t* : z_shm_client_null, \
-        z_owned_shm_client_storage_t* : z_shm_client_storage_null, \
-        z_owned_shm_mut_t* : z_shm_mut_null, \
-        z_owned_shm_t* : z_shm_null, \
-        z_owned_shm_provider_t* : z_shm_provider_null, \
         z_owned_slice_t* : z_slice_null, \
-        z_owned_source_info_t* : z_source_info_null, \
         z_owned_string_array_t* : z_string_array_null, \
         z_owned_string_t* : z_string_null, \
         z_owned_subscriber_t* : z_subscriber_null, \
         z_owned_task_t* : z_task_null, \
-        zc_owned_closure_log_t* : zc_closure_log_null, \
-        zc_owned_closure_matching_status_t* : zc_closure_matching_status_null, \
-        zc_owned_liveliness_token_t* : zc_liveliness_token_null, \
-        zc_owned_matching_listener_t* : zc_matching_listener_null, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_null, \
-        ze_owned_publication_cache_t* : ze_publication_cache_null, \
-        ze_owned_querying_subscriber_t* : ze_querying_subscriber_null \
+        zc_owned_closure_log_t* : zc_closure_log_null \
     )(this_)
 
-static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) { *this_ = x->_this; z_alloc_layout_null(&x->_this); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *this_ = x->_this; z_bytes_null(&x->_this); }
-static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) { *this_ = x->_this; z_chunk_alloc_result_null(&x->_this); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_closure_hello_null(&x->_this); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_closure_query_null(&x->_this); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_closure_reply_null(&x->_this); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_closure_sample_null(&x->_this); }
-static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) { *closure_ = x->_this; z_closure_zid_null(&x->_this); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) { *this_ = x->_this; z_condvar_null(&x->_this); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t* x) { *this_ = x->_this; z_config_null(&x->_this); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t* x) { *this_ = x->_this; z_encoding_null(&x->_this); }
@@ -280,7 +197,6 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t* x) { *this_ = x->_this; z_fifo_handler_sample_null(&x->_this); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_hello_null(&x->_this); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_keyexpr_null(&x->_this); }
-static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) { *this_ = x->_this; z_memory_layout_null(&x->_this); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_mutex_null(&x->_this); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_publisher_null(&x->_this); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t* x) { *this_ = x->_this; z_query_null(&x->_this); }
@@ -292,36 +208,21 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t* x) { *this_ = x->_this; z_ring_handler_sample_null(&x->_this); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t* x) { *this_ = x->_this; z_sample_null(&x->_this); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t* x) { *this_ = x->_this; z_session_null(&x->_this); }
-static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) { *this_ = x->_this; z_shm_client_null(&x->_this); }
-static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) { *this_ = x->_this; z_shm_client_storage_null(&x->_this); }
-static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t* x) { *this_ = x->_this; z_shm_null(&x->_this); }
-static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) { *this_ = x->_this; z_shm_mut_null(&x->_this); }
-static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) { *this_ = x->_this; z_shm_provider_null(&x->_this); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t* x) { *this_ = x->_this; z_slice_null(&x->_this); }
-static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) { *this_ = x->_this; z_source_info_null(&x->_this); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) { *this_ = x->_this; z_string_array_null(&x->_this); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) { *this_ = x->_this; z_string_null(&x->_this); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_subscriber_null(&x->_this); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_task_null(&x->_this); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_closure_log_null(&x->_this); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) { *closure_ = x->_this; zc_closure_matching_status_null(&x->_this); }
-static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) { *this_ = x->_this; zc_liveliness_token_null(&x->_this); }
-static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) { *this_ = x->_this; zc_matching_listener_null(&x->_this); }
-static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) { *this_ = x->_this; zc_shm_client_list_null(&x->_this); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) { *this_ = x->_this; ze_publication_cache_null(&x->_this); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) { *this_ = x->_this; ze_querying_subscriber_null(&x->_this); }
 
 
 #define z_take(this_, x) \
     _Generic((this_), \
-        z_owned_alloc_layout_t* : z_alloc_layout_take, \
         z_owned_bytes_t* : z_bytes_take, \
-        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_take, \
         z_owned_closure_hello_t* : z_closure_hello_take, \
         z_owned_closure_query_t* : z_closure_query_take, \
         z_owned_closure_reply_t* : z_closure_reply_take, \
         z_owned_closure_sample_t* : z_closure_sample_take, \
-        z_owned_closure_zid_t* : z_closure_zid_take, \
         z_owned_condvar_t* : z_condvar_take, \
         z_owned_config_t* : z_config_take, \
         z_owned_encoding_t* : z_encoding_take, \
@@ -330,7 +231,6 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_take, \
         z_owned_hello_t* : z_hello_take, \
         z_owned_keyexpr_t* : z_keyexpr_take, \
-        z_owned_memory_layout_t* : z_memory_layout_take, \
         z_owned_mutex_t* : z_mutex_take, \
         z_owned_publisher_t* : z_publisher_take, \
         z_owned_query_t* : z_query_take, \
@@ -342,36 +242,21 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_take, \
         z_owned_sample_t* : z_sample_take, \
         z_owned_session_t* : z_session_take, \
-        z_owned_shm_client_t* : z_shm_client_take, \
-        z_owned_shm_client_storage_t* : z_shm_client_storage_take, \
-        z_owned_shm_t* : z_shm_take, \
-        z_owned_shm_mut_t* : z_shm_mut_take, \
-        z_owned_shm_provider_t* : z_shm_provider_take, \
         z_owned_slice_t* : z_slice_take, \
-        z_owned_source_info_t* : z_source_info_take, \
         z_owned_string_array_t* : z_string_array_take, \
         z_owned_string_t* : z_string_take, \
         z_owned_subscriber_t* : z_subscriber_take, \
         z_owned_task_t* : z_task_take, \
-        zc_owned_closure_log_t* : zc_closure_log_take, \
-        zc_owned_closure_matching_status_t* : zc_closure_matching_status_take, \
-        zc_owned_liveliness_token_t* : zc_liveliness_token_take, \
-        zc_owned_matching_listener_t* : zc_publisher_matching_listener_take, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_take, \
-        ze_owned_publication_cache_t* : ze_publication_cache_take, \
-        ze_owned_querying_subscriber_t* : ze_querying_subscriber_take \
+        zc_owned_closure_log_t* : zc_closure_log_take \
     )(this_, x)
 
 #define z_check(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_alloc_layout_check, \
         z_owned_bytes_t : z_bytes_check, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_check, \
         z_owned_closure_hello_t : z_closure_hello_check, \
         z_owned_closure_query_t : z_closure_query_check, \
         z_owned_closure_reply_t : z_closure_reply_check, \
         z_owned_closure_sample_t : z_closure_sample_check, \
-        z_owned_closure_zid_t : z_closure_zid_check, \
         z_owned_condvar_t : z_condvar_check, \
         z_owned_config_t : z_config_check, \
         z_owned_encoding_t : z_encoding_check, \
@@ -380,7 +265,6 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_check, \
         z_owned_hello_t : z_hello_check, \
         z_owned_keyexpr_t : z_keyexpr_check, \
-        z_owned_memory_layout_t : z_memory_layout_check, \
         z_owned_mutex_t : z_mutex_check, \
         z_owned_publisher_t : z_publisher_check, \
         z_owned_query_t : z_query_check, \
@@ -392,24 +276,12 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         z_owned_ring_handler_sample_t : z_ring_handler_sample_check, \
         z_owned_sample_t : z_sample_check, \
         z_owned_session_t : z_session_check, \
-        z_owned_shm_t : z_shm_check, \
-        z_owned_shm_client_t : z_shm_client_check, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_check, \
-        z_owned_shm_mut_t : z_shm_mut_check, \
-        z_owned_shm_provider_t : z_shm_provider_check, \
         z_owned_slice_t : z_slice_check, \
-        z_owned_source_info_t : z_source_info_check, \
         z_owned_string_array_t : z_string_array_check, \
         z_owned_string_t : z_string_check, \
         z_owned_subscriber_t : z_subscriber_check, \
         z_owned_task_t : z_task_check, \
-        zc_owned_closure_log_t : zc_closure_log_check, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_check, \
-        zc_owned_liveliness_token_t : zc_liveliness_token_check, \
-        zc_owned_matching_listener_t : zc_matching_listener_check, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_check, \
-        ze_owned_publication_cache_t : ze_publication_cache_check, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_check \
+        zc_owned_closure_log_t : zc_closure_log_check \
     )(&this_)
 
 #define z_call(closure, hello) \
@@ -417,9 +289,7 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
         const z_loaned_closure_hello_t* : z_closure_hello_call, \
         const z_loaned_closure_query_t* : z_closure_query_call, \
         const z_loaned_closure_reply_t* : z_closure_reply_call, \
-        const z_loaned_closure_sample_t* : z_closure_sample_call, \
-        const z_loaned_closure_zid_t* : z_closure_zid_call, \
-        const zc_loaned_closure_matching_status_t* : zc_closure_matching_status_call \
+        const z_loaned_closure_sample_t* : z_closure_sample_call \
     )(closure, hello)
 
 #define z_closure(x, callback, dropper, ctx) \
@@ -447,14 +317,11 @@ static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* t
 #else  // #ifndef __cplusplus
 
 
-static inline z_moved_alloc_layout_t* z_alloc_layout_move(z_owned_alloc_layout_t* x) { return reinterpret_cast<z_moved_alloc_layout_t*>(x); }
 static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return reinterpret_cast<z_moved_bytes_t*>(x); }
-static inline z_moved_chunk_alloc_result_t* z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return reinterpret_cast<z_moved_chunk_alloc_result_t*>(x); }
 static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return reinterpret_cast<z_moved_closure_hello_t*>(x); }
 static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return reinterpret_cast<z_moved_closure_query_t*>(x); }
 static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return reinterpret_cast<z_moved_closure_reply_t*>(x); }
 static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return reinterpret_cast<z_moved_closure_sample_t*>(x); }
-static inline z_moved_closure_zid_t* z_closure_zid_move(z_owned_closure_zid_t* x) { return reinterpret_cast<z_moved_closure_zid_t*>(x); }
 static inline z_moved_condvar_t* z_condvar_move(z_owned_condvar_t* x) { return reinterpret_cast<z_moved_condvar_t*>(x); }
 static inline z_moved_config_t* z_config_move(z_owned_config_t* x) { return reinterpret_cast<z_moved_config_t*>(x); }
 static inline z_moved_encoding_t* z_encoding_move(z_owned_encoding_t* x) { return reinterpret_cast<z_moved_encoding_t*>(x); }
@@ -463,7 +330,6 @@ static inline z_moved_fifo_handler_reply_t* z_fifo_handler_reply_move(z_owned_fi
 static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return reinterpret_cast<z_moved_fifo_handler_sample_t*>(x); }
 static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return reinterpret_cast<z_moved_hello_t*>(x); }
 static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return reinterpret_cast<z_moved_keyexpr_t*>(x); }
-static inline z_moved_memory_layout_t* z_memory_layout_move(z_owned_memory_layout_t* x) { return reinterpret_cast<z_moved_memory_layout_t*>(x); }
 static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return reinterpret_cast<z_moved_mutex_t*>(x); }
 static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return reinterpret_cast<z_moved_publisher_t*>(x); }
 static inline z_moved_query_t* z_query_move(z_owned_query_t* x) { return reinterpret_cast<z_moved_query_t*>(x); }
@@ -475,35 +341,20 @@ static inline z_moved_ring_handler_reply_t* z_ring_handler_reply_move(z_owned_ri
 static inline z_moved_ring_handler_sample_t* z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return reinterpret_cast<z_moved_ring_handler_sample_t*>(x); }
 static inline z_moved_sample_t* z_sample_move(z_owned_sample_t* x) { return reinterpret_cast<z_moved_sample_t*>(x); }
 static inline z_moved_session_t* z_session_move(z_owned_session_t* x) { return reinterpret_cast<z_moved_session_t*>(x); }
-static inline z_moved_shm_client_t* z_shm_client_move(z_owned_shm_client_t* x) { return reinterpret_cast<z_moved_shm_client_t*>(x); }
-static inline z_moved_shm_client_storage_t* z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return reinterpret_cast<z_moved_shm_client_storage_t*>(x); }
-static inline z_moved_shm_t* z_shm_move(z_owned_shm_t* x) { return reinterpret_cast<z_moved_shm_t*>(x); }
-static inline z_moved_shm_mut_t* z_shm_mut_move(z_owned_shm_mut_t* x) { return reinterpret_cast<z_moved_shm_mut_t*>(x); }
-static inline z_moved_shm_provider_t* z_shm_provider_move(z_owned_shm_provider_t* x) { return reinterpret_cast<z_moved_shm_provider_t*>(x); }
 static inline z_moved_slice_t* z_slice_move(z_owned_slice_t* x) { return reinterpret_cast<z_moved_slice_t*>(x); }
-static inline z_moved_source_info_t* z_source_info_move(z_owned_source_info_t* x) { return reinterpret_cast<z_moved_source_info_t*>(x); }
 static inline z_moved_string_array_t* z_string_array_move(z_owned_string_array_t* x) { return reinterpret_cast<z_moved_string_array_t*>(x); }
 static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return reinterpret_cast<z_moved_string_t*>(x); }
 static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return reinterpret_cast<z_moved_subscriber_t*>(x); }
 static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return reinterpret_cast<z_moved_task_t*>(x); }
 static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return reinterpret_cast<zc_moved_closure_log_t*>(x); }
-static inline zc_moved_closure_matching_status_t* zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return reinterpret_cast<zc_moved_closure_matching_status_t*>(x); }
-static inline zc_moved_liveliness_token_t* zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return reinterpret_cast<zc_moved_liveliness_token_t*>(x); }
-static inline zc_moved_matching_listener_t* zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return reinterpret_cast<zc_moved_matching_listener_t*>(x); }
-static inline zc_moved_shm_client_list_t* zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return reinterpret_cast<zc_moved_shm_client_list_t*>(x); }
-static inline ze_moved_publication_cache_t* ze_publication_cache_move(ze_owned_publication_cache_t* x) { return reinterpret_cast<ze_moved_publication_cache_t*>(x); }
-static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return reinterpret_cast<ze_moved_querying_subscriber_t*>(x); }
 
 
 
-inline const z_loaned_alloc_layout_t* z_loan(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_loan(&this_); };
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& this_) { return z_bytes_loan(&this_); };
-inline const z_loaned_chunk_alloc_result_t* z_loan(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_loan(&this_); };
 inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t& closure) { return z_closure_hello_loan(&closure); };
 inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t& closure) { return z_closure_query_loan(&closure); };
 inline const z_loaned_closure_reply_t* z_loan(const z_owned_closure_reply_t& closure) { return z_closure_reply_loan(&closure); };
 inline const z_loaned_closure_sample_t* z_loan(const z_owned_closure_sample_t& closure) { return z_closure_sample_loan(&closure); };
-inline const z_loaned_closure_zid_t* z_loan(const z_owned_closure_zid_t& closure) { return z_closure_zid_loan(&closure); };
 inline const z_loaned_condvar_t* z_loan(const z_owned_condvar_t& this_) { return z_condvar_loan(&this_); };
 inline const z_loaned_config_t* z_loan(const z_owned_config_t& this_) { return z_config_loan(&this_); };
 inline const z_loaned_encoding_t* z_loan(const z_owned_encoding_t& this_) { return z_encoding_loan(&this_); };
@@ -512,7 +363,6 @@ inline const z_loaned_fifo_handler_reply_t* z_loan(const z_owned_fifo_handler_re
 inline const z_loaned_fifo_handler_sample_t* z_loan(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_loan(&this_); };
 inline const z_loaned_hello_t* z_loan(const z_owned_hello_t& this_) { return z_hello_loan(&this_); };
 inline const z_loaned_keyexpr_t* z_loan(const z_owned_keyexpr_t& this_) { return z_keyexpr_loan(&this_); };
-inline const z_loaned_memory_layout_t* z_loan(const z_owned_memory_layout_t& this_) { return z_memory_layout_loan(&this_); };
 inline const z_loaned_publisher_t* z_loan(const z_owned_publisher_t& this_) { return z_publisher_loan(&this_); };
 inline const z_loaned_query_t* z_loan(const z_owned_query_t& this_) { return z_query_loan(&this_); };
 inline const z_loaned_queryable_t* z_loan(const z_owned_queryable_t& this_) { return z_queryable_loan(&this_); };
@@ -523,12 +373,7 @@ inline const z_loaned_ring_handler_reply_t* z_loan(const z_owned_ring_handler_re
 inline const z_loaned_ring_handler_sample_t* z_loan(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_loan(&this_); };
 inline const z_loaned_sample_t* z_loan(const z_owned_sample_t& this_) { return z_sample_loan(&this_); };
 inline const z_loaned_session_t* z_loan(const z_owned_session_t& this_) { return z_session_loan(&this_); };
-inline const z_loaned_shm_client_storage_t* z_loan(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_loan(&this_); };
-inline const z_loaned_shm_t* z_loan(const z_owned_shm_t& this_) { return z_shm_loan(&this_); };
-inline const z_loaned_shm_mut_t* z_loan(const z_owned_shm_mut_t& this_) { return z_shm_mut_loan(&this_); };
-inline const z_loaned_shm_provider_t* z_loan(const z_owned_shm_provider_t& this_) { return z_shm_provider_loan(&this_); };
 inline const z_loaned_slice_t* z_loan(const z_owned_slice_t& this_) { return z_slice_loan(&this_); };
-inline const z_loaned_source_info_t* z_loan(const z_owned_source_info_t& this_) { return z_source_info_loan(&this_); };
 inline const z_loaned_string_array_t* z_loan(const z_owned_string_array_t& this_) { return z_string_array_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_owned_string_t& this_) { return z_string_loan(&this_); };
 inline const z_loaned_subscriber_t* z_loan(const z_owned_subscriber_t& this_) { return z_subscriber_loan(&this_); };
@@ -536,10 +381,6 @@ inline const z_loaned_keyexpr_t* z_loan(const z_view_keyexpr_t& this_) { return 
 inline const z_loaned_slice_t* z_loan(const z_view_slice_t& this_) { return z_view_slice_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_view_string_t& this_) { return z_view_string_loan(&this_); };
 inline const zc_loaned_closure_log_t* z_loan(const zc_owned_closure_log_t& closure) { return zc_closure_log_loan(&closure); };
-inline const zc_loaned_closure_matching_status_t* z_loan(const zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_loan(&closure); };
-inline const zc_loaned_liveliness_token_t* z_loan(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_loan(&this_); };
-inline const zc_loaned_shm_client_list_t* z_loan(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan(&this_); };
-inline const ze_loaned_querying_subscriber_t* z_loan(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_loan(&this_); };
 
 
 inline z_loaned_bytes_t* z_loan_mut(z_owned_bytes_t& this_) { return z_bytes_loan_mut(&this_); };
@@ -548,20 +389,14 @@ inline z_loaned_config_t* z_loan_mut(z_owned_config_t& this_) { return z_config_
 inline z_loaned_encoding_t* z_loan_mut(z_owned_encoding_t& this_) { return z_encoding_loan_mut(&this_); };
 inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t& this_) { return z_mutex_loan_mut(&this_); };
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& this_) { return z_publisher_loan_mut(&this_); };
-inline z_loaned_shm_t* z_loan_mut(z_owned_shm_t& this_) { return z_shm_loan_mut(&this_); };
-inline z_loaned_shm_mut_t* z_loan_mut(z_owned_shm_mut_t& this_) { return z_shm_mut_loan_mut(&this_); };
 inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { return z_string_array_loan_mut(&this_); };
-inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan_mut(&this_); };
 
 
-inline void z_drop(z_moved_alloc_layout_t* this_) { z_alloc_layout_drop(this_); };
 inline void z_drop(z_moved_bytes_t* this_) { z_bytes_drop(this_); };
-inline void z_drop(z_moved_chunk_alloc_result_t* this_) { z_chunk_alloc_result_drop(this_); };
 inline void z_drop(z_moved_closure_hello_t* this_) { z_closure_hello_drop(this_); };
 inline void z_drop(z_moved_closure_query_t* closure_) { z_closure_query_drop(closure_); };
 inline void z_drop(z_moved_closure_reply_t* closure_) { z_closure_reply_drop(closure_); };
 inline void z_drop(z_moved_closure_sample_t* closure_) { z_closure_sample_drop(closure_); };
-inline void z_drop(z_moved_closure_zid_t* closure_) { z_closure_zid_drop(closure_); };
 inline void z_drop(z_moved_condvar_t* this_) { z_condvar_drop(this_); };
 inline void z_drop(z_moved_config_t* this_) { z_config_drop(this_); };
 inline void z_drop(z_moved_encoding_t* this_) { z_encoding_drop(this_); };
@@ -570,7 +405,6 @@ inline void z_drop(z_moved_fifo_handler_reply_t* this_) { z_fifo_handler_reply_d
 inline void z_drop(z_moved_fifo_handler_sample_t* this_) { z_fifo_handler_sample_drop(this_); };
 inline void z_drop(z_moved_hello_t* this_) { z_hello_drop(this_); };
 inline void z_drop(z_moved_keyexpr_t* this_) { z_keyexpr_drop(this_); };
-inline void z_drop(z_moved_memory_layout_t* this_) { z_memory_layout_drop(this_); };
 inline void z_drop(z_moved_mutex_t* this_) { z_mutex_drop(this_); };
 inline void z_drop(z_moved_publisher_t* this_) { z_publisher_drop(this_); };
 inline void z_drop(z_moved_query_t* this_) { z_query_drop(this_); };
@@ -582,34 +416,19 @@ inline void z_drop(z_moved_ring_handler_reply_t* this_) { z_ring_handler_reply_d
 inline void z_drop(z_moved_ring_handler_sample_t* this_) { z_ring_handler_sample_drop(this_); };
 inline void z_drop(z_moved_sample_t* this_) { z_sample_drop(this_); };
 inline void z_drop(z_moved_session_t* this_) { z_session_drop(this_); };
-inline void z_drop(z_moved_shm_client_t* this_) { z_shm_client_drop(this_); };
-inline void z_drop(z_moved_shm_client_storage_t* this_) { z_shm_client_storage_drop(this_); };
-inline void z_drop(z_moved_shm_t* this_) { z_shm_drop(this_); };
-inline void z_drop(z_moved_shm_mut_t* this_) { z_shm_mut_drop(this_); };
-inline void z_drop(z_moved_shm_provider_t* this_) { z_shm_provider_drop(this_); };
 inline void z_drop(z_moved_slice_t* this_) { z_slice_drop(this_); };
-inline void z_drop(z_moved_source_info_t* this_) { z_source_info_drop(this_); };
 inline void z_drop(z_moved_string_array_t* this_) { z_string_array_drop(this_); };
 inline void z_drop(z_moved_string_t* this_) { z_string_drop(this_); };
 inline void z_drop(z_moved_subscriber_t* this_) { z_subscriber_drop(this_); };
 inline void z_drop(z_moved_task_t* this_) { z_task_drop(this_); };
 inline void z_drop(zc_moved_closure_log_t* closure_) { zc_closure_log_drop(closure_); };
-inline void z_drop(zc_moved_closure_matching_status_t* closure_) { zc_closure_matching_status_drop(closure_); };
-inline void z_drop(zc_moved_liveliness_token_t* this_) { zc_liveliness_token_drop(this_); };
-inline z_result_t z_drop(zc_moved_matching_listener_t* this_) { return zc_publisher_matching_listener_drop(this_); };
-inline void z_drop(zc_moved_shm_client_list_t* this_) { zc_shm_client_list_drop(this_); };
-inline void z_drop(ze_moved_publication_cache_t* this_) { ze_publication_cache_drop(this_); };
-inline void z_drop(ze_moved_querying_subscriber_t* this_) { ze_querying_subscriber_drop(this_); };
 
 
-inline z_moved_alloc_layout_t* z_move(z_owned_alloc_layout_t& this_) { return z_alloc_layout_move(&this_); };
 inline z_moved_bytes_t* z_move(z_owned_bytes_t& this_) { return z_bytes_move(&this_); };
-inline z_moved_chunk_alloc_result_t* z_move(z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_move(&this_); };
 inline z_moved_closure_hello_t* z_move(z_owned_closure_hello_t& this_) { return z_closure_hello_move(&this_); };
 inline z_moved_closure_query_t* z_move(z_owned_closure_query_t& closure_) { return z_closure_query_move(&closure_); };
 inline z_moved_closure_reply_t* z_move(z_owned_closure_reply_t& closure_) { return z_closure_reply_move(&closure_); };
 inline z_moved_closure_sample_t* z_move(z_owned_closure_sample_t& closure_) { return z_closure_sample_move(&closure_); };
-inline z_moved_closure_zid_t* z_move(z_owned_closure_zid_t& closure_) { return z_closure_zid_move(&closure_); };
 inline z_moved_condvar_t* z_move(z_owned_condvar_t& this_) { return z_condvar_move(&this_); };
 inline z_moved_config_t* z_move(z_owned_config_t& this_) { return z_config_move(&this_); };
 inline z_moved_encoding_t* z_move(z_owned_encoding_t& this_) { return z_encoding_move(&this_); };
@@ -618,7 +437,6 @@ inline z_moved_fifo_handler_reply_t* z_move(z_owned_fifo_handler_reply_t& this_)
 inline z_moved_fifo_handler_sample_t* z_move(z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_move(&this_); };
 inline z_moved_hello_t* z_move(z_owned_hello_t& this_) { return z_hello_move(&this_); };
 inline z_moved_keyexpr_t* z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
-inline z_moved_memory_layout_t* z_move(z_owned_memory_layout_t& this_) { return z_memory_layout_move(&this_); };
 inline z_moved_mutex_t* z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
 inline z_moved_publisher_t* z_move(z_owned_publisher_t& this_) { return z_publisher_move(&this_); };
 inline z_moved_query_t* z_move(z_owned_query_t& this_) { return z_query_move(&this_); };
@@ -630,34 +448,19 @@ inline z_moved_ring_handler_reply_t* z_move(z_owned_ring_handler_reply_t& this_)
 inline z_moved_ring_handler_sample_t* z_move(z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_move(&this_); };
 inline z_moved_sample_t* z_move(z_owned_sample_t& this_) { return z_sample_move(&this_); };
 inline z_moved_session_t* z_move(z_owned_session_t& this_) { return z_session_move(&this_); };
-inline z_moved_shm_client_t* z_move(z_owned_shm_client_t& this_) { return z_shm_client_move(&this_); };
-inline z_moved_shm_client_storage_t* z_move(z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_move(&this_); };
-inline z_moved_shm_t* z_move(z_owned_shm_t& this_) { return z_shm_move(&this_); };
-inline z_moved_shm_mut_t* z_move(z_owned_shm_mut_t& this_) { return z_shm_mut_move(&this_); };
-inline z_moved_shm_provider_t* z_move(z_owned_shm_provider_t& this_) { return z_shm_provider_move(&this_); };
 inline z_moved_slice_t* z_move(z_owned_slice_t& this_) { return z_slice_move(&this_); };
-inline z_moved_source_info_t* z_move(z_owned_source_info_t& this_) { return z_source_info_move(&this_); };
 inline z_moved_string_array_t* z_move(z_owned_string_array_t& this_) { return z_string_array_move(&this_); };
 inline z_moved_string_t* z_move(z_owned_string_t& this_) { return z_string_move(&this_); };
 inline z_moved_subscriber_t* z_move(z_owned_subscriber_t& this_) { return z_subscriber_move(&this_); };
 inline z_moved_task_t* z_move(z_owned_task_t& this_) { return z_task_move(&this_); };
 inline zc_moved_closure_log_t* z_move(zc_owned_closure_log_t& closure_) { return zc_closure_log_move(&closure_); };
-inline zc_moved_closure_matching_status_t* z_move(zc_owned_closure_matching_status_t& closure_) { return zc_closure_matching_status_move(&closure_); };
-inline zc_moved_liveliness_token_t* z_move(zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_move(&this_); };
-inline zc_moved_matching_listener_t* z_move(zc_owned_matching_listener_t& this_) { return zc_publisher_matching_listener_move(&this_); };
-inline zc_moved_shm_client_list_t* z_move(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_move(&this_); };
-inline ze_moved_publication_cache_t* z_move(ze_owned_publication_cache_t& this_) { return ze_publication_cache_move(&this_); };
-inline ze_moved_querying_subscriber_t* z_move(ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_move(&this_); };
 
 
-inline void z_null(z_owned_alloc_layout_t* this_) { z_alloc_layout_null(this_); };
 inline void z_null(z_owned_bytes_t* this_) { z_bytes_null(this_); };
-inline void z_null(z_owned_chunk_alloc_result_t* this_) { z_chunk_alloc_result_null(this_); };
 inline void z_null(z_owned_closure_hello_t* this_) { z_closure_hello_null(this_); };
 inline void z_null(z_owned_closure_query_t* this_) { z_closure_query_null(this_); };
 inline void z_null(z_owned_closure_reply_t* this_) { z_closure_reply_null(this_); };
 inline void z_null(z_owned_closure_sample_t* this_) { z_closure_sample_null(this_); };
-inline void z_null(z_owned_closure_zid_t* this_) { z_closure_zid_null(this_); };
 inline void z_null(z_owned_condvar_t* this_) { z_condvar_null(this_); };
 inline void z_null(z_owned_config_t* this_) { z_config_null(this_); };
 inline void z_null(z_owned_encoding_t* this_) { z_encoding_null(this_); };
@@ -666,7 +469,6 @@ inline void z_null(z_owned_fifo_handler_reply_t* this_) { z_fifo_handler_reply_n
 inline void z_null(z_owned_fifo_handler_sample_t* this_) { z_fifo_handler_sample_null(this_); };
 inline void z_null(z_owned_hello_t* this_) { z_hello_null(this_); };
 inline void z_null(z_owned_keyexpr_t* this_) { z_keyexpr_null(this_); };
-inline void z_null(z_owned_memory_layout_t* this_) { z_memory_layout_null(this_); };
 inline void z_null(z_owned_mutex_t* this_) { z_mutex_null(this_); };
 inline void z_null(z_owned_publisher_t* this_) { z_publisher_null(this_); };
 inline void z_null(z_owned_query_t* this_) { z_query_null(this_); };
@@ -678,33 +480,18 @@ inline void z_null(z_owned_ring_handler_reply_t* this_) { z_ring_handler_reply_n
 inline void z_null(z_owned_ring_handler_sample_t* this_) { z_ring_handler_sample_null(this_); };
 inline void z_null(z_owned_sample_t* this_) { z_sample_null(this_); };
 inline void z_null(z_owned_session_t* this_) { z_session_null(this_); };
-inline void z_null(z_owned_shm_client_t* this_) { z_shm_client_null(this_); };
-inline void z_null(z_owned_shm_client_storage_t* this_) { z_shm_client_storage_null(this_); };
-inline void z_null(z_owned_shm_mut_t* this_) { z_shm_mut_null(this_); };
-inline void z_null(z_owned_shm_t* this_) { z_shm_null(this_); };
-inline void z_null(z_owned_shm_provider_t* this_) { z_shm_provider_null(this_); };
 inline void z_null(z_owned_slice_t* this_) { z_slice_null(this_); };
-inline void z_null(z_owned_source_info_t* this_) { z_source_info_null(this_); };
 inline void z_null(z_owned_string_array_t* this_) { z_string_array_null(this_); };
 inline void z_null(z_owned_string_t* this_) { z_string_null(this_); };
 inline void z_null(z_owned_subscriber_t* this_) { z_subscriber_null(this_); };
 inline void z_null(z_owned_task_t* this_) { z_task_null(this_); };
 inline void z_null(zc_owned_closure_log_t* this_) { zc_closure_log_null(this_); };
-inline void z_null(zc_owned_closure_matching_status_t* this_) { zc_closure_matching_status_null(this_); };
-inline void z_null(zc_owned_liveliness_token_t* this_) { zc_liveliness_token_null(this_); };
-inline void z_null(zc_owned_matching_listener_t* this_) { zc_matching_listener_null(this_); };
-inline void z_null(zc_owned_shm_client_list_t* this_) { zc_shm_client_list_null(this_); };
-inline void z_null(ze_owned_publication_cache_t* this_) { ze_publication_cache_null(this_); };
-inline void z_null(ze_owned_querying_subscriber_t* this_) { ze_querying_subscriber_null(this_); };
 
-static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) { *this_ = x->_this; z_alloc_layout_null(&x->_this); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *this_ = x->_this; z_bytes_null(&x->_this); }
-static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) { *this_ = x->_this; z_chunk_alloc_result_null(&x->_this); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_closure_hello_null(&x->_this); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_closure_query_null(&x->_this); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_closure_reply_null(&x->_this); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_closure_sample_null(&x->_this); }
-static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) { *closure_ = x->_this; z_closure_zid_null(&x->_this); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) { *this_ = x->_this; z_condvar_null(&x->_this); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t* x) { *this_ = x->_this; z_config_null(&x->_this); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t* x) { *this_ = x->_this; z_encoding_null(&x->_this); }
@@ -713,7 +500,6 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t* x) { *this_ = x->_this; z_fifo_handler_sample_null(&x->_this); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_hello_null(&x->_this); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_keyexpr_null(&x->_this); }
-static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) { *this_ = x->_this; z_memory_layout_null(&x->_this); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_mutex_null(&x->_this); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_publisher_null(&x->_this); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t* x) { *this_ = x->_this; z_query_null(&x->_this); }
@@ -725,35 +511,17 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t* x) { *this_ = x->_this; z_ring_handler_sample_null(&x->_this); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t* x) { *this_ = x->_this; z_sample_null(&x->_this); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t* x) { *this_ = x->_this; z_session_null(&x->_this); }
-static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) { *this_ = x->_this; z_shm_client_null(&x->_this); }
-static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) { *this_ = x->_this; z_shm_client_storage_null(&x->_this); }
-static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t* x) { *this_ = x->_this; z_shm_null(&x->_this); }
-static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) { *this_ = x->_this; z_shm_mut_null(&x->_this); }
-static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) { *this_ = x->_this; z_shm_provider_null(&x->_this); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t* x) { *this_ = x->_this; z_slice_null(&x->_this); }
-static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) { *this_ = x->_this; z_source_info_null(&x->_this); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) { *this_ = x->_this; z_string_array_null(&x->_this); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) { *this_ = x->_this; z_string_null(&x->_this); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_subscriber_null(&x->_this); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_task_null(&x->_this); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_closure_log_null(&x->_this); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) { *closure_ = x->_this; zc_closure_matching_status_null(&x->_this); }
-static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) { *this_ = x->_this; zc_liveliness_token_null(&x->_this); }
-static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) { *this_ = x->_this; zc_matching_listener_null(&x->_this); }
-static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) { *this_ = x->_this; zc_shm_client_list_null(&x->_this); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) { *this_ = x->_this; ze_publication_cache_null(&x->_this); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) { *this_ = x->_this; ze_querying_subscriber_null(&x->_this); }
 
 
 
-inline void z_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) {
-    z_alloc_layout_take(this_, x);
-};
 inline void z_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) {
     z_bytes_take(this_, x);
-};
-inline void z_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) {
-    z_chunk_alloc_result_take(this_, x);
 };
 inline void z_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) {
     z_closure_hello_take(this_, x);
@@ -766,9 +534,6 @@ inline void z_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x
 };
 inline void z_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) {
     z_closure_sample_take(closure_, x);
-};
-inline void z_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) {
-    z_closure_zid_take(closure_, x);
 };
 inline void z_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) {
     z_condvar_take(this_, x);
@@ -793,9 +558,6 @@ inline void z_take(z_owned_hello_t* this_, z_moved_hello_t* x) {
 };
 inline void z_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) {
     z_keyexpr_take(this_, x);
-};
-inline void z_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) {
-    z_memory_layout_take(this_, x);
 };
 inline void z_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) {
     z_mutex_take(this_, x);
@@ -830,26 +592,8 @@ inline void z_take(z_owned_sample_t* this_, z_moved_sample_t* x) {
 inline void z_take(z_owned_session_t* this_, z_moved_session_t* x) {
     z_session_take(this_, x);
 };
-inline void z_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) {
-    z_shm_client_take(this_, x);
-};
-inline void z_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) {
-    z_shm_client_storage_take(this_, x);
-};
-inline void z_take(z_owned_shm_t* this_, z_moved_shm_t* x) {
-    z_shm_take(this_, x);
-};
-inline void z_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) {
-    z_shm_mut_take(this_, x);
-};
-inline void z_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) {
-    z_shm_provider_take(this_, x);
-};
 inline void z_take(z_owned_slice_t* this_, z_moved_slice_t* x) {
     z_slice_take(this_, x);
-};
-inline void z_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) {
-    z_source_info_take(this_, x);
 };
 inline void z_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) {
     z_string_array_take(this_, x);
@@ -866,34 +610,13 @@ inline void z_take(z_owned_task_t* this_, z_moved_task_t* x) {
 inline void z_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) {
     zc_closure_log_take(closure_, x);
 };
-inline void z_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) {
-    zc_closure_matching_status_take(closure_, x);
-};
-inline void z_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) {
-    zc_liveliness_token_take(this_, x);
-};
-inline void z_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) {
-    zc_publisher_matching_listener_take(this_, x);
-};
-inline void z_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) {
-    zc_shm_client_list_take(this_, x);
-};
-inline void z_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) {
-    ze_publication_cache_take(this_, x);
-};
-inline void z_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) {
-    ze_querying_subscriber_take(this_, x);
-};
 
 
-inline bool z_check(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_check(&this_); };
 inline bool z_check(const z_owned_bytes_t& this_) { return z_bytes_check(&this_); };
-inline bool z_check(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_check(&this_); };
 inline bool z_check(const z_owned_closure_hello_t& this_) { return z_closure_hello_check(&this_); };
 inline bool z_check(const z_owned_closure_query_t& this_) { return z_closure_query_check(&this_); };
 inline bool z_check(const z_owned_closure_reply_t& this_) { return z_closure_reply_check(&this_); };
 inline bool z_check(const z_owned_closure_sample_t& this_) { return z_closure_sample_check(&this_); };
-inline bool z_check(const z_owned_closure_zid_t& this_) { return z_closure_zid_check(&this_); };
 inline bool z_check(const z_owned_condvar_t& this_) { return z_condvar_check(&this_); };
 inline bool z_check(const z_owned_config_t& this_) { return z_config_check(&this_); };
 inline bool z_check(const z_owned_encoding_t& this_) { return z_encoding_check(&this_); };
@@ -902,7 +625,6 @@ inline bool z_check(const z_owned_fifo_handler_reply_t& this_) { return z_fifo_h
 inline bool z_check(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_hello_t& this_) { return z_hello_check(&this_); };
 inline bool z_check(const z_owned_keyexpr_t& this_) { return z_keyexpr_check(&this_); };
-inline bool z_check(const z_owned_memory_layout_t& this_) { return z_memory_layout_check(&this_); };
 inline bool z_check(const z_owned_mutex_t& this_) { return z_mutex_check(&this_); };
 inline bool z_check(const z_owned_publisher_t& this_) { return z_publisher_check(&this_); };
 inline bool z_check(const z_owned_query_t& query) { return z_query_check(&query); };
@@ -914,24 +636,12 @@ inline bool z_check(const z_owned_ring_handler_reply_t& this_) { return z_ring_h
 inline bool z_check(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_check(&this_); };
 inline bool z_check(const z_owned_sample_t& this_) { return z_sample_check(&this_); };
 inline bool z_check(const z_owned_session_t& this_) { return z_session_check(&this_); };
-inline bool z_check(const z_owned_shm_t& this_) { return z_shm_check(&this_); };
-inline bool z_check(const z_owned_shm_client_t& this_) { return z_shm_client_check(&this_); };
-inline bool z_check(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_check(&this_); };
-inline bool z_check(const z_owned_shm_mut_t& this_) { return z_shm_mut_check(&this_); };
-inline bool z_check(const z_owned_shm_provider_t& this_) { return z_shm_provider_check(&this_); };
 inline bool z_check(const z_owned_slice_t& this_) { return z_slice_check(&this_); };
-inline bool z_check(const z_owned_source_info_t& this_) { return z_source_info_check(&this_); };
 inline bool z_check(const z_owned_string_array_t& this_) { return z_string_array_check(&this_); };
 inline bool z_check(const z_owned_string_t& this_) { return z_string_check(&this_); };
 inline bool z_check(const z_owned_subscriber_t& this_) { return z_subscriber_check(&this_); };
 inline bool z_check(const z_owned_task_t& this_) { return z_task_check(&this_); };
 inline bool z_check(const zc_owned_closure_log_t& this_) { return zc_closure_log_check(&this_); };
-inline bool z_check(const zc_owned_closure_matching_status_t& this_) { return zc_closure_matching_status_check(&this_); };
-inline bool z_check(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_check(&this_); };
-inline bool z_check(const zc_owned_matching_listener_t& this_) { return zc_matching_listener_check(&this_); };
-inline bool z_check(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_check(&this_); };
-inline bool z_check(const ze_owned_publication_cache_t& this_) { return ze_publication_cache_check(&this_); };
-inline bool z_check(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_check(&this_); };
 
 
 inline void z_call(const z_loaned_closure_hello_t* closure, const z_loaned_hello_t* hello) {
@@ -945,12 +655,6 @@ inline void z_call(const z_loaned_closure_reply_t* closure, const z_loaned_reply
 };
 inline void z_call(const z_loaned_closure_sample_t* closure, const z_loaned_sample_t* sample) {
     z_closure_sample_call(closure, sample);
-};
-inline void z_call(const z_loaned_closure_zid_t* closure, const z_id_t* z_id) {
-    z_closure_zid_call(closure, z_id);
-};
-inline void z_call(const zc_loaned_closure_matching_status_t* closure, const zc_matching_status_t* mathing_status) {
-    zc_closure_matching_status_call(closure, mathing_status);
 };
 
 
@@ -984,24 +688,6 @@ inline void z_closure(
 inline void z_closure(
     z_owned_closure_sample_t* closure,
     void (*call)(const z_loaned_sample_t*, void*),
-    void (*drop)(void*),
-    void *context) {
-    closure->context = context;
-    closure->drop = drop;
-    closure->call = call;
-};
-inline void z_closure(
-    z_owned_closure_zid_t* closure,
-    void (*call)(const z_id_t*, void*),
-    void (*drop)(void*),
-    void *context) {
-    closure->context = context;
-    closure->drop = drop;
-    closure->call = call;
-};
-inline void z_closure(
-    zc_owned_closure_matching_status_t* closure,
-    void (*call)(const zc_matching_status_t*, void*),
     void (*drop)(void*),
     void *context) {
     closure->context = context;
@@ -1051,12 +737,8 @@ inline z_result_t z_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sa
 
 template<class T> struct z_loaned_to_owned_type_t {};
 template<class T> struct z_owned_to_loaned_type_t {};
-template<> struct z_loaned_to_owned_type_t<z_loaned_alloc_layout_t> { typedef z_owned_alloc_layout_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_alloc_layout_t> { typedef z_loaned_alloc_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_t> { typedef z_owned_bytes_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_t> { typedef z_loaned_bytes_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_chunk_alloc_result_t> { typedef z_owned_chunk_alloc_result_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_chunk_alloc_result_t> { typedef z_loaned_chunk_alloc_result_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_hello_t> { typedef z_owned_closure_hello_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_hello_t> { typedef z_loaned_closure_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_query_t> { typedef z_owned_closure_query_t type; };
@@ -1065,8 +747,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_closure_reply_t> { typedef z
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_reply_t> { typedef z_loaned_closure_reply_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_sample_t> { typedef z_owned_closure_sample_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_sample_t> { typedef z_loaned_closure_sample_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_closure_zid_t> { typedef z_owned_closure_zid_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_closure_zid_t> { typedef z_loaned_closure_zid_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_condvar_t> { typedef z_owned_condvar_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_condvar_t> { typedef z_loaned_condvar_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_config_t> { typedef z_owned_config_t type; };
@@ -1083,8 +763,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_hello_t> { typedef z_owned_h
 template<> struct z_owned_to_loaned_type_t<z_owned_hello_t> { typedef z_loaned_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_keyexpr_t> { typedef z_owned_keyexpr_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_keyexpr_t> { typedef z_loaned_keyexpr_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_memory_layout_t> { typedef z_owned_memory_layout_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_memory_layout_t> { typedef z_loaned_memory_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_publisher_t> { typedef z_owned_publisher_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_publisher_t> { typedef z_loaned_publisher_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_query_t> { typedef z_owned_query_t type; };
@@ -1105,18 +783,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_sample_t> { typedef z_owned_
 template<> struct z_owned_to_loaned_type_t<z_owned_sample_t> { typedef z_loaned_sample_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_session_t> { typedef z_owned_session_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_session_t> { typedef z_loaned_session_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_client_storage_t> { typedef z_owned_shm_client_storage_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_client_storage_t> { typedef z_loaned_shm_client_storage_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_t> { typedef z_owned_shm_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_t> { typedef z_loaned_shm_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_mut_t> { typedef z_owned_shm_mut_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_mut_t> { typedef z_loaned_shm_mut_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_provider_t> { typedef z_owned_shm_provider_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_provider_t> { typedef z_loaned_shm_provider_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_slice_t> { typedef z_owned_slice_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_slice_t> { typedef z_loaned_slice_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_source_info_t> { typedef z_owned_source_info_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_source_info_t> { typedef z_loaned_source_info_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_array_t> { typedef z_owned_string_array_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_string_array_t> { typedef z_loaned_string_array_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_t> { typedef z_owned_string_t type; };
@@ -1125,14 +793,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_subscriber_t> { typedef z_ow
 template<> struct z_owned_to_loaned_type_t<z_owned_subscriber_t> { typedef z_loaned_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_log_t> { typedef zc_owned_closure_log_t type; };
 template<> struct z_owned_to_loaned_type_t<zc_owned_closure_log_t> { typedef zc_loaned_closure_log_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_matching_status_t> { typedef zc_owned_closure_matching_status_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_closure_matching_status_t> { typedef zc_loaned_closure_matching_status_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_liveliness_token_t> { typedef zc_owned_liveliness_token_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_liveliness_token_t> { typedef zc_loaned_liveliness_token_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_shm_client_list_t> { typedef zc_owned_shm_client_list_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_shm_client_list_t> { typedef zc_loaned_shm_client_list_t type; };
-template<> struct z_loaned_to_owned_type_t<ze_loaned_querying_subscriber_t> { typedef ze_owned_querying_subscriber_t type; };
-template<> struct z_owned_to_loaned_type_t<ze_owned_querying_subscriber_t> { typedef ze_loaned_querying_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_mutex_t> { typedef z_owned_mutex_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_mutex_t> { typedef z_loaned_mutex_t type; };
 #endif  // #ifndef __cplusplus

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -22,6 +22,9 @@ static inline z_moved_hello_t z_hello_move(z_owned_hello_t* x) { return (z_moved
 static inline z_moved_keyexpr_t z_keyexpr_move(z_owned_keyexpr_t* x) { return (z_moved_keyexpr_t){x}; }
 static inline z_moved_memory_layout_t z_memory_layout_move(z_owned_memory_layout_t* x) { return (z_moved_memory_layout_t){x}; }
 static inline z_moved_mutex_t z_mutex_move(z_owned_mutex_t* x) { return (z_moved_mutex_t){x}; }
+static inline z_moved_publisher_t z_publisher_move(z_owned_publisher_t* x) { return (z_moved_publisher_t){x}; }
+static inline z_moved_query_t z_query_move(z_owned_query_t* x) { return (z_moved_query_t){x}; }
+static inline z_moved_queryable_t z_queryable_move(z_owned_queryable_t* x) { return (z_moved_queryable_t){x}; }
 static inline z_moved_reply_t z_reply_move(z_owned_reply_t* x) { return (z_moved_reply_t){x}; }
 static inline z_moved_reply_err_t z_reply_err_move(z_owned_reply_err_t* x) { return (z_moved_reply_err_t){x}; }
 static inline z_moved_ring_handler_query_t z_ring_handler_query_move(z_owned_ring_handler_query_t* x) { return (z_moved_ring_handler_query_t){x}; }
@@ -43,7 +46,10 @@ static inline z_moved_task_t z_task_move(z_owned_task_t* x) { return (z_moved_ta
 static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t* x) { return (zc_moved_closure_log_t){x}; }
 static inline zc_moved_closure_matching_status_t zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return (zc_moved_closure_matching_status_t){x}; }
 static inline zc_moved_liveliness_token_t zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return (zc_moved_liveliness_token_t){x}; }
+static inline zc_moved_matching_listener_t zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return (zc_moved_matching_listener_t){x}; }
 static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return (zc_moved_shm_client_list_t){x}; }
+static inline ze_moved_publication_cache_t ze_publication_cache_move(ze_owned_publication_cache_t* x) { return (ze_moved_publication_cache_t){x}; }
+static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return (ze_moved_querying_subscriber_t){x}; }
 
 
 #define z_loan(this_) \
@@ -128,6 +134,9 @@ static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_cl
         z_moved_keyexpr_t : z_keyexpr_drop, \
         z_moved_memory_layout_t : z_memory_layout_drop, \
         z_moved_mutex_t : z_mutex_drop, \
+        z_moved_publisher_t : z_publisher_drop, \
+        z_moved_query_t : z_query_drop, \
+        z_moved_queryable_t : z_queryable_drop, \
         z_moved_reply_t : z_reply_drop, \
         z_moved_reply_err_t : z_reply_err_drop, \
         z_moved_ring_handler_query_t : z_ring_handler_query_drop, \
@@ -149,7 +158,10 @@ static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_cl
         zc_moved_closure_log_t : zc_closure_log_drop, \
         zc_moved_closure_matching_status_t : zc_closure_matching_status_drop, \
         zc_moved_liveliness_token_t : zc_liveliness_token_drop, \
-        zc_moved_shm_client_list_t : zc_shm_client_list_drop \
+        zc_moved_matching_listener_t : zc_publisher_matching_listener_drop, \
+        zc_moved_shm_client_list_t : zc_shm_client_list_drop, \
+        ze_moved_publication_cache_t : ze_publication_cache_drop, \
+        ze_moved_querying_subscriber_t : ze_querying_subscriber_drop \
     )(this_)
 
 #define z_move(this_) \
@@ -172,6 +184,9 @@ static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_cl
         z_owned_keyexpr_t : z_keyexpr_move, \
         z_owned_memory_layout_t : z_memory_layout_move, \
         z_owned_mutex_t : z_mutex_move, \
+        z_owned_publisher_t : z_publisher_move, \
+        z_owned_query_t : z_query_move, \
+        z_owned_queryable_t : z_queryable_move, \
         z_owned_reply_t : z_reply_move, \
         z_owned_reply_err_t : z_reply_err_move, \
         z_owned_ring_handler_query_t : z_ring_handler_query_move, \
@@ -193,7 +208,10 @@ static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_cl
         zc_owned_closure_log_t : zc_closure_log_move, \
         zc_owned_closure_matching_status_t : zc_closure_matching_status_move, \
         zc_owned_liveliness_token_t : zc_liveliness_token_move, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_move \
+        zc_owned_matching_listener_t : zc_publisher_matching_listener_move, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_move, \
+        ze_owned_publication_cache_t : ze_publication_cache_move, \
+        ze_owned_querying_subscriber_t : ze_querying_subscriber_move \
     )(&this_)
 
 #define z_null(this_) \
@@ -249,11 +267,11 @@ static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_cl
 static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t x) { *this_ = *x._ptr; z_alloc_layout_null(x._ptr); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t x) { *this_ = *x._ptr; z_bytes_null(x._ptr); }
 static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) { *this_ = *x._ptr; z_chunk_alloc_result_null(x._ptr); }
-static inline void z_closure_hello_take(z_owned_closure_hello_t* _closure, z_moved_closure_hello_t x) { *_closure = *x._ptr; z_closure_hello_null(x._ptr); }
-static inline void z_closure_query_take(z_owned_closure_query_t* closure, z_moved_closure_query_t x) { *closure = *x._ptr; z_closure_query_null(x._ptr); }
-static inline void z_closure_reply_take(z_owned_closure_reply_t* closure, z_moved_closure_reply_t x) { *closure = *x._ptr; z_closure_reply_null(x._ptr); }
-static inline void z_closure_sample_take(z_owned_closure_sample_t* closure, z_moved_closure_sample_t x) { *closure = *x._ptr; z_closure_sample_null(x._ptr); }
-static inline void z_closure_zid_take(z_owned_closure_zid_t* closure, z_moved_closure_zid_t x) { *closure = *x._ptr; z_closure_zid_null(x._ptr); }
+static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t x) { *this_ = *x._ptr; z_closure_hello_null(x._ptr); }
+static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t x) { *closure_ = *x._ptr; z_closure_query_null(x._ptr); }
+static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t x) { *closure_ = *x._ptr; z_closure_reply_null(x._ptr); }
+static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t x) { *closure_ = *x._ptr; z_closure_sample_null(x._ptr); }
+static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t x) { *closure_ = *x._ptr; z_closure_zid_null(x._ptr); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t x) { *this_ = *x._ptr; z_condvar_null(x._ptr); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t x) { *this_ = *x._ptr; z_config_null(x._ptr); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t x) { *this_ = *x._ptr; z_encoding_null(x._ptr); }
@@ -264,6 +282,9 @@ static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *th
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
 static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) { *this_ = *x._ptr; z_memory_layout_null(x._ptr); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
+static inline void z_publisher_take(z_owned_publisher_t* _this, z_moved_publisher_t x) { *_this = *x._ptr; z_publisher_null(x._ptr); }
+static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
+static inline void z_queryable_take(z_owned_queryable_t* this_, z_moved_queryable_t x) { *this_ = *x._ptr; z_queryable_null(x._ptr); }
 static inline void z_reply_take(z_owned_reply_t* this_, z_moved_reply_t x) { *this_ = *x._ptr; z_reply_null(x._ptr); }
 static inline void z_reply_err_take(z_owned_reply_err_t* this_, z_moved_reply_err_t x) { *this_ = *x._ptr; z_reply_err_null(x._ptr); }
 static inline void z_ring_handler_query_take(z_owned_ring_handler_query_t* this_, z_moved_ring_handler_query_t x) { *this_ = *x._ptr; z_ring_handler_query_null(x._ptr); }
@@ -282,10 +303,13 @@ static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_st
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t x) { *this_ = *x._ptr; z_string_null(x._ptr); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) { *this_ = *x._ptr; z_subscriber_null(x._ptr); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t x) { *this_ = *x._ptr; z_task_null(x._ptr); }
-static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved_closure_log_t x) { *closure = *x._ptr; zc_closure_log_null(x._ptr); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure, zc_moved_closure_matching_status_t x) { *closure = *x._ptr; zc_closure_matching_status_null(x._ptr); }
+static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t x) { *closure_ = *x._ptr; zc_closure_log_null(x._ptr); }
+static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t x) { *closure_ = *x._ptr; zc_closure_matching_status_null(x._ptr); }
 static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
+static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t x) { *this_ = *x._ptr; zc_matching_listener_null(x._ptr); }
 static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
+static inline void ze_publication_cache_take(ze_owned_publication_cache_t* _this, ze_moved_publication_cache_t x) { *_this = *x._ptr; ze_publication_cache_null(x._ptr); }
+static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* _this, ze_moved_querying_subscriber_t x) { *_this = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 #define z_take(this_, x) \
@@ -308,6 +332,9 @@ static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc
         z_owned_keyexpr_t* : z_keyexpr_take, \
         z_owned_memory_layout_t* : z_memory_layout_take, \
         z_owned_mutex_t* : z_mutex_take, \
+        z_owned_publisher_t* : z_publisher_take, \
+        z_owned_query_t* : z_query_take, \
+        z_owned_queryable_t* : z_queryable_take, \
         z_owned_reply_t* : z_reply_take, \
         z_owned_reply_err_t* : z_reply_err_take, \
         z_owned_ring_handler_query_t* : z_ring_handler_query_take, \
@@ -329,7 +356,10 @@ static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc
         zc_owned_closure_log_t* : zc_closure_log_take, \
         zc_owned_closure_matching_status_t* : zc_closure_matching_status_take, \
         zc_owned_liveliness_token_t* : zc_liveliness_token_take, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_take \
+        zc_owned_matching_listener_t* : zc_publisher_matching_listener_take, \
+        zc_owned_shm_client_list_t* : zc_shm_client_list_take, \
+        ze_owned_publication_cache_t* : ze_publication_cache_take, \
+        ze_owned_querying_subscriber_t* : ze_querying_subscriber_take \
     )(this_, x)
 
 #define z_check(this_) \
@@ -435,6 +465,9 @@ static inline z_moved_hello_t z_hello_move(z_owned_hello_t* x) { return z_moved_
 static inline z_moved_keyexpr_t z_keyexpr_move(z_owned_keyexpr_t* x) { return z_moved_keyexpr_t{x}; }
 static inline z_moved_memory_layout_t z_memory_layout_move(z_owned_memory_layout_t* x) { return z_moved_memory_layout_t{x}; }
 static inline z_moved_mutex_t z_mutex_move(z_owned_mutex_t* x) { return z_moved_mutex_t{x}; }
+static inline z_moved_publisher_t z_publisher_move(z_owned_publisher_t* x) { return z_moved_publisher_t{x}; }
+static inline z_moved_query_t z_query_move(z_owned_query_t* x) { return z_moved_query_t{x}; }
+static inline z_moved_queryable_t z_queryable_move(z_owned_queryable_t* x) { return z_moved_queryable_t{x}; }
 static inline z_moved_reply_t z_reply_move(z_owned_reply_t* x) { return z_moved_reply_t{x}; }
 static inline z_moved_reply_err_t z_reply_err_move(z_owned_reply_err_t* x) { return z_moved_reply_err_t{x}; }
 static inline z_moved_ring_handler_query_t z_ring_handler_query_move(z_owned_ring_handler_query_t* x) { return z_moved_ring_handler_query_t{x}; }
@@ -456,7 +489,10 @@ static inline z_moved_task_t z_task_move(z_owned_task_t* x) { return z_moved_tas
 static inline zc_moved_closure_log_t zc_closure_log_move(zc_owned_closure_log_t* x) { return zc_moved_closure_log_t{x}; }
 static inline zc_moved_closure_matching_status_t zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return zc_moved_closure_matching_status_t{x}; }
 static inline zc_moved_liveliness_token_t zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return zc_moved_liveliness_token_t{x}; }
+static inline zc_moved_matching_listener_t zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return zc_moved_matching_listener_t{x}; }
 static inline zc_moved_shm_client_list_t zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return zc_moved_shm_client_list_t{x}; }
+static inline ze_moved_publication_cache_t ze_publication_cache_move(ze_owned_publication_cache_t* x) { return ze_moved_publication_cache_t{x}; }
+static inline ze_moved_querying_subscriber_t ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return ze_moved_querying_subscriber_t{x}; }
 
 
 
@@ -521,11 +557,11 @@ inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_
 inline void z_drop(z_moved_alloc_layout_t this_) { z_alloc_layout_drop(this_); };
 inline void z_drop(z_moved_bytes_t this_) { z_bytes_drop(this_); };
 inline void z_drop(z_moved_chunk_alloc_result_t this_) { z_chunk_alloc_result_drop(this_); };
-inline void z_drop(z_moved_closure_hello_t _closure) { z_closure_hello_drop(_closure); };
-inline void z_drop(z_moved_closure_query_t closure) { z_closure_query_drop(closure); };
-inline void z_drop(z_moved_closure_reply_t closure) { z_closure_reply_drop(closure); };
-inline void z_drop(z_moved_closure_sample_t closure) { z_closure_sample_drop(closure); };
-inline void z_drop(z_moved_closure_zid_t closure) { z_closure_zid_drop(closure); };
+inline void z_drop(z_moved_closure_hello_t this_) { z_closure_hello_drop(this_); };
+inline void z_drop(z_moved_closure_query_t closure_) { z_closure_query_drop(closure_); };
+inline void z_drop(z_moved_closure_reply_t closure_) { z_closure_reply_drop(closure_); };
+inline void z_drop(z_moved_closure_sample_t closure_) { z_closure_sample_drop(closure_); };
+inline void z_drop(z_moved_closure_zid_t closure_) { z_closure_zid_drop(closure_); };
 inline void z_drop(z_moved_condvar_t this_) { z_condvar_drop(this_); };
 inline void z_drop(z_moved_config_t this_) { z_config_drop(this_); };
 inline void z_drop(z_moved_encoding_t this_) { z_encoding_drop(this_); };
@@ -536,6 +572,9 @@ inline void z_drop(z_moved_hello_t this_) { z_hello_drop(this_); };
 inline void z_drop(z_moved_keyexpr_t this_) { z_keyexpr_drop(this_); };
 inline void z_drop(z_moved_memory_layout_t this_) { z_memory_layout_drop(this_); };
 inline void z_drop(z_moved_mutex_t this_) { z_mutex_drop(this_); };
+inline void z_drop(z_moved_publisher_t _this) { z_publisher_drop(_this); };
+inline void z_drop(z_moved_query_t this_) { z_query_drop(this_); };
+inline void z_drop(z_moved_queryable_t this_) { z_queryable_drop(this_); };
 inline void z_drop(z_moved_reply_t this_) { z_reply_drop(this_); };
 inline void z_drop(z_moved_reply_err_t this_) { z_reply_err_drop(this_); };
 inline void z_drop(z_moved_ring_handler_query_t this_) { z_ring_handler_query_drop(this_); };
@@ -554,20 +593,23 @@ inline void z_drop(z_moved_string_array_t this_) { z_string_array_drop(this_); }
 inline void z_drop(z_moved_string_t this_) { z_string_drop(this_); };
 inline void z_drop(z_moved_subscriber_t this_) { z_subscriber_drop(this_); };
 inline void z_drop(z_moved_task_t this_) { z_task_drop(this_); };
-inline void z_drop(zc_moved_closure_log_t closure) { zc_closure_log_drop(closure); };
-inline void z_drop(zc_moved_closure_matching_status_t closure) { zc_closure_matching_status_drop(closure); };
+inline void z_drop(zc_moved_closure_log_t closure_) { zc_closure_log_drop(closure_); };
+inline void z_drop(zc_moved_closure_matching_status_t closure_) { zc_closure_matching_status_drop(closure_); };
 inline void z_drop(zc_moved_liveliness_token_t this_) { zc_liveliness_token_drop(this_); };
+inline z_result_t z_drop(zc_moved_matching_listener_t this_) { return zc_publisher_matching_listener_drop(this_); };
 inline void z_drop(zc_moved_shm_client_list_t this_) { zc_shm_client_list_drop(this_); };
+inline void z_drop(ze_moved_publication_cache_t _this) { ze_publication_cache_drop(_this); };
+inline void z_drop(ze_moved_querying_subscriber_t _this) { ze_querying_subscriber_drop(_this); };
 
 
 inline z_moved_alloc_layout_t z_move(z_owned_alloc_layout_t& this_) { return z_alloc_layout_move(&this_); };
 inline z_moved_bytes_t z_move(z_owned_bytes_t& this_) { return z_bytes_move(&this_); };
 inline z_moved_chunk_alloc_result_t z_move(z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_move(&this_); };
-inline z_moved_closure_hello_t z_move(z_owned_closure_hello_t& _closure) { return z_closure_hello_move(&_closure); };
-inline z_moved_closure_query_t z_move(z_owned_closure_query_t& closure) { return z_closure_query_move(&closure); };
-inline z_moved_closure_reply_t z_move(z_owned_closure_reply_t& closure) { return z_closure_reply_move(&closure); };
-inline z_moved_closure_sample_t z_move(z_owned_closure_sample_t& closure) { return z_closure_sample_move(&closure); };
-inline z_moved_closure_zid_t z_move(z_owned_closure_zid_t& closure) { return z_closure_zid_move(&closure); };
+inline z_moved_closure_hello_t z_move(z_owned_closure_hello_t& this_) { return z_closure_hello_move(&this_); };
+inline z_moved_closure_query_t z_move(z_owned_closure_query_t& closure_) { return z_closure_query_move(&closure_); };
+inline z_moved_closure_reply_t z_move(z_owned_closure_reply_t& closure_) { return z_closure_reply_move(&closure_); };
+inline z_moved_closure_sample_t z_move(z_owned_closure_sample_t& closure_) { return z_closure_sample_move(&closure_); };
+inline z_moved_closure_zid_t z_move(z_owned_closure_zid_t& closure_) { return z_closure_zid_move(&closure_); };
 inline z_moved_condvar_t z_move(z_owned_condvar_t& this_) { return z_condvar_move(&this_); };
 inline z_moved_config_t z_move(z_owned_config_t& this_) { return z_config_move(&this_); };
 inline z_moved_encoding_t z_move(z_owned_encoding_t& this_) { return z_encoding_move(&this_); };
@@ -578,6 +620,9 @@ inline z_moved_hello_t z_move(z_owned_hello_t& this_) { return z_hello_move(&thi
 inline z_moved_keyexpr_t z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
 inline z_moved_memory_layout_t z_move(z_owned_memory_layout_t& this_) { return z_memory_layout_move(&this_); };
 inline z_moved_mutex_t z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
+inline z_moved_publisher_t z_move(z_owned_publisher_t& _this) { return z_publisher_move(&_this); };
+inline z_moved_query_t z_move(z_owned_query_t& this_) { return z_query_move(&this_); };
+inline z_moved_queryable_t z_move(z_owned_queryable_t& this_) { return z_queryable_move(&this_); };
 inline z_moved_reply_t z_move(z_owned_reply_t& this_) { return z_reply_move(&this_); };
 inline z_moved_reply_err_t z_move(z_owned_reply_err_t& this_) { return z_reply_err_move(&this_); };
 inline z_moved_ring_handler_query_t z_move(z_owned_ring_handler_query_t& this_) { return z_ring_handler_query_move(&this_); };
@@ -596,10 +641,13 @@ inline z_moved_string_array_t z_move(z_owned_string_array_t& this_) { return z_s
 inline z_moved_string_t z_move(z_owned_string_t& this_) { return z_string_move(&this_); };
 inline z_moved_subscriber_t z_move(z_owned_subscriber_t& this_) { return z_subscriber_move(&this_); };
 inline z_moved_task_t z_move(z_owned_task_t& this_) { return z_task_move(&this_); };
-inline zc_moved_closure_log_t z_move(zc_owned_closure_log_t& closure) { return zc_closure_log_move(&closure); };
-inline zc_moved_closure_matching_status_t z_move(zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_move(&closure); };
+inline zc_moved_closure_log_t z_move(zc_owned_closure_log_t& closure_) { return zc_closure_log_move(&closure_); };
+inline zc_moved_closure_matching_status_t z_move(zc_owned_closure_matching_status_t& closure_) { return zc_closure_matching_status_move(&closure_); };
 inline zc_moved_liveliness_token_t z_move(zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_move(&this_); };
+inline zc_moved_matching_listener_t z_move(zc_owned_matching_listener_t& this_) { return zc_publisher_matching_listener_move(&this_); };
 inline zc_moved_shm_client_list_t z_move(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_move(&this_); };
+inline ze_moved_publication_cache_t z_move(ze_owned_publication_cache_t& _this) { return ze_publication_cache_move(&_this); };
+inline ze_moved_querying_subscriber_t z_move(ze_owned_querying_subscriber_t& _this) { return ze_querying_subscriber_move(&_this); };
 
 
 inline void z_null(z_owned_alloc_layout_t* this_) { z_alloc_layout_null(this_); };
@@ -652,11 +700,11 @@ inline void z_null(ze_owned_querying_subscriber_t* this_) { ze_querying_subscrib
 static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t x) { *this_ = *x._ptr; z_alloc_layout_null(x._ptr); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t x) { *this_ = *x._ptr; z_bytes_null(x._ptr); }
 static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) { *this_ = *x._ptr; z_chunk_alloc_result_null(x._ptr); }
-static inline void z_closure_hello_take(z_owned_closure_hello_t* _closure, z_moved_closure_hello_t x) { *_closure = *x._ptr; z_closure_hello_null(x._ptr); }
-static inline void z_closure_query_take(z_owned_closure_query_t* closure, z_moved_closure_query_t x) { *closure = *x._ptr; z_closure_query_null(x._ptr); }
-static inline void z_closure_reply_take(z_owned_closure_reply_t* closure, z_moved_closure_reply_t x) { *closure = *x._ptr; z_closure_reply_null(x._ptr); }
-static inline void z_closure_sample_take(z_owned_closure_sample_t* closure, z_moved_closure_sample_t x) { *closure = *x._ptr; z_closure_sample_null(x._ptr); }
-static inline void z_closure_zid_take(z_owned_closure_zid_t* closure, z_moved_closure_zid_t x) { *closure = *x._ptr; z_closure_zid_null(x._ptr); }
+static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t x) { *this_ = *x._ptr; z_closure_hello_null(x._ptr); }
+static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t x) { *closure_ = *x._ptr; z_closure_query_null(x._ptr); }
+static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t x) { *closure_ = *x._ptr; z_closure_reply_null(x._ptr); }
+static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t x) { *closure_ = *x._ptr; z_closure_sample_null(x._ptr); }
+static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t x) { *closure_ = *x._ptr; z_closure_zid_null(x._ptr); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t x) { *this_ = *x._ptr; z_condvar_null(x._ptr); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t x) { *this_ = *x._ptr; z_config_null(x._ptr); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t x) { *this_ = *x._ptr; z_encoding_null(x._ptr); }
@@ -667,6 +715,9 @@ static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t x) { *th
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t x) { *this_ = *x._ptr; z_keyexpr_null(x._ptr); }
 static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) { *this_ = *x._ptr; z_memory_layout_null(x._ptr); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t x) { *this_ = *x._ptr; z_mutex_null(x._ptr); }
+static inline void z_publisher_take(z_owned_publisher_t* _this, z_moved_publisher_t x) { *_this = *x._ptr; z_publisher_null(x._ptr); }
+static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t x) { *this_ = *x._ptr; z_query_null(x._ptr); }
+static inline void z_queryable_take(z_owned_queryable_t* this_, z_moved_queryable_t x) { *this_ = *x._ptr; z_queryable_null(x._ptr); }
 static inline void z_reply_take(z_owned_reply_t* this_, z_moved_reply_t x) { *this_ = *x._ptr; z_reply_null(x._ptr); }
 static inline void z_reply_err_take(z_owned_reply_err_t* this_, z_moved_reply_err_t x) { *this_ = *x._ptr; z_reply_err_null(x._ptr); }
 static inline void z_ring_handler_query_take(z_owned_ring_handler_query_t* this_, z_moved_ring_handler_query_t x) { *this_ = *x._ptr; z_ring_handler_query_null(x._ptr); }
@@ -685,10 +736,13 @@ static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_st
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t x) { *this_ = *x._ptr; z_string_null(x._ptr); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) { *this_ = *x._ptr; z_subscriber_null(x._ptr); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t x) { *this_ = *x._ptr; z_task_null(x._ptr); }
-static inline void zc_closure_log_take(zc_owned_closure_log_t* closure, zc_moved_closure_log_t x) { *closure = *x._ptr; zc_closure_log_null(x._ptr); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure, zc_moved_closure_matching_status_t x) { *closure = *x._ptr; zc_closure_matching_status_null(x._ptr); }
+static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t x) { *closure_ = *x._ptr; zc_closure_log_null(x._ptr); }
+static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t x) { *closure_ = *x._ptr; zc_closure_matching_status_null(x._ptr); }
 static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) { *this_ = *x._ptr; zc_liveliness_token_null(x._ptr); }
+static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t x) { *this_ = *x._ptr; zc_matching_listener_null(x._ptr); }
 static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) { *this_ = *x._ptr; zc_shm_client_list_null(x._ptr); }
+static inline void ze_publication_cache_take(ze_owned_publication_cache_t* _this, ze_moved_publication_cache_t x) { *_this = *x._ptr; ze_publication_cache_null(x._ptr); }
+static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* _this, ze_moved_querying_subscriber_t x) { *_this = *x._ptr; ze_querying_subscriber_null(x._ptr); }
 
 
 
@@ -701,20 +755,20 @@ inline void z_take(z_owned_bytes_t* this_, z_moved_bytes_t x) {
 inline void z_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t x) {
     z_chunk_alloc_result_take(this_, x);
 };
-inline void z_take(z_owned_closure_hello_t* _closure, z_moved_closure_hello_t x) {
-    z_closure_hello_take(_closure, x);
+inline void z_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t x) {
+    z_closure_hello_take(this_, x);
 };
-inline void z_take(z_owned_closure_query_t* closure, z_moved_closure_query_t x) {
-    z_closure_query_take(closure, x);
+inline void z_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t x) {
+    z_closure_query_take(closure_, x);
 };
-inline void z_take(z_owned_closure_reply_t* closure, z_moved_closure_reply_t x) {
-    z_closure_reply_take(closure, x);
+inline void z_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t x) {
+    z_closure_reply_take(closure_, x);
 };
-inline void z_take(z_owned_closure_sample_t* closure, z_moved_closure_sample_t x) {
-    z_closure_sample_take(closure, x);
+inline void z_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t x) {
+    z_closure_sample_take(closure_, x);
 };
-inline void z_take(z_owned_closure_zid_t* closure, z_moved_closure_zid_t x) {
-    z_closure_zid_take(closure, x);
+inline void z_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t x) {
+    z_closure_zid_take(closure_, x);
 };
 inline void z_take(z_owned_condvar_t* this_, z_moved_condvar_t x) {
     z_condvar_take(this_, x);
@@ -745,6 +799,15 @@ inline void z_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t x) {
 };
 inline void z_take(z_owned_mutex_t* this_, z_moved_mutex_t x) {
     z_mutex_take(this_, x);
+};
+inline void z_take(z_owned_publisher_t* _this, z_moved_publisher_t x) {
+    z_publisher_take(_this, x);
+};
+inline void z_take(z_owned_query_t* this_, z_moved_query_t x) {
+    z_query_take(this_, x);
+};
+inline void z_take(z_owned_queryable_t* this_, z_moved_queryable_t x) {
+    z_queryable_take(this_, x);
 };
 inline void z_take(z_owned_reply_t* this_, z_moved_reply_t x) {
     z_reply_take(this_, x);
@@ -800,17 +863,26 @@ inline void z_take(z_owned_subscriber_t* this_, z_moved_subscriber_t x) {
 inline void z_take(z_owned_task_t* this_, z_moved_task_t x) {
     z_task_take(this_, x);
 };
-inline void z_take(zc_owned_closure_log_t* closure, zc_moved_closure_log_t x) {
-    zc_closure_log_take(closure, x);
+inline void z_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t x) {
+    zc_closure_log_take(closure_, x);
 };
-inline void z_take(zc_owned_closure_matching_status_t* closure, zc_moved_closure_matching_status_t x) {
-    zc_closure_matching_status_take(closure, x);
+inline void z_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t x) {
+    zc_closure_matching_status_take(closure_, x);
 };
 inline void z_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t x) {
     zc_liveliness_token_take(this_, x);
 };
+inline void z_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t x) {
+    zc_publisher_matching_listener_take(this_, x);
+};
 inline void z_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t x) {
     zc_shm_client_list_take(this_, x);
+};
+inline void z_take(ze_owned_publication_cache_t* _this, ze_moved_publication_cache_t x) {
+    ze_publication_cache_take(_this, x);
+};
+inline void z_take(ze_owned_querying_subscriber_t* _this, ze_moved_querying_subscriber_t x) {
+    ze_querying_subscriber_take(_this, x);
 };
 
 

--- a/src/closures/hello_closure.rs
+++ b/src/closures/hello_closure.rs
@@ -83,8 +83,8 @@ impl Drop for z_owned_closure_hello_t {
 /// Constructs a closure in a gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_closure_hello_null(this: *mut MaybeUninit<z_owned_closure_hello_t>) {
-    (*this).write(z_owned_closure_hello_t::default());
+pub unsafe extern "C" fn z_closure_hello_null(this_: *mut MaybeUninit<z_owned_closure_hello_t>) {
+    (*this_).write(z_owned_closure_hello_t::default());
 }
 /// Calls the closure. Calling an uninitialized closure is a no-op.
 #[no_mangle]
@@ -129,8 +129,8 @@ impl<F: Fn(&z_loaned_hello_t)> From<F> for z_owned_closure_hello_t {
 
 /// Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_closure_hello_check(this: &z_owned_closure_hello_t) -> bool {
-    !this.is_empty()
+pub extern "C" fn z_closure_hello_check(this_: &z_owned_closure_hello_t) -> bool {
+    !this_.is_empty()
 }
 
 /// Borrows closure.

--- a/src/closures/hello_closure.rs
+++ b/src/closures/hello_closure.rs
@@ -17,7 +17,7 @@ use std::mem::MaybeUninit;
 use libc::c_void;
 
 use crate::{
-    transmute::{LoanedCTypeRef, OwnedCTypeRef},
+    transmute::{LoanedCTypeRef, OwnedCTypeRef, TakeRustType},
     z_loaned_hello_t,
 };
 /// A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:
@@ -102,8 +102,9 @@ pub extern "C" fn z_closure_hello_call(
 }
 /// Drops the closure. Droping an uninitialized closure is a no-op.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_closure_hello_drop(_closure: z_moved_closure_hello_t) {}
+pub extern "C" fn z_closure_hello_drop(this_: &mut z_moved_closure_hello_t) {
+    let _ = this_.take_rust_type();
+}
 
 impl<F: Fn(&z_loaned_hello_t)> From<F> for z_owned_closure_hello_t {
     fn from(f: F) -> Self {

--- a/src/closures/hello_closure.rs
+++ b/src/closures/hello_closure.rs
@@ -48,13 +48,13 @@ pub struct z_loaned_closure_hello_t {
 /// Moved closure.
 #[repr(C)]
 pub struct z_moved_closure_hello_t {
-    pub _ptr: Option<&'static mut z_owned_closure_hello_t>,
+    _this: z_owned_closure_hello_t,
 }
 
 decl_c_type!(
     owned(z_owned_closure_hello_t),
     loaned(z_loaned_closure_hello_t),
-    moved(z_moved_closure_hello_t)
+    moved(z_moved_closure_hello_t),
 );
 
 impl Default for z_owned_closure_hello_t {

--- a/src/closures/log_closure.rs
+++ b/src/closures/log_closure.rs
@@ -146,8 +146,8 @@ impl Drop for zc_owned_closure_log_t {
 /// Constructs a closure in a gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn zc_closure_log_null(this: *mut MaybeUninit<zc_owned_closure_log_t>) {
-    (*this).write(zc_owned_closure_log_t::default());
+pub unsafe extern "C" fn zc_closure_log_null(this_: *mut MaybeUninit<zc_owned_closure_log_t>) {
+    (*this_).write(zc_owned_closure_log_t::default());
 }
 /// Calls the closure. Calling an uninitialized closure is a no-op.
 #[no_mangle]
@@ -172,8 +172,8 @@ pub extern "C" fn zc_closure_log_drop(closure_: &mut zc_moved_closure_log_t) {
 
 /// Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn zc_closure_log_check(this: &zc_owned_closure_log_t) -> bool {
-    !this.is_empty()
+pub extern "C" fn zc_closure_log_check(this_: &zc_owned_closure_log_t) -> bool {
+    !this_.is_empty()
 }
 
 /// Borrows closure.

--- a/src/closures/log_closure.rs
+++ b/src/closures/log_closure.rs
@@ -102,13 +102,13 @@ pub struct zc_loaned_closure_log_t {
 /// Moved closure.
 #[repr(C)]
 pub struct zc_moved_closure_log_t {
-    _ptr: Option<&'static mut zc_owned_closure_log_t>,
+    _this: zc_owned_closure_log_t,
 }
 
 decl_c_type!(
     owned(zc_owned_closure_log_t),
     loaned(zc_loaned_closure_log_t),
-    moved(zc_moved_closure_log_t)
+    moved(zc_moved_closure_log_t),
 );
 
 impl Default for zc_owned_closure_log_t {

--- a/src/closures/log_closure.rs
+++ b/src/closures/log_closure.rs
@@ -15,7 +15,7 @@
 use std::mem::MaybeUninit;
 
 use crate::{
-    transmute::{LoanedCTypeRef, OwnedCTypeRef},
+    transmute::{LoanedCTypeRef, OwnedCTypeRef, TakeRustType},
     z_loaned_string_t,
 };
 
@@ -166,8 +166,9 @@ pub extern "C" fn zc_closure_log_call(
 }
 /// Drops the closure. Droping an uninitialized closure is a no-op.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn zc_closure_log_drop(closure: zc_moved_closure_log_t) {}
+pub extern "C" fn zc_closure_log_drop(closure_: &mut zc_moved_closure_log_t) {
+    let _ = closure_.take_rust_type();
+}
 
 /// Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
 #[no_mangle]

--- a/src/closures/matching_status_closure.rs
+++ b/src/closures/matching_status_closure.rs
@@ -112,7 +112,9 @@ pub extern "C" fn zc_closure_matching_status_call(
 }
 /// Drops the closure, resetting it to its gravestone state. Droping an uninitialized closure is a no-op.
 #[no_mangle]
-pub extern "C" fn zc_closure_matching_status_drop(closure_: &mut zc_moved_closure_matching_status_t) {
+pub extern "C" fn zc_closure_matching_status_drop(
+    closure_: &mut zc_moved_closure_matching_status_t,
+) {
     let _ = closure_.take_rust_type();
 }
 

--- a/src/closures/matching_status_closure.rs
+++ b/src/closures/matching_status_closure.rs
@@ -46,12 +46,13 @@ pub struct zc_loaned_closure_matching_status_t {
 /// Moved closure.
 #[repr(C)]
 pub struct zc_moved_closure_matching_status_t {
-    pub _ptr: Option<&'static mut zc_owned_closure_matching_status_t>,
+    _this: zc_owned_closure_matching_status_t,
 }
 
 decl_c_type!(
     owned(zc_owned_closure_matching_status_t),
     loaned(zc_loaned_closure_matching_status_t),
+    moved(zc_moved_closure_matching_status_t),
 );
 
 impl Default for zc_owned_closure_matching_status_t {

--- a/src/closures/matching_status_closure.rs
+++ b/src/closures/matching_status_closure.rs
@@ -16,7 +16,7 @@ use std::mem::MaybeUninit;
 use libc::c_void;
 
 use crate::{
-    transmute::{LoanedCTypeRef, OwnedCTypeRef},
+    transmute::{LoanedCTypeRef, OwnedCTypeRef, TakeRustType},
     zc_matching_status_t,
 };
 /// A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:
@@ -112,8 +112,9 @@ pub extern "C" fn zc_closure_matching_status_call(
 }
 /// Drops the closure, resetting it to its gravestone state. Droping an uninitialized closure is a no-op.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn zc_closure_matching_status_drop(closure: zc_moved_closure_matching_status_t) {}
+pub extern "C" fn zc_closure_matching_status_drop(closure_: &mut zc_moved_closure_matching_status_t) {
+    let _ = closure_.take_rust_type();
+}
 
 impl<F: Fn(&zc_matching_status_t)> From<F> for zc_owned_closure_matching_status_t {
     fn from(f: F) -> Self {

--- a/src/closures/matching_status_closure.rs
+++ b/src/closures/matching_status_closure.rs
@@ -52,7 +52,6 @@ pub struct zc_moved_closure_matching_status_t {
 decl_c_type!(
     owned(zc_owned_closure_matching_status_t),
     loaned(zc_loaned_closure_matching_status_t),
-    moved(zc_moved_closure_matching_status_t)
 );
 
 impl Default for zc_owned_closure_matching_status_t {

--- a/src/closures/query_channel.rs
+++ b/src/closures/query_channel.rs
@@ -41,14 +41,14 @@ pub extern "C" fn z_fifo_handler_query_drop(this_: &mut z_moved_fifo_handler_que
 
 /// Constructs a handler in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_fifo_handler_query_null(this: &mut MaybeUninit<z_owned_fifo_handler_query_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_fifo_handler_query_null(this_: &mut MaybeUninit<z_owned_fifo_handler_query_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if handler is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_fifo_handler_query_check(this: &z_owned_fifo_handler_query_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_fifo_handler_query_check(this_: &z_owned_fifo_handler_query_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 extern "C" fn __z_handler_query_send(query: &z_loaned_query_t, context: *mut c_void) {
@@ -161,14 +161,14 @@ pub extern "C" fn z_ring_handler_query_drop(this_: &mut z_moved_ring_handler_que
 
 /// Constructs a handler in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_ring_handler_query_null(this: &mut MaybeUninit<z_owned_ring_handler_query_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_ring_handler_query_null(this_: &mut MaybeUninit<z_owned_ring_handler_query_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if handler is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_ring_handler_query_check(this: &z_owned_ring_handler_query_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_ring_handler_query_check(this_: &z_owned_ring_handler_query_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Constructs send and recieve ends of the ring channel

--- a/src/closures/query_channel.rs
+++ b/src/closures/query_channel.rs
@@ -25,7 +25,7 @@ pub use crate::opaque_types::{
 };
 use crate::{
     result::{self, z_result_t},
-    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_query_t, z_owned_closure_query_t, z_owned_query_t,
 };
 decl_c_type!(
@@ -35,8 +35,9 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_fifo_handler_query_drop(this: z_moved_fifo_handler_query_t) {}
+pub extern "C" fn z_fifo_handler_query_drop(this_: &mut z_moved_fifo_handler_query_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Constructs a handler in gravestone state.
 #[no_mangle]
@@ -154,8 +155,9 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_ring_handler_query_drop(this: z_moved_ring_handler_query_t) {}
+pub extern "C" fn z_ring_handler_query_drop(this_: &mut z_moved_ring_handler_query_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Constructs a handler in gravestone state.
 #[no_mangle]

--- a/src/closures/query_channel.rs
+++ b/src/closures/query_channel.rs
@@ -31,7 +31,6 @@ use crate::{
 decl_c_type!(
     owned(z_owned_fifo_handler_query_t, option flume::Receiver<Query> ),
     loaned(z_loaned_fifo_handler_query_t),
-    moved(z_moved_fifo_handler_query_t)
 );
 
 /// Drops the handler and resets it to a gravestone state.
@@ -151,7 +150,6 @@ decl_c_type!(
         option RingChannelHandler<Query>,
     ),
     loaned(z_loaned_ring_handler_query_t),
-moved(z_moved_ring_handler_query_t)
 );
 
 /// Drops the handler and resets it to a gravestone state.

--- a/src/closures/query_closure.rs
+++ b/src/closures/query_closure.rs
@@ -83,14 +83,14 @@ impl Drop for z_owned_closure_query_t {
 /// Constructs a closure in its gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_closure_query_null(this: *mut MaybeUninit<z_owned_closure_query_t>) {
-    (*this).write(z_owned_closure_query_t::default());
+pub unsafe extern "C" fn z_closure_query_null(this_: *mut MaybeUninit<z_owned_closure_query_t>) {
+    (*this_).write(z_owned_closure_query_t::default());
 }
 
 /// Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_closure_query_check(this: &z_owned_closure_query_t) -> bool {
-    !this.is_empty()
+pub extern "C" fn z_closure_query_check(this_: &z_owned_closure_query_t) -> bool {
+    !this_.is_empty()
 }
 
 /// Calls the closure. Calling an uninitialized closure is a no-op.

--- a/src/closures/query_closure.rs
+++ b/src/closures/query_closure.rs
@@ -47,13 +47,13 @@ pub struct z_loaned_closure_query_t {
 /// Moved closure.
 #[repr(C)]
 pub struct z_moved_closure_query_t {
-    pub _ptr: Option<&'static mut z_owned_closure_query_t>,
+    _this: z_owned_closure_query_t,
 }
 
 decl_c_type!(
     owned(z_owned_closure_query_t),
     loaned(z_loaned_closure_query_t),
-    moved(z_moved_closure_query_t)
+    moved(z_moved_closure_query_t),
 );
 
 impl Default for z_owned_closure_query_t {

--- a/src/closures/query_closure.rs
+++ b/src/closures/query_closure.rs
@@ -17,7 +17,7 @@ use std::mem::MaybeUninit;
 use libc::c_void;
 
 use crate::{
-    transmute::{LoanedCTypeRef, OwnedCTypeRef},
+    transmute::{LoanedCTypeRef, OwnedCTypeRef, TakeRustType},
     z_loaned_query_t,
 };
 /// A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:
@@ -107,8 +107,9 @@ pub extern "C" fn z_closure_query_call(
 }
 /// Drops the closure, resetting it to its gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_closure_query_drop(closure: z_moved_closure_query_t) {}
+pub extern "C" fn z_closure_query_drop(closure_: &mut z_moved_closure_query_t) {
+    let _ = closure_.take_rust_type();
+}
 
 impl<F: Fn(&z_loaned_query_t)> From<F> for z_owned_closure_query_t {
     fn from(f: F) -> Self {

--- a/src/closures/reply_closure.rs
+++ b/src/closures/reply_closure.rs
@@ -46,14 +46,15 @@ pub struct z_loaned_closure_reply_t {
 
 /// Moved closure.
 #[repr(C)]
+#[derive(Default)]
 pub struct z_moved_closure_reply_t {
-    pub _ptr: Option<&'static mut z_owned_closure_reply_t>,
+    pub _this: z_owned_closure_reply_t,
 }
 
 decl_c_type!(
     owned(z_owned_closure_reply_t),
     loaned(z_loaned_closure_reply_t),
-    moved(z_moved_closure_reply_t)
+    moved(z_moved_closure_reply_t),
 );
 
 impl Default for z_owned_closure_reply_t {

--- a/src/closures/reply_closure.rs
+++ b/src/closures/reply_closure.rs
@@ -84,14 +84,14 @@ impl Drop for z_owned_closure_reply_t {
 /// Constructs a closure int its gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_closure_reply_null(this: *mut MaybeUninit<z_owned_closure_reply_t>) {
-    (*this).write(z_owned_closure_reply_t::default());
+pub unsafe extern "C" fn z_closure_reply_null(this_: *mut MaybeUninit<z_owned_closure_reply_t>) {
+    (*this_).write(z_owned_closure_reply_t::default());
 }
 
 /// Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_closure_reply_check(this: &z_owned_closure_reply_t) -> bool {
-    !this.is_empty()
+pub extern "C" fn z_closure_reply_check(this_: &z_owned_closure_reply_t) -> bool {
+    !this_.is_empty()
 }
 
 /// Calls the closure. Calling an uninitialized closure is a no-op.

--- a/src/closures/reply_closure.rs
+++ b/src/closures/reply_closure.rs
@@ -17,7 +17,7 @@ use std::mem::MaybeUninit;
 use libc::c_void;
 
 use crate::{
-    transmute::{LoanedCTypeRef, OwnedCTypeRef},
+    transmute::{LoanedCTypeRef, OwnedCTypeRef, TakeRustType},
     z_loaned_reply_t,
 };
 /// A structure that contains all the elements for stateful, memory-leak-free callbacks.
@@ -110,8 +110,9 @@ pub extern "C" fn z_closure_reply_call(
 }
 /// Drops the closure, resetting it to its gravestone state. Droping an uninitialized closure is a no-op.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_closure_reply_drop(closure: z_moved_closure_reply_t) {}
+pub extern "C" fn z_closure_reply_drop(closure_: &mut z_moved_closure_reply_t) {
+    let _ = closure_.take_rust_type();
+}
 
 impl<F: Fn(&z_loaned_reply_t)> From<F> for z_owned_closure_reply_t {
     fn from(f: F) -> Self {

--- a/src/closures/response_channel.rs
+++ b/src/closures/response_channel.rs
@@ -25,7 +25,7 @@ pub use crate::opaque_types::{
 };
 use crate::{
     result::{self, z_result_t},
-    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_reply_t, z_owned_closure_reply_t, z_owned_reply_t,
 };
 decl_c_type!(
@@ -35,8 +35,9 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_fifo_handler_reply_drop(this: z_moved_fifo_handler_reply_t) {}
+pub extern "C" fn z_fifo_handler_reply_drop(this_: &mut z_moved_fifo_handler_reply_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Constructs a handler in gravestone state.
 #[no_mangle]
@@ -150,8 +151,9 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_ring_handler_reply_drop(this: z_moved_ring_handler_reply_t) {}
+pub extern "C" fn z_ring_handler_reply_drop(this_: &mut z_moved_ring_handler_reply_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Constructs a handler in gravestone state.
 #[no_mangle]

--- a/src/closures/response_channel.rs
+++ b/src/closures/response_channel.rs
@@ -31,7 +31,6 @@ use crate::{
 decl_c_type!(
     owned(z_owned_fifo_handler_reply_t, option flume::Receiver<Reply>),
     loaned(z_loaned_fifo_handler_reply_t),
-    moved(z_moved_fifo_handler_reply_t)
 );
 
 /// Drops the handler and resets it to a gravestone state.
@@ -147,7 +146,6 @@ pub use crate::opaque_types::{
 decl_c_type!(
     owned(z_owned_ring_handler_reply_t, option RingChannelHandler<Reply>),
     loaned(z_loaned_ring_handler_reply_t),
-    moved(z_moved_ring_handler_reply_t)
 );
 
 /// Drops the handler and resets it to a gravestone state.

--- a/src/closures/response_channel.rs
+++ b/src/closures/response_channel.rs
@@ -41,14 +41,14 @@ pub extern "C" fn z_fifo_handler_reply_drop(this_: &mut z_moved_fifo_handler_rep
 
 /// Constructs a handler in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_fifo_handler_reply_null(this: &mut MaybeUninit<z_owned_fifo_handler_reply_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_fifo_handler_reply_null(this_: &mut MaybeUninit<z_owned_fifo_handler_reply_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if handler is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_fifo_handler_reply_check(this: &z_owned_fifo_handler_reply_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_fifo_handler_reply_check(this_: &z_owned_fifo_handler_reply_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 extern "C" fn __z_handler_reply_send(reply: &z_loaned_reply_t, context: *mut c_void) {
@@ -157,14 +157,14 @@ pub extern "C" fn z_ring_handler_reply_drop(this_: &mut z_moved_ring_handler_rep
 
 /// Constructs a handler in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_ring_handler_reply_null(this: &mut MaybeUninit<z_owned_ring_handler_reply_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_ring_handler_reply_null(this_: &mut MaybeUninit<z_owned_ring_handler_reply_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if handler is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_ring_handler_reply_check(this: &z_owned_ring_handler_reply_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_ring_handler_reply_check(this_: &z_owned_ring_handler_reply_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Constructs send and recieve ends of the ring channel

--- a/src/closures/sample_channel.rs
+++ b/src/closures/sample_channel.rs
@@ -25,7 +25,7 @@ pub use crate::opaque_types::{
 };
 use crate::{
     result::{self, z_result_t},
-    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_sample_t, z_owned_closure_sample_t, z_owned_sample_t,
 };
 decl_c_type!(
@@ -35,8 +35,9 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_fifo_handler_sample_drop(this: z_moved_fifo_handler_sample_t) {}
+pub extern "C" fn z_fifo_handler_sample_drop(this_: &mut z_moved_fifo_handler_sample_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Constructs a handler in gravestone state.
 #[no_mangle]
@@ -156,8 +157,9 @@ decl_c_type!(
 
 /// Drops the handler and resets it to a gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_ring_handler_sample_drop(this: z_moved_ring_handler_sample_t) {}
+pub extern "C" fn z_ring_handler_sample_drop(this_: &mut z_moved_ring_handler_sample_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Constructs a handler in gravestone state.
 #[no_mangle]

--- a/src/closures/sample_channel.rs
+++ b/src/closures/sample_channel.rs
@@ -49,8 +49,8 @@ pub extern "C" fn z_fifo_handler_sample_null(
 
 /// Returns ``true`` if handler is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_fifo_handler_sample_check(this: &z_owned_fifo_handler_sample_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_fifo_handler_sample_check(this_: &z_owned_fifo_handler_sample_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 extern "C" fn __z_handler_sample_send(sample: &z_loaned_sample_t, context: *mut c_void) {
@@ -171,8 +171,8 @@ pub extern "C" fn z_ring_handler_sample_null(
 
 /// Returns ``true`` if handler is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_ring_handler_sample_check(this: &z_owned_ring_handler_sample_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_ring_handler_sample_check(this_: &z_owned_ring_handler_sample_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Constructs send and recieve ends of the ring channel

--- a/src/closures/sample_channel.rs
+++ b/src/closures/sample_channel.rs
@@ -31,7 +31,6 @@ use crate::{
 decl_c_type!(
     owned(z_owned_fifo_handler_sample_t, option flume::Receiver<Sample>),
     loaned(z_loaned_fifo_handler_sample_t),
-    moved(z_moved_fifo_handler_sample_t)
 );
 
 /// Drops the handler and resets it to a gravestone state.
@@ -153,7 +152,6 @@ decl_c_type!(
         option RingChannelHandler<Sample>,
     ),
     loaned(z_loaned_ring_handler_sample_t),
-    moved(z_moved_ring_handler_sample_t)
 );
 
 /// Drops the handler and resets it to a gravestone state.

--- a/src/closures/sample_closure.rs
+++ b/src/closures/sample_closure.rs
@@ -47,13 +47,13 @@ pub struct z_loaned_closure_sample_t {
 /// Moved closure.
 #[repr(C)]
 pub struct z_moved_closure_sample_t {
-    pub _ptr: Option<&'static mut z_owned_closure_sample_t>,
+    _this: z_owned_closure_sample_t,
 }
 
 decl_c_type!(
     owned(z_owned_closure_sample_t),
     loaned(z_loaned_closure_sample_t),
-    moved(z_moved_closure_sample_t)
+    moved(z_moved_closure_sample_t),
 );
 
 impl Default for z_owned_closure_sample_t {

--- a/src/closures/sample_closure.rs
+++ b/src/closures/sample_closure.rs
@@ -84,14 +84,14 @@ impl Drop for z_owned_closure_sample_t {
 /// Constructs a closure in its gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_closure_sample_null(this: &mut MaybeUninit<z_owned_closure_sample_t>) {
-    this.write(z_owned_closure_sample_t::default());
+pub unsafe extern "C" fn z_closure_sample_null(this_: &mut MaybeUninit<z_owned_closure_sample_t>) {
+    this_.write(z_owned_closure_sample_t::default());
 }
 
 /// Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_closure_sample_check(this: &z_owned_closure_sample_t) -> bool {
-    !this.is_empty()
+pub extern "C" fn z_closure_sample_check(this_: &z_owned_closure_sample_t) -> bool {
+    !this_.is_empty()
 }
 
 /// Calls the closure. Calling an uninitialized closure is a no-op.

--- a/src/closures/sample_closure.rs
+++ b/src/closures/sample_closure.rs
@@ -17,7 +17,7 @@ use std::mem::MaybeUninit;
 use libc::c_void;
 
 use crate::{
-    transmute::{LoanedCTypeRef, OwnedCTypeRef},
+    transmute::{LoanedCTypeRef, OwnedCTypeRef, TakeRustType},
     z_loaned_sample_t,
 };
 /// A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
@@ -109,8 +109,9 @@ pub extern "C" fn z_closure_sample_call(
 
 /// Drops the closure. Droping an uninitialized closure is a no-op.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_closure_sample_drop(closure: z_moved_closure_sample_t) {}
+pub extern "C" fn z_closure_sample_drop(closure_: &mut z_moved_closure_sample_t) {
+    let _ = closure_.take_rust_type();
+}
 
 impl<F: Fn(&z_loaned_sample_t)> From<F> for z_owned_closure_sample_t {
     fn from(f: F) -> Self {

--- a/src/closures/zenohid_closure.rs
+++ b/src/closures/zenohid_closure.rs
@@ -53,7 +53,6 @@ pub struct z_moved_closure_zid_t {
 decl_c_type!(
     owned(z_owned_closure_zid_t),
     loaned(z_loaned_closure_zid_t),
-    moved(z_moved_closure_zid_t)
 );
 
 impl Default for z_owned_closure_zid_t {

--- a/src/closures/zenohid_closure.rs
+++ b/src/closures/zenohid_closure.rs
@@ -17,7 +17,7 @@ use std::mem::MaybeUninit;
 use libc::c_void;
 
 use crate::{
-    transmute::{LoanedCTypeRef, OwnedCTypeRef},
+    transmute::{LoanedCTypeRef, OwnedCTypeRef, TakeRustType},
     z_id_t,
 };
 /// A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks:
@@ -107,8 +107,9 @@ pub extern "C" fn z_closure_zid_call(closure: &z_loaned_closure_zid_t, z_id: &z_
 }
 /// Drops the closure, resetting it to its gravestone state. Droping an uninitialized (null) closure is a no-op.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_closure_zid_drop(closure: z_moved_closure_zid_t) {}
+pub extern "C" fn z_closure_zid_drop(closure_: &mut z_moved_closure_zid_t) {
+    let _ = closure_.take_rust_type();
+}
 
 impl<F: Fn(&z_id_t)> From<F> for z_owned_closure_zid_t {
     fn from(f: F) -> Self {

--- a/src/closures/zenohid_closure.rs
+++ b/src/closures/zenohid_closure.rs
@@ -84,15 +84,15 @@ impl Drop for z_owned_closure_zid_t {
 /// Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_closure_zid_check(this: &z_owned_closure_zid_t) -> bool {
-    !this.is_empty()
+pub unsafe extern "C" fn z_closure_zid_check(this_: &z_owned_closure_zid_t) -> bool {
+    !this_.is_empty()
 }
 
 /// Constructs a null closure.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_closure_zid_null(this: &mut MaybeUninit<z_owned_closure_zid_t>) {
-    this.write(z_owned_closure_zid_t::default());
+pub unsafe extern "C" fn z_closure_zid_null(this_: &mut MaybeUninit<z_owned_closure_zid_t>) {
+    this_.write(z_owned_closure_zid_t::default());
 }
 /// Calls the closure. Calling an uninitialized closure is a no-op.
 #[no_mangle]

--- a/src/closures/zenohid_closure.rs
+++ b/src/closures/zenohid_closure.rs
@@ -47,12 +47,13 @@ pub struct z_loaned_closure_zid_t {
 /// Moved closure.
 #[repr(C)]
 pub struct z_moved_closure_zid_t {
-    pub _ptr: Option<&'static mut z_owned_closure_zid_t>,
+    pub _this: z_owned_closure_zid_t,
 }
 
 decl_c_type!(
     owned(z_owned_closure_zid_t),
     loaned(z_loaned_closure_zid_t),
+    moved(z_moved_closure_zid_t),
 );
 
 impl Default for z_owned_closure_zid_t {

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -311,7 +311,9 @@ pub extern "C" fn z_view_slice_is_empty(this_: &z_view_slice_t) -> bool {
 /// Constructs an empty `z_owned_slice_t`.
 #[no_mangle]
 pub extern "C" fn z_slice_empty(this_: &mut MaybeUninit<z_owned_slice_t>) {
-    this_.as_rust_type_mut_uninit().write(CSliceOwned::default());
+    this_
+        .as_rust_type_mut_uninit()
+        .write(CSliceOwned::default());
 }
 
 /// Constructs an empty `z_owned_slice_t`.
@@ -323,7 +325,7 @@ pub extern "C" fn z_slice_null(this_: &mut MaybeUninit<z_owned_slice_t>) {
 /// Frees the memory and invalidates the slice.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_slice_drop(this_:&mut z_moved_slice_t) {
+pub unsafe extern "C" fn z_slice_drop(this_: &mut z_moved_slice_t) {
     let _ = this_.take_rust_type();
 }
 
@@ -543,7 +545,8 @@ pub extern "C" fn z_string_check(this_: &z_owned_string_t) -> bool {
 /// Constructs owned string in a gravestone state.
 #[no_mangle]
 pub extern "C" fn z_string_null(this_: &mut MaybeUninit<z_owned_string_t>) {
-    this_.as_rust_type_mut_uninit()
+    this_
+        .as_rust_type_mut_uninit()
         .write(CStringOwned::default());
 }
 
@@ -557,7 +560,8 @@ pub extern "C" fn z_view_string_is_empty(this_: &z_view_string_t) -> bool {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_string_empty(this_: &mut MaybeUninit<z_owned_string_t>) {
-    this_.as_rust_type_mut_uninit()
+    this_
+        .as_rust_type_mut_uninit()
         .write(CStringOwned::default());
 }
 
@@ -565,7 +569,9 @@ pub unsafe extern "C" fn z_string_empty(this_: &mut MaybeUninit<z_owned_string_t
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_view_string_empty(this_: &mut MaybeUninit<z_view_string_t>) {
-    this_.as_rust_type_mut_uninit().write(CStringView::default());
+    this_
+        .as_rust_type_mut_uninit()
+        .write(CStringView::default());
 }
 
 /// Borrows string.

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -269,8 +269,8 @@ decl_c_type!(
 
 /// Constructs an empty view slice.
 #[no_mangle]
-pub extern "C" fn z_view_slice_empty(this: &mut MaybeUninit<z_view_slice_t>) {
-    this.as_rust_type_mut_uninit().write(CSliceView::default());
+pub extern "C" fn z_view_slice_empty(this_: &mut MaybeUninit<z_view_slice_t>) {
+    this_.as_rust_type_mut_uninit().write(CSliceView::default());
 }
 
 /// Constructs a `len` bytes long view starting at `start`.
@@ -298,26 +298,26 @@ pub unsafe extern "C" fn z_view_slice_from_buf(
 
 /// Borrows view slice.
 #[no_mangle]
-pub extern "C" fn z_view_slice_loan(this: &z_view_slice_t) -> &z_loaned_slice_t {
-    this.as_rust_type_ref().as_loaned_c_type_ref()
+pub extern "C" fn z_view_slice_loan(this_: &z_view_slice_t) -> &z_loaned_slice_t {
+    this_.as_rust_type_ref().as_loaned_c_type_ref()
 }
 
 /// @return ``true`` if the slice is not empty, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_view_slice_is_empty(this: &z_view_slice_t) -> bool {
-    this.as_rust_type_ref().is_empty()
+pub extern "C" fn z_view_slice_is_empty(this_: &z_view_slice_t) -> bool {
+    this_.as_rust_type_ref().is_empty()
 }
 
 /// Constructs an empty `z_owned_slice_t`.
 #[no_mangle]
-pub extern "C" fn z_slice_empty(this: &mut MaybeUninit<z_owned_slice_t>) {
-    this.as_rust_type_mut_uninit().write(CSliceOwned::default());
+pub extern "C" fn z_slice_empty(this_: &mut MaybeUninit<z_owned_slice_t>) {
+    this_.as_rust_type_mut_uninit().write(CSliceOwned::default());
 }
 
 /// Constructs an empty `z_owned_slice_t`.
 #[no_mangle]
-pub extern "C" fn z_slice_null(this: &mut MaybeUninit<z_owned_slice_t>) {
-    z_slice_empty(this);
+pub extern "C" fn z_slice_null(this_: &mut MaybeUninit<z_owned_slice_t>) {
+    z_slice_empty(this_);
 }
 
 /// Frees the memory and invalidates the slice.
@@ -329,39 +329,39 @@ pub unsafe extern "C" fn z_slice_drop(this_:&mut z_moved_slice_t) {
 
 /// Borrows slice.
 #[no_mangle]
-pub extern "C" fn z_slice_loan(this: &z_owned_slice_t) -> &z_loaned_slice_t {
-    this.as_rust_type_ref().as_loaned_c_type_ref()
+pub extern "C" fn z_slice_loan(this_: &z_owned_slice_t) -> &z_loaned_slice_t {
+    this_.as_rust_type_ref().as_loaned_c_type_ref()
 }
 
 /// Constructs an owned copy of a slice.
 #[no_mangle]
-pub extern "C" fn z_slice_clone(dst: &mut MaybeUninit<z_owned_slice_t>, this: &z_loaned_slice_t) {
+pub extern "C" fn z_slice_clone(dst: &mut MaybeUninit<z_owned_slice_t>, this_: &z_loaned_slice_t) {
     dst.as_rust_type_mut_uninit()
-        .write(this.as_rust_type_ref().clone_to_owned());
+        .write(this_.as_rust_type_ref().clone_to_owned());
 }
 
 /// @return ``true`` if slice is not empty, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_slice_check(this: &z_owned_slice_t) -> bool {
-    !this.as_rust_type_ref().is_empty()
+pub extern "C" fn z_slice_check(this_: &z_owned_slice_t) -> bool {
+    !this_.as_rust_type_ref().is_empty()
 }
 
 /// @return the length of the slice.
 #[no_mangle]
-pub extern "C" fn z_slice_len(this: &z_loaned_slice_t) -> usize {
-    this.as_rust_type_ref().len()
+pub extern "C" fn z_slice_len(this_: &z_loaned_slice_t) -> usize {
+    this_.as_rust_type_ref().len()
 }
 
 /// @return the pointer to the slice data.
 #[no_mangle]
-pub extern "C" fn z_slice_data(this: &z_loaned_slice_t) -> *const u8 {
-    this.as_rust_type_ref().data()
+pub extern "C" fn z_slice_data(this_: &z_loaned_slice_t) -> *const u8 {
+    this_.as_rust_type_ref().data()
 }
 
 /// @return ``true`` if slice is empty, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_slice_is_empty(this: &z_loaned_slice_t) -> bool {
-    this.as_rust_type_ref().is_empty()
+pub extern "C" fn z_slice_is_empty(this_: &z_loaned_slice_t) -> bool {
+    this_.as_rust_type_ref().is_empty()
 }
 
 /// Constructs a slice by copying a `len` bytes long sequence starting at `start`.
@@ -536,48 +536,48 @@ pub unsafe extern "C" fn z_string_drop(this_: &mut z_moved_string_t) {
 
 /// @return ``true`` if `this_` is a valid string, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_string_check(this: &z_owned_string_t) -> bool {
-    !this.as_rust_type_ref().is_empty()
+pub extern "C" fn z_string_check(this_: &z_owned_string_t) -> bool {
+    !this_.as_rust_type_ref().is_empty()
 }
 
 /// Constructs owned string in a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_string_null(this: &mut MaybeUninit<z_owned_string_t>) {
-    this.as_rust_type_mut_uninit()
+pub extern "C" fn z_string_null(this_: &mut MaybeUninit<z_owned_string_t>) {
+    this_.as_rust_type_mut_uninit()
         .write(CStringOwned::default());
 }
 
 /// @return ``true`` if view string is valid, ``false`` if it is in a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_view_string_is_empty(this: &z_view_string_t) -> bool {
-    this.as_rust_type_ref().is_empty()
+pub extern "C" fn z_view_string_is_empty(this_: &z_view_string_t) -> bool {
+    this_.as_rust_type_ref().is_empty()
 }
 
 /// Constructs an empty owned string.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_string_empty(this: &mut MaybeUninit<z_owned_string_t>) {
-    this.as_rust_type_mut_uninit()
+pub unsafe extern "C" fn z_string_empty(this_: &mut MaybeUninit<z_owned_string_t>) {
+    this_.as_rust_type_mut_uninit()
         .write(CStringOwned::default());
 }
 
 /// Constructs an empty view string.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_view_string_empty(this: &mut MaybeUninit<z_view_string_t>) {
-    this.as_rust_type_mut_uninit().write(CStringView::default());
+pub unsafe extern "C" fn z_view_string_empty(this_: &mut MaybeUninit<z_view_string_t>) {
+    this_.as_rust_type_mut_uninit().write(CStringView::default());
 }
 
 /// Borrows string.
 #[no_mangle]
-pub extern "C" fn z_string_loan(this: &z_owned_string_t) -> &z_loaned_string_t {
-    this.as_rust_type_ref().as_loaned_c_type_ref()
+pub extern "C" fn z_string_loan(this_: &z_owned_string_t) -> &z_loaned_string_t {
+    this_.as_rust_type_ref().as_loaned_c_type_ref()
 }
 
 /// Borrows view string.
 #[no_mangle]
-pub extern "C" fn z_view_string_loan(this: &z_view_string_t) -> &z_loaned_string_t {
-    this.as_rust_type_ref().as_loaned_c_type_ref()
+pub extern "C" fn z_view_string_loan(this_: &z_view_string_t) -> &z_loaned_string_t {
+    this_.as_rust_type_ref().as_loaned_c_type_ref()
 }
 
 /// Constructs an owned string by copying `str` into it (including terminating 0), using `strlen` (this should therefore not be used with untrusted inputs).
@@ -586,10 +586,10 @@ pub extern "C" fn z_view_string_loan(this: &z_view_string_t) -> &z_loaned_string
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_string_copy_from_str(
-    this: &mut MaybeUninit<z_owned_string_t>,
+    this_: &mut MaybeUninit<z_owned_string_t>,
     str: *const libc::c_char,
 ) -> z_result_t {
-    z_string_copy_from_substr(this, str, strlen(str))
+    z_string_copy_from_substr(this_, str, strlen(str))
 }
 
 /// Constructs an owned string by copying a `str` substring of length `len`.
@@ -689,14 +689,14 @@ pub unsafe extern "C" fn z_view_string_from_substr(
 
 /// @return the length of the string (without terminating 0 character).
 #[no_mangle]
-pub extern "C" fn z_string_len(this: &z_loaned_string_t) -> usize {
-    this.as_rust_type_ref().len()
+pub extern "C" fn z_string_len(this_: &z_loaned_string_t) -> usize {
+    this_.as_rust_type_ref().len()
 }
 
 /// @return the pointer of the string data.
 #[no_mangle]
-pub extern "C" fn z_string_data(this: &z_loaned_string_t) -> *const libc::c_char {
-    this.as_rust_type_ref().data() as _
+pub extern "C" fn z_string_data(this_: &z_loaned_string_t) -> *const libc::c_char {
+    this_.as_rust_type_ref().data() as _
 }
 
 /// Constructs an owned copy of a string.
@@ -712,14 +712,14 @@ pub extern "C" fn z_string_clone(
 
 // Converts loaned string into loaned slice (with terminating 0 character).
 #[no_mangle]
-pub extern "C" fn z_string_as_slice(this: &z_loaned_string_t) -> &z_loaned_slice_t {
-    this.as_rust_type_ref().as_ref().as_loaned_c_type_ref()
+pub extern "C" fn z_string_as_slice(this_: &z_loaned_string_t) -> &z_loaned_slice_t {
+    this_.as_rust_type_ref().as_ref().as_loaned_c_type_ref()
 }
 
 /// @return ``true`` if string is empty, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_string_is_empty(this: &z_loaned_string_t) -> bool {
-    this.as_rust_type_ref().is_empty()
+pub extern "C" fn z_string_is_empty(this_: &z_loaned_string_t) -> bool {
+    this_.as_rust_type_ref().is_empty()
 }
 
 pub use crate::opaque_types::{
@@ -733,20 +733,20 @@ decl_c_type!(
 
 /// Constructs a new empty string array.
 #[no_mangle]
-pub extern "C" fn z_string_array_new(this: &mut MaybeUninit<z_owned_string_array_t>) {
-    this.as_rust_type_mut_uninit().write(Some(ZVector::new()));
+pub extern "C" fn z_string_array_new(this_: &mut MaybeUninit<z_owned_string_array_t>) {
+    this_.as_rust_type_mut_uninit().write(Some(ZVector::new()));
 }
 
 /// Constructs string array in its gravestone state.
 #[no_mangle]
-pub extern "C" fn z_string_array_null(this: &mut MaybeUninit<z_owned_string_array_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_string_array_null(this_: &mut MaybeUninit<z_owned_string_array_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// @return ``true`` if the string array is valid, ``false`` if it is in a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_string_array_check(this: &z_owned_string_array_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_string_array_check(this_: &z_owned_string_array_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Destroys the string array, resetting it to its gravestone value.
@@ -781,14 +781,14 @@ pub unsafe extern "C" fn z_string_array_loan_mut(
 
 /// @return number of elements in the array.
 #[no_mangle]
-pub extern "C" fn z_string_array_len(this: &z_loaned_string_array_t) -> usize {
-    this.as_rust_type_ref().len()
+pub extern "C" fn z_string_array_len(this_: &z_loaned_string_array_t) -> usize {
+    this_.as_rust_type_ref().len()
 }
 
 /// @return ``true`` if the array is empty, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_string_array_is_empty(this: &z_loaned_string_array_t) -> bool {
-    this.as_rust_type_ref().is_empty()
+pub extern "C" fn z_string_array_is_empty(this_: &z_loaned_string_array_t) -> bool {
+    this_.as_rust_type_ref().is_empty()
 }
 
 /// @return the value at the position of index in the string array.

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -265,7 +265,6 @@ decl_c_type!(
     owned(z_owned_slice_t, CSliceOwned),
     loaned(z_loaned_slice_t, CSlice),
     view(z_view_slice_t, CSliceView),
-    moved(z_moved_slice_t)
 );
 
 /// Constructs an empty view slice.
@@ -525,7 +524,6 @@ decl_c_type!(
     owned(z_owned_string_t, CStringOwned),
     loaned(z_loaned_string_t, CString),
     view(z_view_string_t, CStringView),
-    moved(z_moved_string_t)
 );
 
 /// Frees memory and invalidates `z_owned_string_t`, putting it in gravestone state.
@@ -729,7 +727,6 @@ pub type ZVector = Vec<CString>;
 decl_c_type!(
     owned(z_owned_string_array_t, option ZVector),
     loaned(z_loaned_string_array_t),
-    moved(z_moved_string_array_t)
 );
 
 /// Constructs a new empty string array.

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -25,7 +25,7 @@ use libc::strlen;
 
 use crate::{
     result::{self, z_result_t},
-    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
 };
 
 pub struct CSlice {
@@ -323,8 +323,9 @@ pub extern "C" fn z_slice_null(this: &mut MaybeUninit<z_owned_slice_t>) {
 /// Frees the memory and invalidates the slice.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-#[allow(unused_variables)]
-pub unsafe extern "C" fn z_slice_drop(this: z_moved_slice_t) {}
+pub unsafe extern "C" fn z_slice_drop(this_:&mut z_moved_slice_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Borrows slice.
 #[no_mangle]
@@ -529,8 +530,9 @@ decl_c_type!(
 /// Frees memory and invalidates `z_owned_string_t`, putting it in gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-#[allow(unused_variables)]
-pub unsafe extern "C" fn z_string_drop(this: z_moved_string_t) {}
+pub unsafe extern "C" fn z_string_drop(this_: &mut z_moved_string_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// @return ``true`` if `this_` is a valid string, ``false`` if it is in gravestone state.
 #[no_mangle]
@@ -749,8 +751,9 @@ pub extern "C" fn z_string_array_check(this: &z_owned_string_array_t) -> bool {
 
 /// Destroys the string array, resetting it to its gravestone value.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_string_array_drop(this: z_moved_string_array_t) {}
+pub extern "C" fn z_string_array_drop(this_: &mut z_moved_string_array_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Borrows string array.
 #[no_mangle]

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -12,6 +12,9 @@
 //   ZettaScale Zenoh team, <zenoh@zettascale.tech>
 //
 
+#[cfg(feature = "unstable")]
+use crate::transmute::TakeRustType;
+
 use std::{mem::MaybeUninit, ptr::null};
 
 use libc::c_ulong;
@@ -201,8 +204,9 @@ pub unsafe extern "C" fn z_sample_loan(this: &z_owned_sample_t) -> &z_loaned_sam
 
 /// Frees the memory and invalidates the sample, resetting it to a gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_sample_drop(this: z_moved_sample_t) {}
+pub extern "C" fn z_sample_drop(this_: &mut z_moved_sample_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Constructs sample in its gravestone state.
 #[no_mangle]
@@ -535,8 +539,9 @@ pub extern "C" fn z_source_info_loan(this: &z_owned_source_info_t) -> &z_loaned_
 #[cfg(feature = "unstable")]
 /// Frees the memory and invalidates the source info, resetting it to a gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_source_info_drop(this: z_moved_source_info_t) {}
+pub extern "C" fn z_source_info_drop(this_: &mut z_moved_source_info_t) {
+    let _ = this_.take_rust_type();
+}
 
 #[cfg(feature = "unstable")]
 /// Constructs source info in its gravestone state.

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -12,9 +12,9 @@
 //   ZettaScale Zenoh team, <zenoh@zettascale.tech>
 //
 
-use crate::transmute::TakeRustType;
-use libc::c_ulong;
 use std::{mem::MaybeUninit, ptr::null};
+
+use libc::c_ulong;
 use zenoh::{
     qos::{CongestionControl, Priority},
     query::{ConsolidationMode, QueryTarget},
@@ -36,7 +36,7 @@ use crate::z_id_t;
 use crate::z_moved_source_info_t;
 use crate::{
     result,
-    transmute::{CTypeRef, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{CTypeRef, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_bytes_t, z_loaned_encoding_t, z_loaned_keyexpr_t, z_loaned_session_t,
 };
 

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -103,7 +103,6 @@ pub use crate::opaque_types::{z_moved_sample_t, z_owned_sample_t};
 decl_c_type!(
     owned(z_owned_sample_t, option Sample),
     loaned(z_loaned_sample_t),
-    moved(z_moved_sample_t)
 );
 
 /// Returns the key expression of the sample.
@@ -482,7 +481,6 @@ pub use crate::opaque_types::{z_loaned_source_info_t, z_owned_source_info_t};
 decl_c_type!(
     owned(z_owned_source_info_t, SourceInfo),
     loaned(z_loaned_source_info_t, SourceInfo),
-    moved(z_moved_source_info_t)
 );
 
 #[cfg(feature = "unstable")]

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -12,12 +12,9 @@
 //   ZettaScale Zenoh team, <zenoh@zettascale.tech>
 //
 
-#[cfg(feature = "unstable")]
 use crate::transmute::TakeRustType;
-
-use std::{mem::MaybeUninit, ptr::null};
-
 use libc::c_ulong;
+use std::{mem::MaybeUninit, ptr::null};
 use zenoh::{
     qos::{CongestionControl, Priority},
     query::{ConsolidationMode, QueryTarget},
@@ -155,7 +152,10 @@ pub extern "C" fn z_sample_attachment(this_: &z_loaned_sample_t) -> *const z_loa
 /// Returns the sample source_info.
 #[no_mangle]
 pub extern "C" fn z_sample_source_info(this_: &z_loaned_sample_t) -> &z_loaned_source_info_t {
-    this_.as_rust_type_ref().source_info().as_loaned_c_type_ref()
+    this_
+        .as_rust_type_ref()
+        .source_info()
+        .as_loaned_c_type_ref()
 }
 
 /// Constructs an owned shallow copy of the sample (i.e. all modficiations applied to the copy, might be visible in the original) in provided uninitilized memory location.
@@ -196,7 +196,8 @@ pub extern "C" fn z_sample_check(this_: &z_owned_sample_t) -> bool {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_sample_loan(this_: &z_owned_sample_t) -> &z_loaned_sample_t {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -90,15 +90,15 @@ pub extern "C" fn z_timestamp_new(
 
 /// Returns NPT64 time associated with this timestamp.
 #[no_mangle]
-pub extern "C" fn z_timestamp_ntp64_time(this: &z_timestamp_t) -> u64 {
-    this.as_rust_type_ref().get_time().0
+pub extern "C" fn z_timestamp_ntp64_time(this_: &z_timestamp_t) -> u64 {
+    this_.as_rust_type_ref().get_time().0
 }
 
 #[cfg(feature = "unstable")]
 /// Returns id associated with this timestamp.
 #[no_mangle]
-pub extern "C" fn z_timestamp_id(this: &z_timestamp_t) -> z_id_t {
-    this.as_rust_type_ref().get_id().to_le_bytes().into()
+pub extern "C" fn z_timestamp_id(this_: &z_timestamp_t) -> z_id_t {
+    this_.as_rust_type_ref().get_id().to_le_bytes().into()
 }
 
 use crate::opaque_types::z_loaned_sample_t;
@@ -110,31 +110,31 @@ decl_c_type!(
 
 /// Returns the key expression of the sample.
 #[no_mangle]
-pub extern "C" fn z_sample_keyexpr(this: &z_loaned_sample_t) -> &z_loaned_keyexpr_t {
-    this.as_rust_type_ref().key_expr().as_loaned_c_type_ref()
+pub extern "C" fn z_sample_keyexpr(this_: &z_loaned_sample_t) -> &z_loaned_keyexpr_t {
+    this_.as_rust_type_ref().key_expr().as_loaned_c_type_ref()
 }
 /// Returns the encoding associated with the sample data.
 #[no_mangle]
-pub extern "C" fn z_sample_encoding(this: &z_loaned_sample_t) -> &z_loaned_encoding_t {
-    this.as_rust_type_ref().encoding().as_loaned_c_type_ref()
+pub extern "C" fn z_sample_encoding(this_: &z_loaned_sample_t) -> &z_loaned_encoding_t {
+    this_.as_rust_type_ref().encoding().as_loaned_c_type_ref()
 }
 /// Returns the sample payload data.
 #[no_mangle]
-pub extern "C" fn z_sample_payload(this: &z_loaned_sample_t) -> &z_loaned_bytes_t {
-    this.as_rust_type_ref().payload().as_loaned_c_type_ref()
+pub extern "C" fn z_sample_payload(this_: &z_loaned_sample_t) -> &z_loaned_bytes_t {
+    this_.as_rust_type_ref().payload().as_loaned_c_type_ref()
 }
 
 /// Returns the sample kind.
 #[no_mangle]
-pub extern "C" fn z_sample_kind(this: &z_loaned_sample_t) -> z_sample_kind_t {
-    this.as_rust_type_ref().kind().into()
+pub extern "C" fn z_sample_kind(this_: &z_loaned_sample_t) -> z_sample_kind_t {
+    this_.as_rust_type_ref().kind().into()
 }
 /// Returns the sample timestamp.
 ///
 /// Will return `NULL`, if sample is not associated with a timestamp.
 #[no_mangle]
-pub extern "C" fn z_sample_timestamp(this: &z_loaned_sample_t) -> Option<&z_timestamp_t> {
-    if let Some(t) = this.as_rust_type_ref().timestamp() {
+pub extern "C" fn z_sample_timestamp(this_: &z_loaned_sample_t) -> Option<&z_timestamp_t> {
+    if let Some(t) = this_.as_rust_type_ref().timestamp() {
         Some(t.as_ctype_ref())
     } else {
         None
@@ -145,8 +145,8 @@ pub extern "C" fn z_sample_timestamp(this: &z_loaned_sample_t) -> Option<&z_time
 ///
 /// Returns `NULL`, if sample does not contain any attachment.
 #[no_mangle]
-pub extern "C" fn z_sample_attachment(this: &z_loaned_sample_t) -> *const z_loaned_bytes_t {
-    match this.as_rust_type_ref().attachment() {
+pub extern "C" fn z_sample_attachment(this_: &z_loaned_sample_t) -> *const z_loaned_bytes_t {
+    match this_.as_rust_type_ref().attachment() {
         Some(attachment) => attachment.as_loaned_c_type_ref() as *const _,
         None => null(),
     }
@@ -154,8 +154,8 @@ pub extern "C" fn z_sample_attachment(this: &z_loaned_sample_t) -> *const z_loan
 #[cfg(feature = "unstable")]
 /// Returns the sample source_info.
 #[no_mangle]
-pub extern "C" fn z_sample_source_info(this: &z_loaned_sample_t) -> &z_loaned_source_info_t {
-    this.as_rust_type_ref().source_info().as_loaned_c_type_ref()
+pub extern "C" fn z_sample_source_info(this_: &z_loaned_sample_t) -> &z_loaned_source_info_t {
+    this_.as_rust_type_ref().source_info().as_loaned_c_type_ref()
 }
 
 /// Constructs an owned shallow copy of the sample (i.e. all modficiations applied to the copy, might be visible in the original) in provided uninitilized memory location.
@@ -170,33 +170,33 @@ pub extern "C" fn z_sample_clone(
 
 /// Returns sample qos priority value.
 #[no_mangle]
-pub extern "C" fn z_sample_priority(this: &z_loaned_sample_t) -> z_priority_t {
-    this.as_rust_type_ref().priority().into()
+pub extern "C" fn z_sample_priority(this_: &z_loaned_sample_t) -> z_priority_t {
+    this_.as_rust_type_ref().priority().into()
 }
 
 /// Returns whether sample qos express flag was set or not.
 #[no_mangle]
-pub extern "C" fn z_sample_express(this: &z_loaned_sample_t) -> bool {
-    this.as_rust_type_ref().express()
+pub extern "C" fn z_sample_express(this_: &z_loaned_sample_t) -> bool {
+    this_.as_rust_type_ref().express()
 }
 
 /// Returns sample qos congestion control value.
 #[no_mangle]
-pub extern "C" fn z_sample_congestion_control(this: &z_loaned_sample_t) -> z_congestion_control_t {
-    this.as_rust_type_ref().congestion_control().into()
+pub extern "C" fn z_sample_congestion_control(this_: &z_loaned_sample_t) -> z_congestion_control_t {
+    this_.as_rust_type_ref().congestion_control().into()
 }
 
 /// Returns ``true`` if sample is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_sample_check(this: &z_owned_sample_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_sample_check(this_: &z_owned_sample_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Borrows sample.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_sample_loan(this: &z_owned_sample_t) -> &z_loaned_sample_t {
-    this.as_rust_type_ref()
+pub unsafe extern "C" fn z_sample_loan(this_: &z_owned_sample_t) -> &z_loaned_sample_t {
+    this_.as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -210,8 +210,8 @@ pub extern "C" fn z_sample_drop(this_: &mut z_moved_sample_t) {
 
 /// Constructs sample in its gravestone state.
 #[no_mangle]
-pub extern "C" fn z_sample_null(this: &mut MaybeUninit<z_owned_sample_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_sample_null(this_: &mut MaybeUninit<z_owned_sample_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// The locality of samples to be received by subscribers or targeted by publishers.
@@ -470,14 +470,14 @@ decl_c_type!(copy(z_entity_global_id_t, EntityGlobalId));
 #[cfg(feature = "unstable")]
 /// Returns the zenoh id of entity global id.
 #[no_mangle]
-pub extern "C" fn z_entity_global_id_zid(this: &z_entity_global_id_t) -> z_id_t {
-    this.as_rust_type_ref().zid().into_c_type()
+pub extern "C" fn z_entity_global_id_zid(this_: &z_entity_global_id_t) -> z_id_t {
+    this_.as_rust_type_ref().zid().into_c_type()
 }
 #[cfg(feature = "unstable")]
 /// Returns the entity id of the entity global id.
 #[no_mangle]
-pub extern "C" fn z_entity_global_id_eid(this: &z_entity_global_id_t) -> u32 {
-    this.as_rust_type_ref().eid()
+pub extern "C" fn z_entity_global_id_eid(this_: &z_entity_global_id_t) -> u32 {
+    this_.as_rust_type_ref().eid()
 }
 #[cfg(feature = "unstable")]
 pub use crate::opaque_types::{z_loaned_source_info_t, z_owned_source_info_t};
@@ -507,8 +507,8 @@ pub extern "C" fn z_source_info_new(
 #[cfg(feature = "unstable")]
 /// Returns the source_id of the source info.
 #[no_mangle]
-pub extern "C" fn z_source_info_id(this: &z_loaned_source_info_t) -> z_entity_global_id_t {
-    match this.as_rust_type_ref().source_id {
+pub extern "C" fn z_source_info_id(this_: &z_loaned_source_info_t) -> z_entity_global_id_t {
+    match this_.as_rust_type_ref().source_id {
         Some(source_id) => source_id,
         None => EntityGlobalId::default(),
     }
@@ -518,22 +518,22 @@ pub extern "C" fn z_source_info_id(this: &z_loaned_source_info_t) -> z_entity_gl
 #[cfg(feature = "unstable")]
 /// Returns the source_sn of the source info.
 #[no_mangle]
-pub extern "C" fn z_source_info_sn(this: &z_loaned_source_info_t) -> u64 {
-    this.as_rust_type_ref().source_sn.unwrap_or(0)
+pub extern "C" fn z_source_info_sn(this_: &z_loaned_source_info_t) -> u64 {
+    this_.as_rust_type_ref().source_sn.unwrap_or(0)
 }
 
 #[cfg(feature = "unstable")]
 /// Returns ``true`` if source info is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_source_info_check(this: &z_owned_source_info_t) -> bool {
-    this.as_rust_type_ref().source_id.is_some() || this.as_rust_type_ref().source_sn.is_some()
+pub extern "C" fn z_source_info_check(this_: &z_owned_source_info_t) -> bool {
+    this_.as_rust_type_ref().source_id.is_some() || this_.as_rust_type_ref().source_sn.is_some()
 }
 
 #[cfg(feature = "unstable")]
 /// Borrows source info.
 #[no_mangle]
-pub extern "C" fn z_source_info_loan(this: &z_owned_source_info_t) -> &z_loaned_source_info_t {
-    this.as_rust_type_ref().as_loaned_c_type_ref()
+pub extern "C" fn z_source_info_loan(this_: &z_owned_source_info_t) -> &z_loaned_source_info_t {
+    this_.as_rust_type_ref().as_loaned_c_type_ref()
 }
 
 #[cfg(feature = "unstable")]
@@ -546,6 +546,6 @@ pub extern "C" fn z_source_info_drop(this_: &mut z_moved_source_info_t) {
 #[cfg(feature = "unstable")]
 /// Constructs source info in its gravestone state.
 #[no_mangle]
-pub extern "C" fn z_source_info_null(this: &mut MaybeUninit<z_owned_source_info_t>) {
-    this.as_rust_type_mut_uninit().write(SourceInfo::default());
+pub extern "C" fn z_source_info_null(this_: &mut MaybeUninit<z_owned_source_info_t>) {
+    this_.as_rust_type_mut_uninit().write(SourceInfo::default());
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ use zenoh::config::{Config, Locator, ValidatedMap, WhatAmI};
 
 use crate::{
     result::{self, z_result_t, Z_OK},
-    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_owned_string_t, z_string_copy_from_substr, z_string_null,
 };
 
@@ -220,8 +220,10 @@ pub unsafe extern "C" fn zc_config_insert_json_from_substr(
 
 /// Frees `config`, and resets it to its gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_config_drop(this: z_moved_config_t) {}
+pub extern "C" fn z_config_drop(this_: &mut z_moved_config_t) {
+    let _ = this_.take_rust_type();
+}
+
 /// Returns ``true`` if config is valid, ``false`` if it is in a gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,32 +73,32 @@ decl_c_type!(
 
 /// Borrows config.
 #[no_mangle]
-pub extern "C" fn z_config_loan(this: &'static z_owned_config_t) -> &z_loaned_config_t {
-    let this = this.as_rust_type_ref();
+pub extern "C" fn z_config_loan(this_: &'static z_owned_config_t) -> &z_loaned_config_t {
+    let this = this_.as_rust_type_ref();
     let this = unsafe { this.as_ref().unwrap_unchecked() };
     this.as_loaned_c_type_ref()
 }
 
 /// Mutably borrows config.
 #[no_mangle]
-pub extern "C" fn z_config_loan_mut(this: &mut z_owned_config_t) -> &mut z_loaned_config_t {
-    let this = this.as_rust_type_mut();
+pub extern "C" fn z_config_loan_mut(this_: &mut z_owned_config_t) -> &mut z_loaned_config_t {
+    let this = this_.as_rust_type_mut();
     let this = unsafe { this.as_mut().unwrap_unchecked() };
     this.as_loaned_c_type_mut()
 }
 
 /// Constructs a new empty configuration.
 #[no_mangle]
-pub extern "C" fn z_config_default(this: &mut MaybeUninit<z_owned_config_t>) -> result::z_result_t {
-    this.as_rust_type_mut_uninit()
+pub extern "C" fn z_config_default(this_: &mut MaybeUninit<z_owned_config_t>) -> result::z_result_t {
+    this_.as_rust_type_mut_uninit()
         .write(Some(Config::default()));
     Z_OK
 }
 
 /// Constructs config in its gravestone state.
 #[no_mangle]
-pub extern "C" fn z_config_null(this: &mut MaybeUninit<z_owned_config_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_config_null(this_: &mut MaybeUninit<z_owned_config_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Clones the config into provided uninitialized memory location.
@@ -227,8 +227,8 @@ pub extern "C" fn z_config_drop(this_: &mut z_moved_config_t) {
 /// Returns ``true`` if config is valid, ``false`` if it is in a gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_config_check(this: &z_owned_config_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_config_check(this_: &z_owned_config_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Reads a configuration from a JSON-serialized string, such as '{mode:"client",connect:{endpoints:["tcp/127.0.0.1:7447"]}}'.
@@ -337,8 +337,8 @@ pub unsafe extern "C" fn zc_config_from_env(
 /// Constructs a default peer mode configuration.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_config_peer(this: &mut MaybeUninit<z_owned_config_t>) -> result::z_result_t {
-    this.as_rust_type_mut_uninit()
+pub extern "C" fn z_config_peer(this_: &mut MaybeUninit<z_owned_config_t>) -> result::z_result_t {
+    this_.as_rust_type_mut_uninit()
         .write(Some(zenoh::config::peer()));
     Z_OK
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,8 +89,11 @@ pub extern "C" fn z_config_loan_mut(this_: &mut z_owned_config_t) -> &mut z_loan
 
 /// Constructs a new empty configuration.
 #[no_mangle]
-pub extern "C" fn z_config_default(this_: &mut MaybeUninit<z_owned_config_t>) -> result::z_result_t {
-    this_.as_rust_type_mut_uninit()
+pub extern "C" fn z_config_default(
+    this_: &mut MaybeUninit<z_owned_config_t>,
+) -> result::z_result_t {
+    this_
+        .as_rust_type_mut_uninit()
         .write(Some(Config::default()));
     Z_OK
 }
@@ -338,7 +341,8 @@ pub unsafe extern "C" fn zc_config_from_env(
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub extern "C" fn z_config_peer(this_: &mut MaybeUninit<z_owned_config_t>) -> result::z_result_t {
-    this_.as_rust_type_mut_uninit()
+    this_
+        .as_rust_type_mut_uninit()
         .write(Some(zenoh::config::peer()));
     Z_OK
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,7 +69,6 @@ pub use crate::opaque_types::{z_loaned_config_t, z_moved_config_t, z_owned_confi
 decl_c_type!(
     owned(z_owned_config_t, option Config),
     loaned(z_loaned_config_t),
-    moved(z_moved_config_t)
 );
 
 /// Borrows config.

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -138,8 +138,8 @@ pub extern "C" fn z_encoding_loan_default() -> &'static z_loaned_encoding_t {
 
 /// Constructs a default `z_owned_encoding_t`.
 #[no_mangle]
-pub extern "C" fn z_encoding_null(this: &mut MaybeUninit<z_owned_encoding_t>) {
-    this.as_rust_type_mut_uninit().write(Encoding::default());
+pub extern "C" fn z_encoding_null(this_: &mut MaybeUninit<z_owned_encoding_t>) {
+    this_.as_rust_type_mut_uninit().write(Encoding::default());
 }
 
 /// Frees the memory and resets the encoding it to its default value.
@@ -150,20 +150,20 @@ pub extern "C" fn z_encoding_drop(this_: &mut z_moved_encoding_t) {
 
 /// Returns ``true`` if encoding is in non-default state, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_encoding_check(this: &'static z_owned_encoding_t) -> bool {
-    *this.as_rust_type_ref() != Encoding::default()
+pub extern "C" fn z_encoding_check(this_: &'static z_owned_encoding_t) -> bool {
+    *this_.as_rust_type_ref() != Encoding::default()
 }
 
 /// Borrows encoding.
 #[no_mangle]
-pub extern "C" fn z_encoding_loan(this: &z_owned_encoding_t) -> &z_loaned_encoding_t {
-    this.as_rust_type_ref().as_loaned_c_type_ref()
+pub extern "C" fn z_encoding_loan(this_: &z_owned_encoding_t) -> &z_loaned_encoding_t {
+    this_.as_rust_type_ref().as_loaned_c_type_ref()
 }
 
 /// Mutably borrows encoding.
 #[no_mangle]
-pub extern "C" fn z_encoding_loan_mut(this: &mut z_owned_encoding_t) -> &mut z_loaned_encoding_t {
-    this.as_rust_type_mut().as_loaned_c_type_mut()
+pub extern "C" fn z_encoding_loan_mut(this_: &mut z_owned_encoding_t) -> &mut z_loaned_encoding_t {
+    this_.as_rust_type_mut().as_loaned_c_type_mut()
 }
 
 /// Constructs an owned copy of the encoding in provided uninitilized memory location.

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -26,7 +26,7 @@ use zenoh::bytes::Encoding;
 pub use crate::opaque_types::{z_loaned_encoding_t, z_owned_encoding_t};
 use crate::{
     result::{self, z_result_t},
-    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_moved_encoding_t, z_owned_string_t, z_string_copy_from_substr,
 };
 
@@ -144,8 +144,9 @@ pub extern "C" fn z_encoding_null(this: &mut MaybeUninit<z_owned_encoding_t>) {
 
 /// Frees the memory and resets the encoding it to its default value.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_encoding_drop(this: z_moved_encoding_t) {}
+pub extern "C" fn z_encoding_drop(this_: &mut z_moved_encoding_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Returns ``true`` if encoding is in non-default state, ``false`` otherwise.
 #[no_mangle]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -33,7 +33,6 @@ use crate::{
 decl_c_type!(
     owned(z_owned_encoding_t, Encoding),
     loaned(z_loaned_encoding_t, Encoding),
-    moved(z_moved_encoding_t)
 );
 
 /// Constructs a `z_owned_encoding_t` from a specified substring.

--- a/src/get.rs
+++ b/src/get.rs
@@ -29,7 +29,7 @@ use zenoh::{
 };
 
 use crate::{
-    result, transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit}, z_closure_reply_call, z_closure_reply_loan, z_congestion_control_t, z_consolidation_mode_t, z_loaned_bytes_t, z_loaned_encoding_t, z_loaned_keyexpr_t, z_loaned_sample_t, z_loaned_session_t, z_moved_bytes_t, z_moved_closure_reply_t, z_moved_encoding_t, z_priority_t, z_query_target_t
+    result, transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType}, z_closure_reply_call, z_closure_reply_loan, z_congestion_control_t, z_consolidation_mode_t, z_loaned_bytes_t, z_loaned_encoding_t, z_loaned_keyexpr_t, z_loaned_sample_t, z_loaned_session_t, z_moved_bytes_t, z_moved_closure_reply_t, z_moved_encoding_t, z_priority_t, z_query_target_t
 };
 #[cfg(feature = "unstable")]
 use crate::{
@@ -246,7 +246,7 @@ pub unsafe extern "C" fn z_get(
     callback: &mut z_moved_closure_reply_t,
     options: Option<&mut z_get_options_t>,
 ) -> result::z_result_t {
-    let callback = callback.into_rust_type();
+    let callback = callback.take_rust_type();
     let p = if parameters.is_null() {
         ""
     } else {
@@ -257,17 +257,17 @@ pub unsafe extern "C" fn z_get(
     let mut get = session.get(Selector::from((key_expr, p)));
     if let Some(options) = options {
         if let Some(payload) = options.payload.take() {
-            get = get.payload(payload.into_rust_type());
+            get = get.payload(payload.take_rust_type());
         }
         if let Some(encoding) = options.encoding.take() {
-            get = get.encoding(encoding.into_rust_type());
+            get = get.encoding(encoding.take_rust_type());
         }
         #[cfg(feature = "unstable")]
         if let Some(source_info) = options.source_info.take() {
-            get = get.source_info(source_info.into_rust_type());
+            get = get.source_info(source_info.take_rust_type());
         }
         if let Some(attachment) = options.attachment.take() {
-            get = get.attachment(attachment.into_rust_type());
+            get = get.attachment(attachment.take_rust_type());
         }
 
         get = get

--- a/src/get.rs
+++ b/src/get.rs
@@ -71,34 +71,34 @@ decl_c_type!(
 
 /// Constructs an empty `z_owned_reply_err_t`.
 #[no_mangle]
-pub extern "C" fn z_reply_err_null(this: &mut MaybeUninit<z_owned_reply_err_t>) {
-    this.as_rust_type_mut_uninit()
+pub extern "C" fn z_reply_err_null(this_: &mut MaybeUninit<z_owned_reply_err_t>) {
+    this_.as_rust_type_mut_uninit()
         .write(ReplyErrorNewtype::default());
 }
 
 /// Returns ``true`` if reply error is in non-default state, ``false`` otherwise.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_reply_err_check(this: &'static z_owned_reply_err_t) -> bool {
-    !this.as_rust_type_ref().payload().is_empty()
+pub extern "C" fn z_reply_err_check(this_: &'static z_owned_reply_err_t) -> bool {
+    !this_.as_rust_type_ref().payload().is_empty()
 }
 
 /// Returns reply error payload.
 #[no_mangle]
-pub extern "C" fn z_reply_err_payload(this: &z_loaned_reply_err_t) -> &z_loaned_bytes_t {
-    this.as_rust_type_ref().payload().as_loaned_c_type_ref()
+pub extern "C" fn z_reply_err_payload(this_: &z_loaned_reply_err_t) -> &z_loaned_bytes_t {
+    this_.as_rust_type_ref().payload().as_loaned_c_type_ref()
 }
 
 /// Returns reply error encoding.
 #[no_mangle]
-pub extern "C" fn z_reply_err_encoding(this: &z_loaned_reply_err_t) -> &z_loaned_encoding_t {
-    this.as_rust_type_ref().encoding().as_loaned_c_type_ref()
+pub extern "C" fn z_reply_err_encoding(this_: &z_loaned_reply_err_t) -> &z_loaned_encoding_t {
+    this_.as_rust_type_ref().encoding().as_loaned_c_type_ref()
 }
 
 /// Borrows reply error.
 #[no_mangle]
-pub extern "C" fn z_reply_err_loan(this: &z_owned_reply_err_t) -> &z_loaned_reply_err_t {
-    this.as_rust_type_ref().as_loaned_c_type_ref()
+pub extern "C" fn z_reply_err_loan(this_: &z_owned_reply_err_t) -> &z_loaned_reply_err_t {
+    this_.as_rust_type_ref().as_loaned_c_type_ref()
 }
 
 /// Frees the memory and resets the reply error it to its default value.
@@ -116,8 +116,8 @@ decl_c_type!(
 /// Returns ``true`` if reply contains a valid response, ``false`` otherwise (in this case it contains a errror value).
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_reply_is_ok(this: &z_loaned_reply_t) -> bool {
-    this.as_rust_type_ref().result().is_ok()
+pub unsafe extern "C" fn z_reply_is_ok(this_: &z_loaned_reply_t) -> bool {
+    this_.as_rust_type_ref().result().is_ok()
 }
 
 /// Yields the contents of the reply by asserting it indicates a success.
@@ -125,8 +125,8 @@ pub unsafe extern "C" fn z_reply_is_ok(this: &z_loaned_reply_t) -> bool {
 /// Returns `NULL` if reply does not contain a sample (i. e. if `z_reply_is_ok` returns ``false``).
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_reply_ok(this: &z_loaned_reply_t) -> *const z_loaned_sample_t {
-    match this.as_rust_type_ref().result() {
+pub unsafe extern "C" fn z_reply_ok(this_: &z_loaned_reply_t) -> *const z_loaned_sample_t {
+    match this_.as_rust_type_ref().result() {
         Ok(sample) => sample.as_loaned_c_type_ref() as _,
         Err(_) => null(),
     }
@@ -137,8 +137,8 @@ pub unsafe extern "C" fn z_reply_ok(this: &z_loaned_reply_t) -> *const z_loaned_
 /// Returns `NULL` if reply does not contain a error  (i. e. if `z_reply_is_ok` returns ``true``).
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_reply_err(this: &z_loaned_reply_t) -> *const z_loaned_reply_err_t {
-    match this.as_rust_type_ref().result() {
+pub unsafe extern "C" fn z_reply_err(this_: &z_loaned_reply_t) -> *const z_loaned_reply_err_t {
+    match this_.as_rust_type_ref().result() {
         Ok(_) => null(),
         Err(v) => std::convert::Into::<&ReplyErrorNewtype>::into(v).as_loaned_c_type_ref(),
     }
@@ -164,14 +164,14 @@ pub unsafe extern "C" fn z_reply_replier_id(
 
 /// Constructs the reply in its gravestone state.
 #[no_mangle]
-pub extern "C" fn z_reply_null(this: &mut MaybeUninit<z_owned_reply_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_reply_null(this_: &mut MaybeUninit<z_owned_reply_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 /// Constructs an owned shallow copy of reply in provided uninitialized memory location.
 #[no_mangle]
-pub extern "C" fn z_reply_clone(dst: &mut MaybeUninit<z_owned_reply_t>, this: &z_loaned_reply_t) {
+pub extern "C" fn z_reply_clone(dst: &mut MaybeUninit<z_owned_reply_t>, this_: &z_loaned_reply_t) {
     dst.as_rust_type_mut_uninit()
-        .write(Some(this.as_rust_type_ref().clone()));
+        .write(Some(this_.as_rust_type_ref().clone()));
 }
 
 /// Options passed to the `z_get()` function.
@@ -208,8 +208,8 @@ pub struct z_get_options_t {
 
 /// Constructs default `z_get_options_t`
 #[no_mangle]
-pub extern "C" fn z_get_options_default(this: &mut MaybeUninit<z_get_options_t>) {
-    this.write(z_get_options_t {
+pub extern "C" fn z_get_options_default(this_: &mut MaybeUninit<z_get_options_t>) {
+    this_.write(z_get_options_t {
         target: QueryTarget::default().into(),
         consolidation: QueryConsolidation::default().into(),
         congestion_control: CongestionControl::default().into(),
@@ -313,15 +313,15 @@ pub extern "C" fn z_reply_drop(this_: &mut z_moved_reply_t) {
 
 /// Returns ``true`` if `reply` is valid, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_reply_check(this: &z_owned_reply_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_reply_check(this_: &z_owned_reply_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Borrows reply.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_reply_loan(this: &z_owned_reply_t) -> &z_loaned_reply_t {
-    this.as_rust_type_ref()
+pub unsafe extern "C" fn z_reply_loan(this_: &z_owned_reply_t) -> &z_loaned_reply_t {
+    this_.as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()

--- a/src/get.rs
+++ b/src/get.rs
@@ -29,7 +29,12 @@ use zenoh::{
 };
 
 use crate::{
-    result, transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType}, z_closure_reply_call, z_closure_reply_loan, z_congestion_control_t, z_consolidation_mode_t, z_loaned_bytes_t, z_loaned_encoding_t, z_loaned_keyexpr_t, z_loaned_sample_t, z_loaned_session_t, z_moved_bytes_t, z_moved_closure_reply_t, z_moved_encoding_t, z_priority_t, z_query_target_t
+    result,
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
+    z_closure_reply_call, z_closure_reply_loan, z_congestion_control_t, z_consolidation_mode_t,
+    z_loaned_bytes_t, z_loaned_encoding_t, z_loaned_keyexpr_t, z_loaned_sample_t,
+    z_loaned_session_t, z_moved_bytes_t, z_moved_closure_reply_t, z_moved_encoding_t, z_priority_t,
+    z_query_target_t,
 };
 #[cfg(feature = "unstable")]
 use crate::{
@@ -72,7 +77,8 @@ decl_c_type!(
 /// Constructs an empty `z_owned_reply_err_t`.
 #[no_mangle]
 pub extern "C" fn z_reply_err_null(this_: &mut MaybeUninit<z_owned_reply_err_t>) {
-    this_.as_rust_type_mut_uninit()
+    this_
+        .as_rust_type_mut_uninit()
         .write(ReplyErrorNewtype::default());
 }
 
@@ -321,7 +327,8 @@ pub extern "C" fn z_reply_check(this_: &z_owned_reply_t) -> bool {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_reply_loan(this_: &z_owned_reply_t) -> &z_loaned_reply_t {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()

--- a/src/get.rs
+++ b/src/get.rs
@@ -103,8 +103,9 @@ pub extern "C" fn z_reply_err_loan(this: &z_owned_reply_err_t) -> &z_loaned_repl
 
 /// Frees the memory and resets the reply error it to its default value.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_reply_err_drop(this: z_moved_reply_err_t) {}
+pub extern "C" fn z_reply_err_drop(this_: &mut z_moved_reply_err_t) {
+    let _ = this_.take_rust_type();
+}
 
 pub use crate::opaque_types::{z_loaned_reply_t, z_moved_reply_t, z_owned_reply_t};
 decl_c_type!(
@@ -306,8 +307,9 @@ pub unsafe extern "C" fn z_get(
 
 /// Frees reply, resetting it to its gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_reply_drop(this: z_moved_reply_t) {}
+pub extern "C" fn z_reply_drop(this_: &mut z_moved_reply_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Returns ``true`` if `reply` is valid, ``false`` otherwise.
 #[no_mangle]

--- a/src/get.rs
+++ b/src/get.rs
@@ -220,11 +220,11 @@ pub extern "C" fn z_get_options_default(this_: &mut MaybeUninit<z_get_options_t>
         priority: Priority::default().into(),
         is_express: false,
         timeout_ms: 0,
-        payload: None.into(),
-        encoding: None.into(),
+        payload: None,
+        encoding: None,
         #[cfg(feature = "unstable")]
-        source_info: None.into(),
-        attachment: None.into(),
+        source_info: None,
+        attachment: None,
     });
 }
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -16,7 +16,7 @@ use zenoh::{prelude::*, session::ZenohId};
 pub use crate::opaque_types::z_id_t;
 use crate::{
     result,
-    transmute::{CTypeRef, IntoCType, IntoRustType, RustTypeRef},
+    transmute::{CTypeRef, IntoCType, RustTypeRef, TakeRustType},
     z_closure_zid_call, z_closure_zid_loan, z_loaned_session_t, z_moved_closure_zid_t,
 };
 decl_c_type!(copy(z_id_t, ZenohId));
@@ -49,12 +49,10 @@ pub unsafe extern "C" fn z_info_zid(session: &z_loaned_session_t) -> z_id_t {
 #[no_mangle]
 pub unsafe extern "C" fn z_info_peers_zid(
     session: &z_loaned_session_t,
-    callback: z_moved_closure_zid_t,
+    callback: &mut z_moved_closure_zid_t,
 ) -> result::z_result_t {
     let session = session.as_rust_type_ref();
-    let Some(callback) = callback.into_rust_type() else {
-        return result::Z_EINVAL;
-    };
+    let callback = callback.take_rust_type();
     for id in session.info().peers_zid().wait() {
         z_closure_zid_call(z_closure_zid_loan(&callback), id.as_ctype_ref());
     }
@@ -71,12 +69,10 @@ pub unsafe extern "C" fn z_info_peers_zid(
 #[no_mangle]
 pub unsafe extern "C" fn z_info_routers_zid(
     session: &z_loaned_session_t,
-    callback: z_moved_closure_zid_t,
+    callback: &mut z_moved_closure_zid_t,
 ) -> result::z_result_t {
     let session = session.as_rust_type_ref();
-    let Some(callback) = callback.into_rust_type() else {
-        return result::Z_EINVAL;
-    };
+    let callback = callback.take_rust_type();
     for id in session.info().routers_zid().wait() {
         z_closure_zid_call(z_closure_zid_loan(&callback), id.as_ctype_ref());
     }

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -34,7 +34,6 @@ decl_c_type! {
     owned(z_owned_keyexpr_t, option KeyExpr<'static>),
     loaned(z_loaned_keyexpr_t),
     view(z_view_keyexpr_t, Option<KeyExpr<'static>>),
-    moved(z_moved_keyexpr_t)
 }
 
 /// Constructs an owned key expression in a gravestone state.

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -127,7 +127,8 @@ pub unsafe extern "C" fn z_keyexpr_from_str_autocanonize(
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_keyexpr_loan(this_: &z_owned_keyexpr_t) -> &z_loaned_keyexpr_t {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -137,7 +138,8 @@ pub unsafe extern "C" fn z_keyexpr_loan(this_: &z_owned_keyexpr_t) -> &z_loaned_
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_view_keyexpr_loan(this_: &z_view_keyexpr_t) -> &z_loaned_keyexpr_t {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -38,14 +38,14 @@ decl_c_type! {
 
 /// Constructs an owned key expression in a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_keyexpr_null(this: &mut MaybeUninit<z_owned_keyexpr_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_keyexpr_null(this_: &mut MaybeUninit<z_owned_keyexpr_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Constructs a view key expression in empty state
 #[no_mangle]
-pub extern "C" fn z_view_keyexpr_empty(this: &mut MaybeUninit<z_view_keyexpr_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_view_keyexpr_empty(this_: &mut MaybeUninit<z_view_keyexpr_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 fn keyexpr_create_inner(
@@ -126,8 +126,8 @@ pub unsafe extern "C" fn z_keyexpr_from_str_autocanonize(
 /// Borrows `z_owned_keyexpr_t`.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_keyexpr_loan(this: &z_owned_keyexpr_t) -> &z_loaned_keyexpr_t {
-    this.as_rust_type_ref()
+pub unsafe extern "C" fn z_keyexpr_loan(this_: &z_owned_keyexpr_t) -> &z_loaned_keyexpr_t {
+    this_.as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -136,8 +136,8 @@ pub unsafe extern "C" fn z_keyexpr_loan(this: &z_owned_keyexpr_t) -> &z_loaned_k
 /// Borrows `z_view_keyexpr_t`.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_view_keyexpr_loan(this: &z_view_keyexpr_t) -> &z_loaned_keyexpr_t {
-    this.as_rust_type_ref()
+pub unsafe extern "C" fn z_view_keyexpr_loan(this_: &z_view_keyexpr_t) -> &z_loaned_keyexpr_t {
+    this_.as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -151,14 +151,14 @@ pub extern "C" fn z_keyexpr_drop(this_: &mut z_moved_keyexpr_t) {
 
 /// Returns ``true`` if `keyexpr` is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_keyexpr_check(this: &z_owned_keyexpr_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_keyexpr_check(this_: &z_owned_keyexpr_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Returns ``true`` if `keyexpr` is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn z_view_keyexpr_is_empty(this: &z_view_keyexpr_t) -> bool {
-    this.as_rust_type_ref().is_none()
+pub extern "C" fn z_view_keyexpr_is_empty(this_: &z_view_keyexpr_t) -> bool {
+    this_.as_rust_type_ref().is_none()
 }
 
 /// Returns 0 if the passed string is a valid (and canon) key expression.

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -145,8 +145,9 @@ pub unsafe extern "C" fn z_view_keyexpr_loan(this: &z_view_keyexpr_t) -> &z_loan
 
 /// Frees key expression and resets it to its gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_keyexpr_drop(this: z_moved_keyexpr_t) {}
+pub extern "C" fn z_keyexpr_drop(this_: &mut z_moved_keyexpr_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Returns ``true`` if `keyexpr` is valid, ``false`` if it is in gravestone state.
 #[no_mangle]

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -26,7 +26,7 @@ pub use crate::opaque_types::{
 };
 use crate::{
     result::{self, z_result_t, Z_OK},
-    transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_session_t, z_view_string_from_substr, z_view_string_t,
 };
 
@@ -488,10 +488,10 @@ pub extern "C" fn z_declare_keyexpr(
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
 pub extern "C" fn z_undeclare_keyexpr(
-    this: z_moved_keyexpr_t,
+    this: &mut z_moved_keyexpr_t,
     session: &z_loaned_session_t,
 ) -> result::z_result_t {
-    let Some(kexpr) = this.into_rust_type() else {
+    let Some(kexpr) = this.take_rust_type() else {
         tracing::debug!("Attempted to undeclare dropped keyexpr");
         return result::Z_EINVAL;
     };

--- a/src/liveliness.rs
+++ b/src/liveliness.rs
@@ -46,8 +46,9 @@ pub extern "C" fn zc_liveliness_token_check(this: &zc_owned_liveliness_token_t) 
 
 /// Undeclares liveliness token, frees memory and resets it to a gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn zc_liveliness_token_drop(this: zc_moved_liveliness_token_t) {}
+pub extern "C" fn zc_liveliness_token_drop(this_: &mut zc_moved_liveliness_token_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// The options for `zc_liveliness_declare_token()`.
 #[repr(C)]

--- a/src/liveliness.rs
+++ b/src/liveliness.rs
@@ -30,7 +30,6 @@ use crate::{
 decl_c_type!(
     owned(zc_owned_liveliness_token_t, option LivelinessToken<'static>),
     loaned(zc_loaned_liveliness_token_t),
-    moved(zc_moved_liveliness_token_t)
 );
 
 /// Constructs liveliness token in its gravestone state.

--- a/src/liveliness.rs
+++ b/src/liveliness.rs
@@ -34,14 +34,14 @@ decl_c_type!(
 
 /// Constructs liveliness token in its gravestone state.
 #[no_mangle]
-pub extern "C" fn zc_liveliness_token_null(this: &mut MaybeUninit<zc_owned_liveliness_token_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn zc_liveliness_token_null(this_: &mut MaybeUninit<zc_owned_liveliness_token_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if liveliness token is valid, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn zc_liveliness_token_check(this: &zc_owned_liveliness_token_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn zc_liveliness_token_check(this_: &zc_owned_liveliness_token_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Undeclares liveliness token, frees memory and resets it to a gravestone state.

--- a/src/liveliness.rs
+++ b/src/liveliness.rs
@@ -22,7 +22,7 @@ use zenoh::{
 use crate::{
     opaque_types::{zc_loaned_liveliness_token_t, zc_owned_liveliness_token_t},
     result,
-    transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_closure_reply_call, z_closure_reply_loan, z_closure_sample_call, z_closure_sample_loan,
     z_loaned_keyexpr_t, z_loaned_session_t, z_moved_closure_reply_t, z_moved_closure_sample_t,
     z_owned_subscriber_t, zc_moved_liveliness_token_t,
@@ -110,9 +110,9 @@ pub extern "C" fn zc_liveliness_declare_token(
 /// Destroys a liveliness token, notifying subscribers of its destruction.
 #[no_mangle]
 pub extern "C" fn zc_liveliness_undeclare_token(
-    this: zc_moved_liveliness_token_t,
+    this: &mut zc_moved_liveliness_token_t,
 ) -> result::z_result_t {
-    if let Some(token) = this.into_rust_type() {
+    if let Some(token) = this.take_rust_type() {
         if let Err(e) = token.undeclare().wait() {
             tracing::error!("Failed to undeclare token: {e}");
             return result::Z_EGENERIC;
@@ -149,16 +149,13 @@ pub extern "C" fn zc_liveliness_declare_subscriber(
     this: &mut MaybeUninit<z_owned_subscriber_t>,
     session: &z_loaned_session_t,
     key_expr: &z_loaned_keyexpr_t,
-    callback: z_moved_closure_sample_t,
+    callback: &mut z_moved_closure_sample_t,
     _options: Option<&mut zc_liveliness_subscriber_options_t>,
 ) -> result::z_result_t {
     let this = this.as_rust_type_mut_uninit();
     let session = session.as_rust_type_ref();
     let key_expr = key_expr.as_rust_type_ref();
-    let Some(callback) = callback.into_rust_type() else {
-        this.write(None);
-        return result::Z_EINVAL;
-    };
+    let callback = callback.take_rust_type();
     match session
         .liveliness()
         .declare_subscriber(key_expr)
@@ -204,14 +201,12 @@ pub extern "C" fn zc_liveliness_get_options_default(
 pub extern "C" fn zc_liveliness_get(
     session: &z_loaned_session_t,
     key_expr: &z_loaned_keyexpr_t,
-    callback: z_moved_closure_reply_t,
+    callback: &mut z_moved_closure_reply_t,
     options: Option<&mut zc_liveliness_get_options_t>,
 ) -> result::z_result_t {
     let session = session.as_rust_type_ref();
     let key_expr = key_expr.as_rust_type_ref();
-    let Some(callback) = callback.into_rust_type() else {
-        return result::Z_EINVAL;
-    };
+    let callback = callback.take_rust_type();
     let liveliness: Liveliness<'static> = session.liveliness();
     let mut builder = liveliness.get(key_expr).callback(move |response| {
         z_closure_reply_call(

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -41,7 +41,7 @@ use crate::{z_loaned_shm_t, z_moved_shm_mut_t, z_moved_shm_t, z_owned_shm_t};
 decl_c_type! {
     owned(z_owned_bytes_t, ZBytes),
     loaned(z_loaned_bytes_t),
-    moved(z_moved_bytes_t)
+    moved(z_moved_bytes_t),
 }
 
 /// The gravestone value for `z_owned_bytes_t`.

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -303,62 +303,62 @@ where
 
 /// Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_uint8(this: &mut MaybeUninit<z_owned_bytes_t>, val: u8) {
-    z_bytes_serialize_from_arithmetic::<u8>(this, val);
+pub extern "C" fn z_bytes_serialize_from_uint8(this_: &mut MaybeUninit<z_owned_bytes_t>, val: u8) {
+    z_bytes_serialize_from_arithmetic::<u8>(this_, val);
 }
 
 /// Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_uint16(this: &mut MaybeUninit<z_owned_bytes_t>, val: u16) {
-    z_bytes_serialize_from_arithmetic::<u16>(this, val);
+pub extern "C" fn z_bytes_serialize_from_uint16(this_: &mut MaybeUninit<z_owned_bytes_t>, val: u16) {
+    z_bytes_serialize_from_arithmetic::<u16>(this_, val);
 }
 
 /// Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_uint32(this: &mut MaybeUninit<z_owned_bytes_t>, val: u32) {
-    z_bytes_serialize_from_arithmetic::<u32>(this, val);
+pub extern "C" fn z_bytes_serialize_from_uint32(this_: &mut MaybeUninit<z_owned_bytes_t>, val: u32) {
+    z_bytes_serialize_from_arithmetic::<u32>(this_, val);
 }
 
 /// Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_uint64(this: &mut MaybeUninit<z_owned_bytes_t>, val: u64) {
-    z_bytes_serialize_from_arithmetic::<u64>(this, val);
+pub extern "C" fn z_bytes_serialize_from_uint64(this_: &mut MaybeUninit<z_owned_bytes_t>, val: u64) {
+    z_bytes_serialize_from_arithmetic::<u64>(this_, val);
 }
 
 /// Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_int8(this: &mut MaybeUninit<z_owned_bytes_t>, val: i8) {
-    z_bytes_serialize_from_arithmetic::<i8>(this, val);
+pub extern "C" fn z_bytes_serialize_from_int8(this_: &mut MaybeUninit<z_owned_bytes_t>, val: i8) {
+    z_bytes_serialize_from_arithmetic::<i8>(this_, val);
 }
 
 /// Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_int16(this: &mut MaybeUninit<z_owned_bytes_t>, val: i16) {
-    z_bytes_serialize_from_arithmetic::<i16>(this, val);
+pub extern "C" fn z_bytes_serialize_from_int16(this_: &mut MaybeUninit<z_owned_bytes_t>, val: i16) {
+    z_bytes_serialize_from_arithmetic::<i16>(this_, val);
 }
 
 /// Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_int32(this: &mut MaybeUninit<z_owned_bytes_t>, val: i32) {
-    z_bytes_serialize_from_arithmetic::<i32>(this, val);
+pub extern "C" fn z_bytes_serialize_from_int32(this_: &mut MaybeUninit<z_owned_bytes_t>, val: i32) {
+    z_bytes_serialize_from_arithmetic::<i32>(this_, val);
 }
 
 /// Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_int64(this: &mut MaybeUninit<z_owned_bytes_t>, val: i64) {
-    z_bytes_serialize_from_arithmetic::<i64>(this, val);
+pub extern "C" fn z_bytes_serialize_from_int64(this_: &mut MaybeUninit<z_owned_bytes_t>, val: i64) {
+    z_bytes_serialize_from_arithmetic::<i64>(this_, val);
 }
 
 /// Serializes a float.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_float(this: &mut MaybeUninit<z_owned_bytes_t>, val: f32) {
-    z_bytes_serialize_from_arithmetic::<f32>(this, val);
+pub extern "C" fn z_bytes_serialize_from_float(this_: &mut MaybeUninit<z_owned_bytes_t>, val: f32) {
+    z_bytes_serialize_from_arithmetic::<f32>(this_, val);
 }
 
 /// Serializes a double.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_double(this: &mut MaybeUninit<z_owned_bytes_t>, val: f64) {
-    z_bytes_serialize_from_arithmetic::<f64>(this, val);
+pub extern "C" fn z_bytes_serialize_from_double(this_: &mut MaybeUninit<z_owned_bytes_t>, val: f64) {
+    z_bytes_serialize_from_arithmetic::<f64>(this_, val);
 }
 /// Deserializes into an unsigned integer.
 /// @return 0 in case of success, negative error code otherwise.
@@ -879,8 +879,8 @@ pub unsafe extern "C" fn z_bytes_reader_seek(
 /// @return read position indicator on success or -1L if failure occurs.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_reader_tell(this: &mut z_bytes_reader_t) -> i64 {
-    let reader = this.as_rust_type_mut();
+pub unsafe extern "C" fn z_bytes_reader_tell(this_: &mut z_bytes_reader_t) -> i64 {
+    let reader = this_.as_rust_type_mut();
     reader.stream_position().map(|p| p as i64).unwrap_or(-1)
 }
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -58,8 +58,9 @@ extern "C" fn z_bytes_empty(this: &mut MaybeUninit<z_owned_bytes_t>) {
 /// Drops `this_`, resetting it to gravestone value. If there are any shallow copies
 /// created by `z_bytes_clone()`, they would still stay valid.
 #[no_mangle]
-#[allow(unused_variables)]
-extern "C" fn z_bytes_drop(this: z_moved_bytes_t) {}
+extern "C" fn z_bytes_drop(this_: &mut z_moved_bytes_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Returns ``true`` if `this_` is in a valid state, ``false`` if it is in a gravestone state.
 #[no_mangle]

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -309,19 +309,28 @@ pub extern "C" fn z_bytes_serialize_from_uint8(this_: &mut MaybeUninit<z_owned_b
 
 /// Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_uint16(this_: &mut MaybeUninit<z_owned_bytes_t>, val: u16) {
+pub extern "C" fn z_bytes_serialize_from_uint16(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: u16,
+) {
     z_bytes_serialize_from_arithmetic::<u16>(this_, val);
 }
 
 /// Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_uint32(this_: &mut MaybeUninit<z_owned_bytes_t>, val: u32) {
+pub extern "C" fn z_bytes_serialize_from_uint32(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: u32,
+) {
     z_bytes_serialize_from_arithmetic::<u32>(this_, val);
 }
 
 /// Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_uint64(this_: &mut MaybeUninit<z_owned_bytes_t>, val: u64) {
+pub extern "C" fn z_bytes_serialize_from_uint64(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: u64,
+) {
     z_bytes_serialize_from_arithmetic::<u64>(this_, val);
 }
 
@@ -357,7 +366,10 @@ pub extern "C" fn z_bytes_serialize_from_float(this_: &mut MaybeUninit<z_owned_b
 
 /// Serializes a double.
 #[no_mangle]
-pub extern "C" fn z_bytes_serialize_from_double(this_: &mut MaybeUninit<z_owned_bytes_t>, val: f64) {
+pub extern "C" fn z_bytes_serialize_from_double(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: f64,
+) {
     z_bytes_serialize_from_arithmetic::<f64>(this_, val);
 }
 /// Deserializes into an unsigned integer.

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -762,9 +762,9 @@ pub extern "C" fn z_bytes_iterator_next(
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_bytes_serialize_from_shm(
     this: &mut MaybeUninit<z_owned_bytes_t>,
-    shm: z_moved_shm_t,
+    shm: &mut z_moved_shm_t,
 ) -> z_result_t {
-    let Some(shm) = shm.into_rust_type() else {
+    let Some(shm) = shm.take_rust_type() else {
         this.as_rust_type_mut_uninit().write(ZBytes::default());
         return Z_ENULL;
     };
@@ -778,9 +778,9 @@ pub unsafe extern "C" fn z_bytes_serialize_from_shm(
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_bytes_serialize_from_shm_mut(
     this: &mut MaybeUninit<z_owned_bytes_t>,
-    shm: z_moved_shm_mut_t,
+    shm: &mut z_moved_shm_mut_t,
 ) -> z_result_t {
-    let Some(shm) = shm.into_rust_type() else {
+    let Some(shm) = shm.take_rust_type() else {
         this.as_rust_type_mut_uninit().write(ZBytes::default());
         return Z_ENULL;
     };

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -32,7 +32,7 @@ pub use crate::opaque_types::{z_loaned_bytes_t, z_owned_bytes_t};
 use crate::result::Z_ENULL;
 use crate::{
     result::{self, z_result_t, Z_EINVAL, Z_EIO, Z_EPARSE, Z_OK},
-    transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_slice_t, z_loaned_string_t, z_moved_bytes_t, z_moved_slice_t, z_moved_string_t,
     z_owned_slice_t, z_owned_string_t, CSlice, CSliceOwned, CString, CStringOwned,
 };
@@ -467,7 +467,7 @@ pub unsafe extern "C" fn z_bytes_from_slice(
     this: &mut MaybeUninit<z_owned_bytes_t>,
     slice: &mut z_moved_slice_t,
 ) {
-    let slice = slice.into_rust_type();
+    let slice = slice.take_rust_type();
     let payload = ZBytes::from(slice);
     this.as_rust_type_mut_uninit().write(payload);
 }
@@ -560,7 +560,7 @@ pub unsafe extern "C" fn z_bytes_from_string(
     s: &mut z_moved_string_t,
 ) {
     // TODO: verify that string is a valid utf-8 string ?
-    let cs = s.into_rust_type();
+    let cs = s.take_rust_type();
     let payload = ZBytes::from(cs);
     this.as_rust_type_mut_uninit().write(payload);
 }
@@ -646,7 +646,7 @@ pub extern "C" fn z_bytes_from_pair(
     first: &mut z_moved_bytes_t,
     second: &mut z_moved_bytes_t,
 ) -> z_result_t {
-    let payload = ZBytes::serialize((first.into_rust_type(), second.into_rust_type()));
+    let payload = ZBytes::serialize((first.take_rust_type(), second.take_rust_type()));
     this.as_rust_type_mut_uninit().write(payload);
     Z_OK
 }
@@ -920,7 +920,7 @@ unsafe extern "C" fn z_bytes_writer_append(
     this: &mut z_bytes_writer_t,
     bytes: &mut z_moved_bytes_t,
 ) -> z_result_t {
-    this.as_rust_type_mut().append(bytes.into_rust_type());
+    this.as_rust_type_mut().append(bytes.take_rust_type());
     result::Z_OK
 }
 
@@ -933,6 +933,6 @@ unsafe extern "C" fn z_bytes_writer_append_bounded(
     this: &mut z_bytes_writer_t,
     bytes: &mut z_moved_bytes_t,
 ) -> z_result_t {
-    this.as_rust_type_mut().serialize(bytes.into_rust_type());
+    this.as_rust_type_mut().serialize(bytes.take_rust_type());
     result::Z_OK
 }

--- a/src/platform/synchronization.rs
+++ b/src/platform/synchronization.rs
@@ -50,7 +50,8 @@ pub extern "C" fn z_mutex_null(this_: &mut MaybeUninit<z_owned_mutex_t>) {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_mutex_loan_mut(this_: &mut z_owned_mutex_t) -> &mut z_loaned_mutex_t {
-    this_.as_rust_type_mut()
+    this_
+        .as_rust_type_mut()
         .as_mut()
         .unwrap_unchecked()
         .as_loaned_c_type_mut()
@@ -141,7 +142,8 @@ pub extern "C" fn z_condvar_check(this_: &z_owned_condvar_t) -> bool {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_condvar_loan(this_: &z_owned_condvar_t) -> &z_loaned_condvar_t {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()

--- a/src/platform/synchronization.rs
+++ b/src/platform/synchronization.rs
@@ -15,7 +15,6 @@ use crate::{
 decl_c_type!(
     owned(z_owned_mutex_t, option(Mutex<()>, Option<MutexGuard<'static, ()>>)),
     loaned(z_loaned_mutex_t),
-    moved(z_moved_mutex_t)
 );
 
 /// Constructs a mutex.
@@ -111,7 +110,6 @@ pub use crate::opaque_types::{z_loaned_condvar_t, z_moved_condvar_t, z_owned_con
 decl_c_type_inequal!(
     owned(z_owned_condvar_t, option Condvar),
     loaned(z_loaned_condvar_t),
-    moved(z_moved_condvar_t)
 );
 
 /// Constructs conditional variable.
@@ -197,7 +195,6 @@ pub unsafe extern "C" fn z_condvar_wait(
 pub use crate::opaque_types::{z_moved_task_t, z_owned_task_t};
 decl_c_type!(
     owned(z_owned_task_t, option JoinHandle<()>),
-    moved(z_moved_task_t)
 );
 
 #[repr(C)]

--- a/src/platform/synchronization.rs
+++ b/src/platform/synchronization.rs
@@ -30,8 +30,9 @@ pub extern "C" fn z_mutex_init(this: &mut MaybeUninit<z_owned_mutex_t>) -> resul
 
 /// Drops mutex and resets it to its gravestone state.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_mutex_drop(this: z_moved_mutex_t) {}
+pub extern "C" fn z_mutex_drop(this_: &mut z_moved_mutex_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Returns ``true`` if mutex is valid, ``false`` otherwise.
 #[no_mangle]
@@ -126,8 +127,9 @@ pub extern "C" fn z_condvar_null(this: &mut MaybeUninit<z_owned_condvar_t>) {
 
 /// Drops conditional variable.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_condvar_drop(this: z_moved_condvar_t) {}
+pub extern "C" fn z_condvar_drop(this_: &mut z_moved_condvar_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Returns ``true`` if conditional variable is valid, ``false`` otherwise.
 #[no_mangle]
@@ -209,8 +211,9 @@ pub extern "C" fn z_task_null(this: &mut MaybeUninit<z_owned_task_t>) {
 
 /// Detaches the task and releases all allocated resources.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_task_detach(this: z_moved_task_t) {}
+pub extern "C" fn z_task_detach(this_: &mut z_moved_task_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Joins the task and releases all allocated resources
 #[no_mangle]
@@ -226,8 +229,9 @@ pub extern "C" fn z_task_join(this: &mut z_moved_task_t) -> result::z_result_t {
 
 /// Drop the task. Same as `z_task_detach`. Use `z_task_join` to wait for the task completion.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_task_drop(this: z_moved_task_t) {}
+pub extern "C" fn z_task_drop(this_: &mut z_moved_task_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Returns ``true`` if task is valid, ``false`` otherwise.
 #[no_mangle]

--- a/src/platform/synchronization.rs
+++ b/src/platform/synchronization.rs
@@ -20,8 +20,8 @@ decl_c_type!(
 /// Constructs a mutex.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_mutex_init(this: &mut MaybeUninit<z_owned_mutex_t>) -> result::z_result_t {
-    this.as_rust_type_mut_uninit().write(Some((
+pub extern "C" fn z_mutex_init(this_: &mut MaybeUninit<z_owned_mutex_t>) -> result::z_result_t {
+    this_.as_rust_type_mut_uninit().write(Some((
         Mutex::<()>::new(()),
         None::<MutexGuard<'static, ()>>,
     )));
@@ -36,21 +36,21 @@ pub extern "C" fn z_mutex_drop(this_: &mut z_moved_mutex_t) {
 
 /// Returns ``true`` if mutex is valid, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_mutex_check(this: &z_owned_mutex_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_mutex_check(this_: &z_owned_mutex_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Constructs mutex in a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_mutex_null(this: &mut MaybeUninit<z_owned_mutex_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_mutex_null(this_: &mut MaybeUninit<z_owned_mutex_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Mutably borrows mutex.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_mutex_loan_mut(this: &mut z_owned_mutex_t) -> &mut z_loaned_mutex_t {
-    this.as_rust_type_mut()
+pub unsafe extern "C" fn z_mutex_loan_mut(this_: &mut z_owned_mutex_t) -> &mut z_loaned_mutex_t {
+    this_.as_rust_type_mut()
         .as_mut()
         .unwrap_unchecked()
         .as_loaned_c_type_mut()
@@ -59,8 +59,8 @@ pub unsafe extern "C" fn z_mutex_loan_mut(this: &mut z_owned_mutex_t) -> &mut z_
 /// Locks mutex. If mutex is already locked, blocks the thread until it aquires the lock.
 /// @return 0 in case of success, negative error code in case of failure.
 #[no_mangle]
-pub extern "C" fn z_mutex_lock(this: &'static mut z_loaned_mutex_t) -> result::z_result_t {
-    let this = this.as_rust_type_mut();
+pub extern "C" fn z_mutex_lock(this_: &'static mut z_loaned_mutex_t) -> result::z_result_t {
+    let this = this_.as_rust_type_mut();
 
     match this.0.lock() {
         Ok(new_lock) => {
@@ -77,8 +77,8 @@ pub extern "C" fn z_mutex_lock(this: &'static mut z_loaned_mutex_t) -> result::z
 /// Unlocks previously locked mutex. If mutex was not locked by the current thread, the behaviour is undefined.
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn z_mutex_unlock(this: &mut z_loaned_mutex_t) -> result::z_result_t {
-    let this = this.as_rust_type_mut();
+pub extern "C" fn z_mutex_unlock(this_: &mut z_loaned_mutex_t) -> result::z_result_t {
+    let this = this_.as_rust_type_mut();
     if this.1.is_none() {
         return result::Z_EINVAL_MUTEX;
     } else {
@@ -115,14 +115,14 @@ decl_c_type_inequal!(
 
 /// Constructs conditional variable.
 #[no_mangle]
-pub extern "C" fn z_condvar_init(this: &mut MaybeUninit<z_owned_condvar_t>) {
-    this.as_rust_type_mut_uninit().write(Some(Condvar::new()));
+pub extern "C" fn z_condvar_init(this_: &mut MaybeUninit<z_owned_condvar_t>) {
+    this_.as_rust_type_mut_uninit().write(Some(Condvar::new()));
 }
 
 /// Constructs conditional variable in a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_condvar_null(this: &mut MaybeUninit<z_owned_condvar_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_condvar_null(this_: &mut MaybeUninit<z_owned_condvar_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Drops conditional variable.
@@ -133,15 +133,15 @@ pub extern "C" fn z_condvar_drop(this_: &mut z_moved_condvar_t) {
 
 /// Returns ``true`` if conditional variable is valid, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_condvar_check(this: &z_owned_condvar_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_condvar_check(this_: &z_owned_condvar_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Borrows conditional variable.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_condvar_loan(this: &z_owned_condvar_t) -> &z_loaned_condvar_t {
-    this.as_rust_type_ref()
+pub unsafe extern "C" fn z_condvar_loan(this_: &z_owned_condvar_t) -> &z_loaned_condvar_t {
+    this_.as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -162,8 +162,8 @@ pub unsafe extern "C" fn z_condvar_loan_mut(
 /// Wakes up one blocked thread waiting on this condiitonal variable.
 /// @return 0 in case of success, negative error code in case of failure.
 #[no_mangle]
-pub extern "C" fn z_condvar_signal(this: &z_loaned_condvar_t) -> result::z_result_t {
-    let this = this.as_rust_type_ref();
+pub extern "C" fn z_condvar_signal(this_: &z_loaned_condvar_t) -> result::z_result_t {
+    let this = this_.as_rust_type_ref();
     this.notify_one();
     result::Z_OK
 }
@@ -205,8 +205,8 @@ pub struct z_task_attr_t(usize);
 
 /// Constructs task in a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_task_null(this: &mut MaybeUninit<z_owned_task_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_task_null(this_: &mut MaybeUninit<z_owned_task_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Detaches the task and releases all allocated resources.
@@ -217,8 +217,8 @@ pub extern "C" fn z_task_detach(this_: &mut z_moved_task_t) {
 
 /// Joins the task and releases all allocated resources
 #[no_mangle]
-pub extern "C" fn z_task_join(this: &mut z_moved_task_t) -> result::z_result_t {
-    let Some(task) = this.take_rust_type() else {
+pub extern "C" fn z_task_join(this_: &mut z_moved_task_t) -> result::z_result_t {
+    let Some(task) = this_.take_rust_type() else {
         return result::Z_OK;
     };
     match task.join() {
@@ -235,8 +235,8 @@ pub extern "C" fn z_task_drop(this_: &mut z_moved_task_t) {
 
 /// Returns ``true`` if task is valid, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_task_check(this: &z_owned_task_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_task_check(this_: &z_owned_task_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 struct FunArgPair {

--- a/src/platform/synchronization.rs
+++ b/src/platform/synchronization.rs
@@ -9,7 +9,7 @@ use libc::c_void;
 pub use crate::opaque_types::{z_loaned_mutex_t, z_moved_mutex_t, z_owned_mutex_t};
 use crate::{
     result,
-    transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
 };
 
 decl_c_type!(
@@ -214,8 +214,8 @@ pub extern "C" fn z_task_detach(this: z_moved_task_t) {}
 
 /// Joins the task and releases all allocated resources
 #[no_mangle]
-pub extern "C" fn z_task_join(this: z_moved_task_t) -> result::z_result_t {
-    let Some(task) = this.into_rust_type() else {
+pub extern "C" fn z_task_join(this: &mut z_moved_task_t) -> result::z_result_t {
+    let Some(task) = this.take_rust_type() else {
         return result::Z_OK;
     };
     match task.join() {

--- a/src/publication_cache.rs
+++ b/src/publication_cache.rs
@@ -65,7 +65,6 @@ decl_c_type!(
         option zenoh_ext::PublicationCache<'static>,
     ),
     loaned(ze_loaned_publication_cache_t),
-    moved(ze_moved_publication_cache_t)
 );
 
 /// Constructs and declares a publication cache.

--- a/src/publication_cache.rs
+++ b/src/publication_cache.rs
@@ -19,7 +19,7 @@ use zenoh_ext::SessionExt;
 
 use crate::{
     result,
-    transmute::{IntoRustType, RustTypeRef, RustTypeRefUninit},
+    transmute::{RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_keyexpr_t, z_loaned_session_t,
 };
 #[cfg(feature = "unstable")]
@@ -134,9 +134,9 @@ pub extern "C" fn ze_publication_cache_check(this: &ze_owned_publication_cache_t
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub extern "C" fn ze_undeclare_publication_cache(
-    this: ze_moved_publication_cache_t,
+    this: &mut ze_moved_publication_cache_t,
 ) -> result::z_result_t {
-    if let Some(p) = this.into_rust_type() {
+    if let Some(p) = this.take_rust_type() {
         if let Err(e) = p.undeclare().wait() {
             tracing::error!("{}", e);
             return result::Z_EGENERIC;
@@ -148,6 +148,6 @@ pub extern "C" fn ze_undeclare_publication_cache(
 /// Drops publication cache. Also attempts to undeclare it.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn ze_publication_cache_drop(this: ze_moved_publication_cache_t) {
-    ze_undeclare_publication_cache(this);
+pub extern "C" fn ze_publication_cache_drop(_this: &mut ze_moved_publication_cache_t) {
+    ze_undeclare_publication_cache(_this);
 }

--- a/src/publication_cache.rs
+++ b/src/publication_cache.rs
@@ -118,15 +118,15 @@ pub extern "C" fn ze_declare_publication_cache(
 /// Constructs a publication cache in a gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn ze_publication_cache_null(this: &mut MaybeUninit<ze_owned_publication_cache_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn ze_publication_cache_null(this_: &mut MaybeUninit<ze_owned_publication_cache_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if publication cache is valid, ``false`` otherwise.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn ze_publication_cache_check(this: &ze_owned_publication_cache_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn ze_publication_cache_check(this_: &ze_owned_publication_cache_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Undeclares and drops publication cache.
@@ -148,6 +148,6 @@ pub extern "C" fn ze_undeclare_publication_cache(
 /// Drops publication cache. Also attempts to undeclare it.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn ze_publication_cache_drop(_this: &mut ze_moved_publication_cache_t) {
-    ze_undeclare_publication_cache(_this);
+pub extern "C" fn ze_publication_cache_drop(this_: &mut ze_moved_publication_cache_t) {
+    ze_undeclare_publication_cache(this_);
 }

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -140,7 +140,8 @@ pub extern "C" fn z_publisher_check(this_: &z_owned_publisher_t) -> bool {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_publisher_loan(this_: &z_owned_publisher_t) -> &z_loaned_publisher_t {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -288,7 +289,7 @@ pub extern "C" fn z_publisher_keyexpr(publisher: &z_loaned_publisher_t) -> &z_lo
 }
 
 #[cfg(feature = "unstable")]
-pub use crate::opaque_types::{zc_moved_matching_listener_t,  zc_owned_matching_listener_t};
+pub use crate::opaque_types::{zc_moved_matching_listener_t, zc_owned_matching_listener_t};
 #[cfg(feature = "unstable")]
 decl_c_type!(
     owned(zc_owned_matching_listener_t, option MatchingListener<'static, ()>),

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -56,8 +56,8 @@ pub struct z_publisher_options_t {
 
 /// Constructs the default value for `z_publisher_options_t`.
 #[no_mangle]
-pub extern "C" fn z_publisher_options_default(this: &mut MaybeUninit<z_publisher_options_t>) {
-    this.write(z_publisher_options_t {
+pub extern "C" fn z_publisher_options_default(this_: &mut MaybeUninit<z_publisher_options_t>) {
+    this_.write(z_publisher_options_t {
         encoding: None.into(),
         congestion_control: CongestionControl::default().into(),
         priority: Priority::default().into(),
@@ -125,22 +125,22 @@ pub extern "C" fn z_declare_publisher(
 /// Constructs a publisher in a gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_publisher_null(this: &mut MaybeUninit<z_owned_publisher_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_publisher_null(this_: &mut MaybeUninit<z_owned_publisher_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if publisher is valid, ``false`` otherwise.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_publisher_check(this: &z_owned_publisher_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_publisher_check(this_: &z_owned_publisher_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Borrows publisher.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_publisher_loan(this: &z_owned_publisher_t) -> &z_loaned_publisher_t {
-    this.as_rust_type_ref()
+pub unsafe extern "C" fn z_publisher_loan(this_: &z_owned_publisher_t) -> &z_loaned_publisher_t {
+    this_.as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -297,15 +297,15 @@ decl_c_type!(
 /// Constructs an empty matching listener
 #[no_mangle]
 #[cfg(feature = "unstable")]
-pub extern "C" fn zc_matching_listener_null(this: &mut MaybeUninit<zc_owned_matching_listener_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn zc_matching_listener_null(this_: &mut MaybeUninit<zc_owned_matching_listener_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Checks the matching listener is for the gravestone state
 #[no_mangle]
 #[cfg(feature = "unstable")]
-pub extern "C" fn zc_matching_listener_check(this: &zc_owned_matching_listener_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn zc_matching_listener_check(this_: &zc_owned_matching_listener_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 #[cfg(feature = "unstable")]
@@ -415,8 +415,8 @@ pub extern "C" fn zc_publisher_get_matching_status(
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_undeclare_publisher(_this: &mut z_moved_publisher_t) -> result::z_result_t {
-    if let Some(p) = _this.take_rust_type() {
+pub extern "C" fn z_undeclare_publisher(this_: &mut z_moved_publisher_t) -> result::z_result_t {
+    if let Some(p) = this_.take_rust_type() {
         if let Err(e) = p.undeclare().wait() {
             tracing::error!("{}", e);
             return result::Z_ENETWORK;
@@ -428,6 +428,6 @@ pub extern "C" fn z_undeclare_publisher(_this: &mut z_moved_publisher_t) -> resu
 /// Frees memory and resets publisher to its gravestone state. Also attempts undeclare publisher.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_publisher_drop(_this: &mut z_moved_publisher_t) {
-    z_undeclare_publisher(_this);
+pub extern "C" fn z_publisher_drop(this_: &mut z_moved_publisher_t) {
+    z_undeclare_publisher(this_);
 }

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -58,7 +58,7 @@ pub struct z_publisher_options_t {
 #[no_mangle]
 pub extern "C" fn z_publisher_options_default(this_: &mut MaybeUninit<z_publisher_options_t>) {
     this_.write(z_publisher_options_t {
-        encoding: None.into(),
+        encoding: None,
         congestion_control: CongestionControl::default().into(),
         priority: Priority::default().into(),
         is_express: false,
@@ -179,11 +179,11 @@ pub extern "C" fn z_publisher_put_options_default(
     this: &mut MaybeUninit<z_publisher_put_options_t>,
 ) {
     this.write(z_publisher_put_options_t {
-        encoding: None.into(),
+        encoding: None,
         timestamp: None,
         #[cfg(feature = "unstable")]
-        source_info: None.into(),
-        attachment: None.into(),
+        source_info: None,
+        attachment: None,
     });
 }
 

--- a/src/put.rs
+++ b/src/put.rs
@@ -25,7 +25,7 @@ use crate::z_moved_source_info_t;
 use crate::{
     commons::*,
     result,
-    transmute::{IntoRustType, RustTypeRef},
+    transmute::{IntoRustType, RustTypeRef, TakeRustType},
     z_loaned_keyexpr_t, z_loaned_session_t, z_moved_bytes_t, z_moved_encoding_t, z_timestamp_t,
 };
 
@@ -89,18 +89,18 @@ pub extern "C" fn z_put(
 ) -> result::z_result_t {
     let session = session.as_rust_type_ref();
     let key_expr = key_expr.as_rust_type_ref();
-    let payload = payload.into_rust_type();
+    let payload = payload.take_rust_type();
     let mut put = session.put(key_expr, payload);
     if let Some(options) = options {
         if let Some(encoding) = options.encoding.take() {
-            put = put.encoding(encoding.into_rust_type());
+            put = put.encoding(encoding.take_rust_type());
         };
         #[cfg(feature = "unstable")]
         if let Some(source_info) = options.source_info.take() {
-            put = put.source_info(source_info.into_rust_type());
+            put = put.source_info(source_info.take_rust_type());
         };
         if let Some(attachment) = options.attachment.take() {
-            put = put.attachment(attachment.into_rust_type());
+            put = put.attachment(attachment.take_rust_type());
         }
         if let Some(timestamp) = options.timestamp.as_ref() {
             put = put.timestamp(Some(timestamp.into_rust_type()));

--- a/src/put.rs
+++ b/src/put.rs
@@ -56,8 +56,8 @@ pub struct z_put_options_t {
 /// Constructs the default value for `z_put_options_t`.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_put_options_default(this: &mut MaybeUninit<z_put_options_t>) {
-    this.write(z_put_options_t {
+pub extern "C" fn z_put_options_default(this_: &mut MaybeUninit<z_put_options_t>) {
+    this_.write(z_put_options_t {
         encoding: None.into(),
         congestion_control: CongestionControl::default().into(),
         priority: Priority::default().into(),
@@ -142,8 +142,8 @@ pub struct z_delete_options_t {
 /// Constructs the default value for `z_delete_options_t`.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_delete_options_default(this: &mut MaybeUninit<z_delete_options_t>) {
-    this.write(z_delete_options_t {
+pub unsafe extern "C" fn z_delete_options_default(this_: &mut MaybeUninit<z_delete_options_t>) {
+    this_.write(z_delete_options_t {
         congestion_control: CongestionControl::default().into(),
         priority: Priority::default().into(),
         is_express: false,

--- a/src/put.rs
+++ b/src/put.rs
@@ -58,7 +58,7 @@ pub struct z_put_options_t {
 #[allow(clippy::missing_safety_doc)]
 pub extern "C" fn z_put_options_default(this_: &mut MaybeUninit<z_put_options_t>) {
     this_.write(z_put_options_t {
-        encoding: None.into(),
+        encoding: None,
         congestion_control: CongestionControl::default().into(),
         priority: Priority::default().into(),
         is_express: false,
@@ -66,8 +66,8 @@ pub extern "C" fn z_put_options_default(this_: &mut MaybeUninit<z_put_options_t>
         #[cfg(feature = "unstable")]
         allowed_destination: zc_locality_default(),
         #[cfg(feature = "unstable")]
-        source_info: None.into(),
-        attachment: None.into(),
+        source_info: None,
+        attachment: None,
     });
 }
 

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -81,9 +81,8 @@ pub unsafe extern "C" fn z_query_loan(this: &'static z_owned_query_t) -> &z_loan
 }
 /// Destroys the query resetting it to its gravestone value.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_query_drop(this: &mut z_moved_query_t) {
-    this.take_rust_type();
+pub extern "C" fn z_query_drop(this_: &mut z_moved_query_t) {
+    let _ = this_.take_rust_type();
 }
 /// Constructs a shallow copy of the query, allowing to keep it in an "open" state past the callback's return.
 ///

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -48,7 +48,8 @@ pub extern "C" fn z_queryable_null(this_: &mut MaybeUninit<z_owned_queryable_t>)
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_queryable_loan(this_: &z_owned_queryable_t) -> &z_loaned_queryable_t {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -74,7 +75,8 @@ pub extern "C" fn z_query_check(query: &z_owned_query_t) -> bool {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_query_loan(this_: &'static z_owned_query_t) -> &z_loaned_query_t {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -160,9 +162,7 @@ pub struct z_query_reply_err_options_t {
 pub extern "C" fn z_query_reply_err_options_default(
     this: &mut MaybeUninit<z_query_reply_err_options_t>,
 ) {
-    this.write(z_query_reply_err_options_t {
-        encoding: None,
-    });
+    this.write(z_query_reply_err_options_t { encoding: None });
 }
 
 /// Represents the set of options that can be applied to a query delete reply,
@@ -433,7 +433,8 @@ pub unsafe extern "C" fn z_query_parameters(
 /// Returns NULL if query does not contain a payload.
 #[no_mangle]
 pub extern "C" fn z_query_payload(this_: &z_loaned_query_t) -> Option<&z_loaned_bytes_t> {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .payload()
         .map(|v| v.as_loaned_c_type_ref())
 }
@@ -443,7 +444,8 @@ pub extern "C" fn z_query_payload(this_: &z_loaned_query_t) -> Option<&z_loaned_
 /// Returns NULL if query does not contain an encoding.
 #[no_mangle]
 pub extern "C" fn z_query_encoding(this_: &z_loaned_query_t) -> Option<&z_loaned_encoding_t> {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .encoding()
         .map(|v| v.as_loaned_c_type_ref())
 }
@@ -453,7 +455,8 @@ pub extern "C" fn z_query_encoding(this_: &z_loaned_query_t) -> Option<&z_loaned
 /// Returns NULL if query does not contain an attachment.
 #[no_mangle]
 pub extern "C" fn z_query_attachment(this_: &z_loaned_query_t) -> Option<&z_loaned_bytes_t> {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .attachment()
         .map(|a| a.as_loaned_c_type_ref())
 }

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -134,14 +134,14 @@ pub struct z_query_reply_options_t {
 #[allow(clippy::missing_safety_doc)]
 pub extern "C" fn z_query_reply_options_default(this_: &mut MaybeUninit<z_query_reply_options_t>) {
     this_.write(z_query_reply_options_t {
-        encoding: None.into(),
+        encoding: None,
         congestion_control: CongestionControl::Block.into(),
         priority: Priority::default().into(),
         is_express: false,
         timestamp: None,
         #[cfg(feature = "unstable")]
-        source_info: None.into(),
-        attachment: None.into(),
+        source_info: None,
+        attachment: None,
     });
 }
 
@@ -161,7 +161,7 @@ pub extern "C" fn z_query_reply_err_options_default(
     this: &mut MaybeUninit<z_query_reply_err_options_t>,
 ) {
     this.write(z_query_reply_err_options_t {
-        encoding: None.into(),
+        encoding: None,
     });
 }
 
@@ -197,8 +197,8 @@ pub extern "C" fn z_query_reply_del_options_default(
         is_express: false,
         timestamp: None,
         #[cfg(feature = "unstable")]
-        source_info: None.into(),
-        attachment: None.into(),
+        source_info: None,
+        attachment: None,
     });
 }
 

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -40,15 +40,15 @@ decl_c_type!(
 
 /// Constructs a queryable in its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_queryable_null(this: &mut MaybeUninit<z_owned_queryable_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_queryable_null(this_: &mut MaybeUninit<z_owned_queryable_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 // Borrows Queryable
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_queryable_loan(this: &z_owned_queryable_t) -> &z_loaned_queryable_t {
-    this.as_rust_type_ref()
+pub unsafe extern "C" fn z_queryable_loan(this_: &z_owned_queryable_t) -> &z_loaned_queryable_t {
+    this_.as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -62,8 +62,8 @@ decl_c_type!(
 
 /// Constructs query in its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_query_null(this: &mut MaybeUninit<z_owned_query_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_query_null(this_: &mut MaybeUninit<z_owned_query_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 /// Returns `false` if `this` is in a gravestone state, `true` otherwise.
 #[no_mangle]
@@ -73,8 +73,8 @@ pub extern "C" fn z_query_check(query: &z_owned_query_t) -> bool {
 /// Borrows the query.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_query_loan(this: &'static z_owned_query_t) -> &z_loaned_query_t {
-    this.as_rust_type_ref()
+pub unsafe extern "C" fn z_query_loan(this_: &'static z_owned_query_t) -> &z_loaned_query_t {
+    this_.as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -88,9 +88,9 @@ pub extern "C" fn z_query_drop(this_: &mut z_moved_query_t) {
 ///
 /// This operation is infallible, but may return a gravestone value if `query` itself was a gravestone value (which cannot be the case in a callback).
 #[no_mangle]
-pub extern "C" fn z_query_clone(dst: &mut MaybeUninit<z_owned_query_t>, this: &z_loaned_query_t) {
+pub extern "C" fn z_query_clone(dst: &mut MaybeUninit<z_owned_query_t>, this_: &z_loaned_query_t) {
     dst.as_rust_type_mut_uninit()
-        .write(Some(this.as_rust_type_ref().clone()));
+        .write(Some(this_.as_rust_type_ref().clone()));
 }
 
 /// Options passed to the `z_declare_queryable()` function.
@@ -103,8 +103,8 @@ pub struct z_queryable_options_t {
 /// Constructs the default value for `z_query_reply_options_t`.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_queryable_options_default(this: &mut MaybeUninit<z_queryable_options_t>) {
-    this.write(z_queryable_options_t { complete: false });
+pub extern "C" fn z_queryable_options_default(this_: &mut MaybeUninit<z_queryable_options_t>) {
+    this_.write(z_queryable_options_t { complete: false });
 }
 
 /// Represents the set of options that can be applied to a query reply,
@@ -132,8 +132,8 @@ pub struct z_query_reply_options_t {
 /// Constructs the default value for `z_query_reply_options_t`.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_query_reply_options_default(this: &mut MaybeUninit<z_query_reply_options_t>) {
-    this.write(z_query_reply_options_t {
+pub extern "C" fn z_query_reply_options_default(this_: &mut MaybeUninit<z_query_reply_options_t>) {
+    this_.write(z_query_reply_options_t {
         encoding: None.into(),
         congestion_control: CongestionControl::Block.into(),
         priority: Priority::default().into(),
@@ -254,8 +254,8 @@ pub extern "C" fn z_declare_queryable(
 /// Returns 0 in case of success, negative error code otherwise.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_undeclare_queryable(this: &mut z_moved_queryable_t) -> result::z_result_t {
-    if let Some(qable) = this.take_rust_type() {
+pub extern "C" fn z_undeclare_queryable(this_: &mut z_moved_queryable_t) -> result::z_result_t {
+    if let Some(qable) = this_.take_rust_type() {
         if let Err(e) = qable.undeclare().wait() {
             tracing::error!("{}", e);
             return result::Z_EGENERIC;
@@ -267,14 +267,14 @@ pub extern "C" fn z_undeclare_queryable(this: &mut z_moved_queryable_t) -> resul
 /// Frees memory and resets it to its gravesztone state. Will also attempt to undeclare queryable.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_queryable_drop(this: &mut z_moved_queryable_t) {
-    z_undeclare_queryable(this);
+pub extern "C" fn z_queryable_drop(this_: &mut z_moved_queryable_t) {
+    z_undeclare_queryable(this_);
 }
 
 /// Returns ``true`` if queryable is valid, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_queryable_check(this: &z_owned_queryable_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_queryable_check(this_: &z_owned_queryable_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Sends a reply to a query.
@@ -412,8 +412,8 @@ pub unsafe extern "C" fn z_query_reply_del(
 /// Gets query key expression.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_query_keyexpr(this: &z_loaned_query_t) -> &z_loaned_keyexpr_t {
-    this.as_rust_type_ref().key_expr().as_loaned_c_type_ref()
+pub extern "C" fn z_query_keyexpr(this_: &z_loaned_query_t) -> &z_loaned_keyexpr_t {
+    this_.as_rust_type_ref().key_expr().as_loaned_c_type_ref()
 }
 
 /// Gets query <a href="https://github.com/eclipse-zenoh/roadmap/tree/main/rfcs/ALL/Selectors">value selector</a>.
@@ -432,8 +432,8 @@ pub unsafe extern "C" fn z_query_parameters(
 ///
 /// Returns NULL if query does not contain a payload.
 #[no_mangle]
-pub extern "C" fn z_query_payload(this: &z_loaned_query_t) -> Option<&z_loaned_bytes_t> {
-    this.as_rust_type_ref()
+pub extern "C" fn z_query_payload(this_: &z_loaned_query_t) -> Option<&z_loaned_bytes_t> {
+    this_.as_rust_type_ref()
         .payload()
         .map(|v| v.as_loaned_c_type_ref())
 }
@@ -442,8 +442,8 @@ pub extern "C" fn z_query_payload(this: &z_loaned_query_t) -> Option<&z_loaned_b
 ///
 /// Returns NULL if query does not contain an encoding.
 #[no_mangle]
-pub extern "C" fn z_query_encoding(this: &z_loaned_query_t) -> Option<&z_loaned_encoding_t> {
-    this.as_rust_type_ref()
+pub extern "C" fn z_query_encoding(this_: &z_loaned_query_t) -> Option<&z_loaned_encoding_t> {
+    this_.as_rust_type_ref()
         .encoding()
         .map(|v| v.as_loaned_c_type_ref())
 }
@@ -452,8 +452,8 @@ pub extern "C" fn z_query_encoding(this: &z_loaned_query_t) -> Option<&z_loaned_
 ///
 /// Returns NULL if query does not contain an attachment.
 #[no_mangle]
-pub extern "C" fn z_query_attachment(this: &z_loaned_query_t) -> Option<&z_loaned_bytes_t> {
-    this.as_rust_type_ref()
+pub extern "C" fn z_query_attachment(this_: &z_loaned_query_t) -> Option<&z_loaned_bytes_t> {
+    this_.as_rust_type_ref()
         .attachment()
         .map(|a| a.as_loaned_c_type_ref())
 }

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -39,7 +39,6 @@ decl_c_type!(
         option(zenoh_ext::FetchingSubscriber<'static, ()>, &'static Session),
     ),
     loaned(ze_loaned_querying_subscriber_t),
-    moved(ze_moved_querying_subscriber_t)
 );
 
 /// Constructs a querying subscriber in a gravestone state.

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -225,14 +225,14 @@ pub extern "C" fn ze_undeclare_querying_subscriber(
 
 /// Drops querying subscriber. Also attempts to undeclare it.
 #[no_mangle]
-pub extern "C" fn ze_querying_subscriber_drop(_this: &mut ze_moved_querying_subscriber_t) {
-    ze_undeclare_querying_subscriber(_this);
+pub extern "C" fn ze_querying_subscriber_drop(this_: &mut ze_moved_querying_subscriber_t) {
+    ze_undeclare_querying_subscriber(this_);
 }
 
 /// Returns ``true`` if querying subscriber is valid, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn ze_querying_subscriber_check(this: &ze_owned_querying_subscriber_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn ze_querying_subscriber_check(this_: &ze_owned_querying_subscriber_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Borrows querying subscriber.

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -43,8 +43,8 @@ pub unsafe extern "C" fn z_hello_drop(this_: &mut z_moved_hello_t) {
 /// Borrows hello message.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_hello_loan(this: &z_owned_hello_t) -> &z_loaned_hello_t {
-    this.as_rust_type_ref()
+pub unsafe extern "C" fn z_hello_loan(this_: &z_owned_hello_t) -> &z_loaned_hello_t {
+    this_.as_rust_type_ref()
         .as_ref()
         .unwrap()
         .as_loaned_c_type_ref()
@@ -52,27 +52,27 @@ pub unsafe extern "C" fn z_hello_loan(this: &z_owned_hello_t) -> &z_loaned_hello
 
 /// Returns ``true`` if `hello message` is valid, ``false`` if it is in a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_hello_check(this: &z_owned_hello_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_hello_check(this_: &z_owned_hello_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Constructs hello message in a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_hello_null(this: &mut MaybeUninit<z_owned_hello_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_hello_null(this_: &mut MaybeUninit<z_owned_hello_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 #[cfg(feature = "unstable")]
 /// Returns id of Zenoh entity that transmitted hello message.
 #[no_mangle]
-pub extern "C" fn z_hello_zid(this: &z_loaned_hello_t) -> z_id_t {
-    this.as_rust_type_ref().zid().into_c_type()
+pub extern "C" fn z_hello_zid(this_: &z_loaned_hello_t) -> z_id_t {
+    this_.as_rust_type_ref().zid().into_c_type()
 }
 
 /// Returns type of Zenoh entity that transmitted hello message.
 #[no_mangle]
-pub extern "C" fn z_hello_whatami(this: &z_loaned_hello_t) -> z_whatami_t {
-    match this.as_rust_type_ref().whatami() {
+pub extern "C" fn z_hello_whatami(this_: &z_loaned_hello_t) -> z_whatami_t {
+    match this_.as_rust_type_ref().whatami() {
         WhatAmI::Router => z_whatami_t::ROUTER,
         WhatAmI::Peer => z_whatami_t::PEER,
         WhatAmI::Client => z_whatami_t::CLIENT,
@@ -141,8 +141,8 @@ pub const DEFAULT_SCOUTING_TIMEOUT: u64 = 1000;
 
 /// Constructs the default values for the scouting operation.
 #[no_mangle]
-pub extern "C" fn z_scout_options_default(this: &mut MaybeUninit<z_scout_options_t>) {
-    this.write(z_scout_options_t::default());
+pub extern "C" fn z_scout_options_default(this_: &mut MaybeUninit<z_scout_options_t>) {
+    this_.write(z_scout_options_t::default());
 }
 
 /// Scout for routers and/or peers.

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -31,7 +31,6 @@ use crate::{transmute::IntoCType, z_id_t};
 decl_c_type!(
     owned(z_owned_hello_t, option Hello ),
     loaned(z_loaned_hello_t),
-    moved(z_moved_hello_t)
 );
 
 /// Frees memory and resets hello message to its gravestone state.
@@ -156,15 +155,13 @@ pub extern "C" fn z_scout_options_default(this: &mut MaybeUninit<z_scout_options
 #[no_mangle]
 pub extern "C" fn z_scout(
     config: z_moved_config_t,
-    callback: z_moved_closure_hello_t,
+    callback: &mut z_moved_closure_hello_t,
     options: Option<&z_scout_options_t>,
 ) -> result::z_result_t {
     if cfg!(feature = "logger-autoinit") {
         zc_init_logging();
     }
-    let Some(callback) = callback.into_rust_type() else {
-        return result::Z_EINVAL;
-    };
+    let callback = callback.into_rust_type();
     let options = options.cloned().unwrap_or_default();
     let what =
         WhatAmIMatcher::try_from(options.what as u8).unwrap_or(WhatAmI::Router | WhatAmI::Peer);

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -44,7 +44,8 @@ pub unsafe extern "C" fn z_hello_drop(this_: &mut z_moved_hello_t) {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_hello_loan(this_: &z_owned_hello_t) -> &z_loaned_hello_t {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .as_ref()
         .unwrap()
         .as_loaned_c_type_ref()

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -36,8 +36,9 @@ decl_c_type!(
 /// Frees memory and resets hello message to its gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-#[allow(unused_variables)]
-pub unsafe extern "C" fn z_hello_drop(this: z_moved_hello_t) {}
+pub unsafe extern "C" fn z_hello_drop(this_: &mut z_moved_hello_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Borrows hello message.
 #[no_mangle]

--- a/src/session.rs
+++ b/src/session.rs
@@ -85,14 +85,14 @@ pub extern "C" fn z_open(
 #[no_mangle]
 pub extern "C" fn z_open_with_custom_shm_clients(
     this: &mut MaybeUninit<z_owned_session_t>,
-    config: z_moved_config_t,
+    config: &mut z_moved_config_t,
     shm_clients: &z_loaned_shm_client_storage_t,
 ) -> result::z_result_t {
     let this = this.as_rust_type_mut_uninit();
     if cfg!(feature = "logger-autoinit") {
         zc_init_logging();
     }
-    let Some(config) = config.into_rust_type().take() else {
+    let Some(config) = config.take_rust_type() else {
         tracing::error!("Config not provided");
         this.write(None);
         return result::Z_EINVAL;

--- a/src/session.rs
+++ b/src/session.rs
@@ -148,8 +148,9 @@ pub extern "C" fn z_close(session: &mut z_moved_session_t) -> result::z_result_t
 ///
 /// This will also close the session if it does not have any clones left.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_session_drop(this: z_moved_session_t) {}
+pub extern "C" fn z_session_drop(this_: &mut z_moved_session_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Constructs an owned shallow copy of the session in provided uninitialized memory location.
 #[allow(clippy::missing_safety_doc)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -33,7 +33,8 @@ decl_c_type!(
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_session_loan(this_: &z_owned_session_t) -> &z_loaned_session_t {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()

--- a/src/session.rs
+++ b/src/session.rs
@@ -32,8 +32,8 @@ decl_c_type!(
 /// Borrows session.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_session_loan(this: &z_owned_session_t) -> &z_loaned_session_t {
-    this.as_rust_type_ref()
+pub unsafe extern "C" fn z_session_loan(this_: &z_owned_session_t) -> &z_loaned_session_t {
+    this_.as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -42,8 +42,8 @@ pub unsafe extern "C" fn z_session_loan(this: &z_owned_session_t) -> &z_loaned_s
 /// Constructs a Zenoh session in its gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_session_null(this: &mut MaybeUninit<z_owned_session_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_session_null(this_: &mut MaybeUninit<z_owned_session_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Constructs and opens a new Zenoh session.
@@ -116,8 +116,8 @@ pub extern "C" fn z_open_with_custom_shm_clients(
 /// Returns ``true`` if `session` is valid, ``false`` otherwise.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_session_check(this: &z_owned_session_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_session_check(this_: &z_owned_session_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Closes a zenoh session. This alos drops and invalidates `session`.

--- a/src/session.rs
+++ b/src/session.rs
@@ -27,7 +27,6 @@ use crate::{
 decl_c_type!(
     owned(z_owned_session_t, option Arc<Session>),
     loaned(z_loaned_session_t),
-    moved(z_moved_session_t)
 );
 
 /// Borrows session.

--- a/src/shm/buffer/zshm.rs
+++ b/src/shm/buffer/zshm.rs
@@ -31,27 +31,27 @@ decl_c_type!(
 
 /// Constructs ZShm slice from ZShmMut slice
 #[no_mangle]
-pub extern "C" fn z_shm_from_mut(this: &mut MaybeUninit<z_owned_shm_t>, that: &mut z_moved_shm_mut_t) {
+pub extern "C" fn z_shm_from_mut(this_: &mut MaybeUninit<z_owned_shm_t>, that: &mut z_moved_shm_mut_t) {
     let shm: Option<ZShm> = that.take_rust_type().take().map(|val| val.into());
-    this.as_rust_type_mut_uninit().write(shm);
+    this_.as_rust_type_mut_uninit().write(shm);
 }
 
 /// Constructs ZShm slice in its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_shm_null(this: &mut MaybeUninit<z_owned_shm_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_shm_null(this_: &mut MaybeUninit<z_owned_shm_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if `this` is valid.
 #[no_mangle]
-pub extern "C" fn z_shm_check(this: &z_owned_shm_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_shm_check(this_: &z_owned_shm_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Converts borrowed ZShm slice to owned ZShm slice by performing a shallow SHM reference copy
 #[no_mangle]
-pub extern "C" fn z_shm_clone(out: &mut MaybeUninit<z_owned_shm_t>, this: &z_loaned_shm_t) {
-    let this = this.as_rust_type_ref();
+pub extern "C" fn z_shm_clone(out: &mut MaybeUninit<z_owned_shm_t>, this_: &z_loaned_shm_t) {
+    let this = this_.as_rust_type_ref();
     let copy = this.to_owned();
     out.as_rust_type_mut_uninit().write(Some(copy));
 }
@@ -59,16 +59,16 @@ pub extern "C" fn z_shm_clone(out: &mut MaybeUninit<z_owned_shm_t>, this: &z_loa
 /// Borrows ZShm slice
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_shm_loan(this: &z_owned_shm_t) -> &z_loaned_shm_t {
-    let this: &zshm = this.as_rust_type_ref().as_ref().unwrap_unchecked().borrow();
+pub unsafe extern "C" fn z_shm_loan(this_: &z_owned_shm_t) -> &z_loaned_shm_t {
+    let this: &zshm = this_.as_rust_type_ref().as_ref().unwrap_unchecked().borrow();
     this.as_loaned_c_type_ref()
 }
 
 /// Mutably borrows ZShm slice
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_shm_loan_mut(this: &mut z_owned_shm_t) -> &mut z_loaned_shm_t {
-    let this: &mut zshm = this
+pub unsafe extern "C" fn z_shm_loan_mut(this_: &mut z_owned_shm_t) -> &mut z_loaned_shm_t {
+    let this: &mut zshm = this_
         .as_rust_type_mut()
         .as_mut()
         .unwrap_unchecked()
@@ -79,8 +79,8 @@ pub unsafe extern "C" fn z_shm_loan_mut(this: &mut z_owned_shm_t) -> &mut z_loan
 /// Mutably borrows ZShm slice as borrowed ZShmMut slice
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_shm_try_mut(this: &mut z_owned_shm_t) -> *mut z_loaned_shm_mut_t {
-    let this = this.as_rust_type_mut();
+pub unsafe extern "C" fn z_shm_try_mut(this_: &mut z_owned_shm_t) -> *mut z_loaned_shm_mut_t {
+    let this = this_.as_rust_type_mut();
     let this: &mut ZShm = this.as_mut().unwrap_unchecked();
     let shm: &mut zshm = this.borrow_mut();
     match shm.try_into() {
@@ -100,8 +100,8 @@ pub extern "C" fn z_shm_drop(this_: &mut z_moved_shm_t) {
 
 /// Tries to reborrow mutably-borrowed ZShm slice as borrowed ZShmMut slice
 #[no_mangle]
-pub extern "C" fn z_shm_try_reloan_mut(this: &mut z_loaned_shm_t) -> *mut z_loaned_shm_mut_t {
-    let this = this.as_rust_type_mut();
+pub extern "C" fn z_shm_try_reloan_mut(this_: &mut z_loaned_shm_t) -> *mut z_loaned_shm_mut_t {
+    let this = this_.as_rust_type_mut();
     match this.try_into() {
         Ok(val) => {
             let v: &mut zshmmut = val;
@@ -113,13 +113,13 @@ pub extern "C" fn z_shm_try_reloan_mut(this: &mut z_loaned_shm_t) -> *mut z_loan
 
 /// @return the length of the ZShm slice
 #[no_mangle]
-pub extern "C" fn z_shm_len(this: &z_loaned_shm_t) -> usize {
-    this.as_rust_type_ref().len()
+pub extern "C" fn z_shm_len(this_: &z_loaned_shm_t) -> usize {
+    this_.as_rust_type_ref().len()
 }
 
 /// @return the pointer of the ZShm slice
 #[no_mangle]
-pub extern "C" fn z_shm_data(this: &z_loaned_shm_t) -> *const libc::c_uchar {
-    let s = this.as_rust_type_ref();
+pub extern "C" fn z_shm_data(this_: &z_loaned_shm_t) -> *const libc::c_uchar {
+    let s = this_.as_rust_type_ref();
     s.as_ref().as_ptr()
 }

--- a/src/shm/buffer/zshm.rs
+++ b/src/shm/buffer/zshm.rs
@@ -27,7 +27,6 @@ use crate::{
 decl_c_type!(
     owned(z_owned_shm_t, option ZShm),
     loaned(z_loaned_shm_t, zshm),
-    moved(z_moved_shm_t)
 );
 
 /// Constructs ZShm slice from ZShmMut slice

--- a/src/shm/buffer/zshm.rs
+++ b/src/shm/buffer/zshm.rs
@@ -94,8 +94,9 @@ pub unsafe extern "C" fn z_shm_try_mut(this: &mut z_owned_shm_t) -> *mut z_loane
 
 /// Deletes ZShm slice
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_shm_drop(this: z_moved_shm_t) {}
+pub extern "C" fn z_shm_drop(this_: &mut z_moved_shm_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Tries to reborrow mutably-borrowed ZShm slice as borrowed ZShmMut slice
 #[no_mangle]

--- a/src/shm/buffer/zshm.rs
+++ b/src/shm/buffer/zshm.rs
@@ -31,7 +31,10 @@ decl_c_type!(
 
 /// Constructs ZShm slice from ZShmMut slice
 #[no_mangle]
-pub extern "C" fn z_shm_from_mut(this_: &mut MaybeUninit<z_owned_shm_t>, that: &mut z_moved_shm_mut_t) {
+pub extern "C" fn z_shm_from_mut(
+    this_: &mut MaybeUninit<z_owned_shm_t>,
+    that: &mut z_moved_shm_mut_t,
+) {
     let shm: Option<ZShm> = that.take_rust_type().take().map(|val| val.into());
     this_.as_rust_type_mut_uninit().write(shm);
 }
@@ -60,7 +63,11 @@ pub extern "C" fn z_shm_clone(out: &mut MaybeUninit<z_owned_shm_t>, this_: &z_lo
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_shm_loan(this_: &z_owned_shm_t) -> &z_loaned_shm_t {
-    let this: &zshm = this_.as_rust_type_ref().as_ref().unwrap_unchecked().borrow();
+    let this: &zshm = this_
+        .as_rust_type_ref()
+        .as_ref()
+        .unwrap_unchecked()
+        .borrow();
     this.as_loaned_c_type_ref()
 }
 

--- a/src/shm/buffer/zshm.rs
+++ b/src/shm/buffer/zshm.rs
@@ -20,7 +20,7 @@ use std::{
 use zenoh::shm::{zshm, zshmmut, ZShm};
 
 use crate::{
-    transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_shm_mut_t, z_loaned_shm_t, z_moved_shm_mut_t, z_moved_shm_t, z_owned_shm_t,
 };
 
@@ -31,8 +31,8 @@ decl_c_type!(
 
 /// Constructs ZShm slice from ZShmMut slice
 #[no_mangle]
-pub extern "C" fn z_shm_from_mut(this: &mut MaybeUninit<z_owned_shm_t>, that: z_moved_shm_mut_t) {
-    let shm: Option<ZShm> = that.into_rust_type().take().map(|val| val.into());
+pub extern "C" fn z_shm_from_mut(this: &mut MaybeUninit<z_owned_shm_t>, that: &mut z_moved_shm_mut_t) {
+    let shm: Option<ZShm> = that.take_rust_type().take().map(|val| val.into());
     this.as_rust_type_mut_uninit().write(shm);
 }
 

--- a/src/shm/buffer/zshmmut.rs
+++ b/src/shm/buffer/zshmmut.rs
@@ -27,7 +27,6 @@ use crate::{
 decl_c_type!(
     owned(z_owned_shm_mut_t, option ZShmMut),
     loaned(z_loaned_shm_mut_t, zshmmut),
-    moved(z_moved_shm_mut_t)
 );
 
 /// Tries to construct ZShmMut slice from ZShm slice

--- a/src/shm/buffer/zshmmut.rs
+++ b/src/shm/buffer/zshmmut.rs
@@ -58,7 +58,11 @@ pub extern "C" fn z_shm_mut_check(this_: &z_owned_shm_mut_t) -> bool {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_shm_mut_loan(this_: &z_owned_shm_mut_t) -> &z_loaned_shm_mut_t {
-    let shmmut: &zshmmut = this_.as_rust_type_ref().as_ref().unwrap_unchecked().borrow();
+    let shmmut: &zshmmut = this_
+        .as_rust_type_ref()
+        .as_ref()
+        .unwrap_unchecked()
+        .borrow();
     shmmut.as_loaned_c_type_ref()
 }
 

--- a/src/shm/buffer/zshmmut.rs
+++ b/src/shm/buffer/zshmmut.rs
@@ -78,8 +78,9 @@ pub unsafe extern "C" fn z_shm_mut_loan_mut(
 
 /// Deletes ZShmMut slice
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_shm_mut_drop(this: z_moved_shm_mut_t) {}
+pub extern "C" fn z_shm_mut_drop(this_: &mut z_moved_shm_mut_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// @return the length of the ZShmMut slice
 #[no_mangle]

--- a/src/shm/buffer/zshmmut.rs
+++ b/src/shm/buffer/zshmmut.rs
@@ -20,7 +20,7 @@ use std::{
 use zenoh::shm::{zshmmut, ZShmMut};
 
 use crate::{
-    transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_shm_mut_t, z_moved_shm_mut_t, z_moved_shm_t, z_owned_shm_mut_t,
 };
 
@@ -33,10 +33,10 @@ decl_c_type!(
 #[no_mangle]
 pub extern "C" fn z_shm_mut_try_from_immut(
     this: &mut MaybeUninit<z_owned_shm_mut_t>,
-    that: z_moved_shm_t,
+    that: &mut z_moved_shm_t,
 ) {
     let shm: Option<ZShmMut> = that
-        .into_rust_type()
+        .take_rust_type()
         .take()
         .and_then(|val| val.try_into().ok());
     this.as_rust_type_mut_uninit().write(shm);

--- a/src/shm/buffer/zshmmut.rs
+++ b/src/shm/buffer/zshmmut.rs
@@ -44,21 +44,21 @@ pub extern "C" fn z_shm_mut_try_from_immut(
 
 /// Constructs ZShmMut slice in its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_shm_mut_null(this: &mut MaybeUninit<z_owned_shm_mut_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_shm_mut_null(this_: &mut MaybeUninit<z_owned_shm_mut_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if `this` is valid.
 #[no_mangle]
-pub extern "C" fn z_shm_mut_check(this: &z_owned_shm_mut_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_shm_mut_check(this_: &z_owned_shm_mut_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Borrows ZShmMut slice
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_shm_mut_loan(this: &z_owned_shm_mut_t) -> &z_loaned_shm_mut_t {
-    let shmmut: &zshmmut = this.as_rust_type_ref().as_ref().unwrap_unchecked().borrow();
+pub unsafe extern "C" fn z_shm_mut_loan(this_: &z_owned_shm_mut_t) -> &z_loaned_shm_mut_t {
+    let shmmut: &zshmmut = this_.as_rust_type_ref().as_ref().unwrap_unchecked().borrow();
     shmmut.as_loaned_c_type_ref()
 }
 
@@ -84,19 +84,19 @@ pub extern "C" fn z_shm_mut_drop(this_: &mut z_moved_shm_mut_t) {
 
 /// @return the length of the ZShmMut slice
 #[no_mangle]
-pub extern "C" fn z_shm_mut_len(this: &z_loaned_shm_mut_t) -> usize {
-    this.as_rust_type_ref().len()
+pub extern "C" fn z_shm_mut_len(this_: &z_loaned_shm_mut_t) -> usize {
+    this_.as_rust_type_ref().len()
 }
 
 /// @return the immutable pointer to the underlying data
 #[no_mangle]
-pub extern "C" fn z_shm_mut_data(this: &z_loaned_shm_mut_t) -> *const libc::c_uchar {
-    let s = this.as_rust_type_ref();
+pub extern "C" fn z_shm_mut_data(this_: &z_loaned_shm_mut_t) -> *const libc::c_uchar {
+    let s = this_.as_rust_type_ref();
     s.as_ref().as_ptr()
 }
 
 /// @return the mutable pointer to the underlying data
 #[no_mangle]
-pub extern "C" fn z_shm_mut_data_mut(this: &mut z_loaned_shm_mut_t) -> *mut libc::c_uchar {
-    this.as_rust_type_mut().as_mut().as_mut_ptr()
+pub extern "C" fn z_shm_mut_data_mut(this_: &mut z_loaned_shm_mut_t) -> *mut libc::c_uchar {
+    this_.as_rust_type_mut().as_mut().as_mut_ptr()
 }

--- a/src/shm/client/shm_client.rs
+++ b/src/shm/client/shm_client.rs
@@ -80,14 +80,14 @@ pub extern "C" fn z_shm_client_new(
 
 /// Constructs SHM client in its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_shm_client_null(this: &mut MaybeUninit<z_owned_shm_client_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_shm_client_null(this_: &mut MaybeUninit<z_owned_shm_client_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if `this` is valid.
 #[no_mangle]
-pub extern "C" fn z_shm_client_check(this: &z_owned_shm_client_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_shm_client_check(this_: &z_owned_shm_client_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Deletes SHM Client

--- a/src/shm/client/shm_client.rs
+++ b/src/shm/client/shm_client.rs
@@ -25,7 +25,7 @@ pub use crate::opaque_types::{z_moved_shm_client_t, z_owned_shm_client_t};
 use crate::{
     context::{zc_threadsafe_context_t, DroppableContext, ThreadsafeContext},
     shm::common::types::z_segment_id_t,
-    transmute::{RustTypeRef, RustTypeRefUninit},
+    transmute::{RustTypeRef, RustTypeRefUninit, TakeRustType},
 };
 
 /// A callbacks for ShmClient
@@ -92,5 +92,6 @@ pub extern "C" fn z_shm_client_check(this: &z_owned_shm_client_t) -> bool {
 
 /// Deletes SHM Client
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_shm_client_drop(this: z_moved_shm_client_t) {}
+pub extern "C" fn z_shm_client_drop(this_: &mut z_moved_shm_client_t) {
+    let _ = this_.take_rust_type();
+}

--- a/src/shm/client/shm_client.rs
+++ b/src/shm/client/shm_client.rs
@@ -41,7 +41,6 @@ pub struct zc_shm_client_callbacks_t {
 
 decl_c_type!(
     owned(z_owned_shm_client_t, option Arc<dyn ShmClient>),
-    moved(z_moved_shm_client_t)
 );
 
 #[derive(Debug)]

--- a/src/shm/client_storage/mod.rs
+++ b/src/shm/client_storage/mod.rs
@@ -32,21 +32,21 @@ decl_c_type!(
 
 /// Creates a new empty list of SHM Clients
 #[no_mangle]
-pub extern "C" fn zc_shm_client_list_new(this: &mut MaybeUninit<zc_owned_shm_client_list_t>) {
+pub extern "C" fn zc_shm_client_list_new(this_: &mut MaybeUninit<zc_owned_shm_client_list_t>) {
     let client_list: Vec<(ProtocolID, Arc<dyn ShmClient>)> = Vec::default();
-    this.as_rust_type_mut_uninit().write(Some(client_list));
+    this_.as_rust_type_mut_uninit().write(Some(client_list));
 }
 
 /// Constructs SHM client list in its gravestone value.
 #[no_mangle]
-pub extern "C" fn zc_shm_client_list_null(this: &mut MaybeUninit<zc_owned_shm_client_list_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn zc_shm_client_list_null(this_: &mut MaybeUninit<zc_owned_shm_client_list_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if `this` is valid.
 #[no_mangle]
-pub extern "C" fn zc_shm_client_list_check(this: &zc_owned_shm_client_list_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn zc_shm_client_list_check(this_: &zc_owned_shm_client_list_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Deletes list of SHM Clients
@@ -150,14 +150,14 @@ pub extern "C" fn z_shm_client_storage_clone(
 
 /// Constructs SHM Client Storage in its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_shm_client_storage_null(this: &mut MaybeUninit<z_owned_shm_client_storage_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_shm_client_storage_null(this_: &mut MaybeUninit<z_owned_shm_client_storage_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if `this` is valid.
 #[no_mangle]
-pub extern "C" fn z_shm_client_storage_check(this: &z_owned_shm_client_storage_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_shm_client_storage_check(this_: &z_owned_shm_client_storage_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Derefs SHM Client Storage

--- a/src/shm/client_storage/mod.rs
+++ b/src/shm/client_storage/mod.rs
@@ -28,7 +28,6 @@ use crate::{
 decl_c_type!(
     owned(zc_owned_shm_client_list_t, option Vec<(ProtocolID, Arc<dyn ShmClient>)>),
     loaned(zc_loaned_shm_client_list_t),
-    moved(zc_moved_shm_client_list_t)
 );
 
 /// Creates a new empty list of SHM Clients
@@ -95,7 +94,6 @@ pub extern "C" fn zc_shm_client_list_add_client(
 decl_c_type!(
     owned(z_owned_shm_client_storage_t, option Arc<ShmClientStorage> ),
     loaned(z_loaned_shm_client_storage_t),
-    moved(z_moved_shm_client_storage_t)
 );
 
 #[no_mangle]

--- a/src/shm/client_storage/mod.rs
+++ b/src/shm/client_storage/mod.rs
@@ -51,8 +51,9 @@ pub extern "C" fn zc_shm_client_list_check(this: &zc_owned_shm_client_list_t) ->
 
 /// Deletes list of SHM Clients
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn zc_shm_client_list_drop(this: zc_moved_shm_client_list_t) {}
+pub extern "C" fn zc_shm_client_list_drop(this_: &mut zc_moved_shm_client_list_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Borrows list of SHM Clients
 #[no_mangle]
@@ -161,8 +162,9 @@ pub extern "C" fn z_shm_client_storage_check(this: &z_owned_shm_client_storage_t
 
 /// Derefs SHM Client Storage
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_shm_client_storage_drop(this: z_moved_shm_client_storage_t) {}
+pub extern "C" fn z_shm_client_storage_drop(this_: &mut z_moved_shm_client_storage_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Borrows SHM Client Storage
 #[no_mangle]

--- a/src/shm/client_storage/mod.rs
+++ b/src/shm/client_storage/mod.rs
@@ -19,7 +19,7 @@ use zenoh::shm::{ProtocolID, ShmClient, ShmClientStorage, GLOBAL_CLIENT_STORAGE}
 use super::common::types::z_protocol_id_t;
 use crate::{
     result::{z_result_t, Z_EINVAL, Z_OK},
-    transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_shm_client_storage_t, z_moved_shm_client_storage_t, z_moved_shm_client_t,
     z_owned_shm_client_storage_t, zc_loaned_shm_client_list_t, zc_moved_shm_client_list_t,
     zc_owned_shm_client_list_t,
@@ -81,10 +81,10 @@ pub unsafe extern "C" fn zc_shm_client_list_loan_mut(
 #[no_mangle]
 pub extern "C" fn zc_shm_client_list_add_client(
     id: z_protocol_id_t,
-    client: z_moved_shm_client_t,
+    client: &mut z_moved_shm_client_t,
     list: &mut zc_loaned_shm_client_list_t,
 ) -> z_result_t {
-    let Some(client) = client.into_rust_type() else {
+    let Some(client) = client.take_rust_type() else {
         return Z_EINVAL;
     };
     list.as_rust_type_mut().push((id, client));

--- a/src/shm/protocol_implementations/posix/posix_shm_client.rs
+++ b/src/shm/protocol_implementations/posix/posix_shm_client.rs
@@ -20,7 +20,7 @@ use crate::{transmute::RustTypeRefUninit, z_owned_shm_client_t};
 
 /// Creates a new POSIX SHM Client
 #[no_mangle]
-pub extern "C" fn z_posix_shm_client_new(this: &mut MaybeUninit<z_owned_shm_client_t>) {
+pub extern "C" fn z_posix_shm_client_new(this_: &mut MaybeUninit<z_owned_shm_client_t>) {
     let client = Arc::new(PosixShmClient) as Arc<dyn ShmClient>;
-    this.as_rust_type_mut_uninit().write(Some(client));
+    this_.as_rust_type_mut_uninit().write(Some(client));
 }

--- a/src/shm/provider/alloc_layout.rs
+++ b/src/shm/provider/alloc_layout.rs
@@ -63,14 +63,14 @@ pub extern "C" fn z_alloc_layout_new(
 
 /// Constructs Alloc Layout in its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_alloc_layout_null(this: &mut MaybeUninit<z_owned_alloc_layout_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_alloc_layout_null(this_: &mut MaybeUninit<z_owned_alloc_layout_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if `this` is valid.
 #[no_mangle]
-pub extern "C" fn z_alloc_layout_check(this: &z_owned_alloc_layout_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_alloc_layout_check(this_: &z_owned_alloc_layout_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Borrows Alloc Layout

--- a/src/shm/provider/alloc_layout.rs
+++ b/src/shm/provider/alloc_layout.rs
@@ -28,7 +28,7 @@ use crate::{
     context::{zc_threadsafe_context_t, Context, ThreadsafeContext},
     result::z_result_t,
     shm::protocol_implementations::posix::posix_shm_provider::PosixAllocLayout,
-    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_alloc_layout_t, z_loaned_shm_provider_t, z_moved_alloc_layout_t,
     z_owned_alloc_layout_t,
 };
@@ -87,8 +87,9 @@ pub unsafe extern "C" fn z_alloc_layout_loan(
 
 /// Deletes Alloc Layout
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_alloc_layout_drop(this: z_moved_alloc_layout_t) {}
+pub extern "C" fn z_alloc_layout_drop(this_: &mut z_moved_alloc_layout_t) {
+    let _ = this_.take_rust_type();
+}
 
 #[no_mangle]
 pub extern "C" fn z_alloc_layout_alloc(

--- a/src/shm/provider/alloc_layout.rs
+++ b/src/shm/provider/alloc_layout.rs
@@ -48,7 +48,6 @@ pub enum CSHMLayout {
 decl_c_type!(
     owned(z_owned_alloc_layout_t, option CSHMLayout),
     loaned(z_loaned_alloc_layout_t),
-    moved(z_moved_alloc_layout_t)
 );
 
 /// Creates a new Alloc Layout for SHM Provider

--- a/src/shm/provider/shm_provider.rs
+++ b/src/shm/provider/shm_provider.rs
@@ -92,14 +92,14 @@ pub extern "C" fn z_shm_provider_threadsafe_new(
 
 /// Constructs SHM Provider in its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_shm_provider_null(this: &mut MaybeUninit<z_owned_shm_provider_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_shm_provider_null(this_: &mut MaybeUninit<z_owned_shm_provider_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if `this` is valid.
 #[no_mangle]
-pub extern "C" fn z_shm_provider_check(this: &z_owned_shm_provider_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_shm_provider_check(this_: &z_owned_shm_provider_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Borrows SHM Provider

--- a/src/shm/provider/shm_provider.rs
+++ b/src/shm/provider/shm_provider.rs
@@ -52,7 +52,6 @@ pub enum CSHMProvider {
 decl_c_type!(
     owned(z_owned_shm_provider_t, option CSHMProvider),
     loaned(z_loaned_shm_provider_t),
-    moved(z_moved_shm_provider_t)
 );
 
 /// Creates a new SHM Provider

--- a/src/shm/provider/shm_provider.rs
+++ b/src/shm/provider/shm_provider.rs
@@ -34,7 +34,7 @@ use crate::{
         protocol_implementations::posix::posix_shm_provider::PosixShmProvider,
         provider::types::z_buf_layout_alloc_result_t,
     },
-    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_shm_provider_t, z_moved_shm_provider_t, z_owned_shm_mut_t, z_owned_shm_provider_t,
 };
 
@@ -116,8 +116,9 @@ pub unsafe extern "C" fn z_shm_provider_loan(
 
 /// Deletes SHM Provider
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_shm_provider_drop(this: z_moved_shm_provider_t) {}
+pub extern "C" fn z_shm_provider_drop(this_: &mut z_moved_shm_provider_t) {
+    let _ = this_.take_rust_type();
+}
 
 #[no_mangle]
 pub extern "C" fn z_shm_provider_alloc(

--- a/src/shm/provider/types.rs
+++ b/src/shm/provider/types.rs
@@ -114,7 +114,6 @@ decl_c_type!(copy(z_alloc_alignment_t, AllocAlignment),);
 decl_c_type_inequal!(
     owned(z_owned_memory_layout_t, option MemoryLayout),
     loaned(z_loaned_memory_layout_t),
-    moved(z_moved_memory_layout_t)
 );
 
 /// Creates a new Memory Layout
@@ -188,7 +187,6 @@ pub extern "C" fn z_memory_layout_get_data(
 decl_c_type!(
     owned(z_owned_chunk_alloc_result_t, option ChunkAllocResult),
     loaned(z_loaned_chunk_alloc_result_t),
-    moved(z_moved_chunk_alloc_result_t)
 );
 
 /// Creates a new Chunk Alloc Result with Ok value

--- a/src/shm/provider/types.rs
+++ b/src/shm/provider/types.rs
@@ -26,7 +26,7 @@ use super::chunk::z_allocated_chunk_t;
 use crate::{
     result::{z_result_t, Z_EINVAL, Z_OK},
     shm::buffer::zshmmut::z_shm_mut_null,
-    transmute::{IntoCType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit},
+    transmute::{IntoCType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_chunk_alloc_result_t, z_loaned_memory_layout_t, z_moved_chunk_alloc_result_t,
     z_moved_memory_layout_t, z_owned_chunk_alloc_result_t, z_owned_memory_layout_t,
     z_owned_shm_mut_t,
@@ -169,8 +169,9 @@ pub unsafe extern "C" fn z_memory_layout_loan(
 
 /// Deletes Memory Layout
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_memory_layout_drop(this: z_moved_memory_layout_t) {}
+pub extern "C" fn z_memory_layout_drop(this_: &mut z_moved_memory_layout_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Extract data from Memory Layout
 #[no_mangle]
@@ -240,8 +241,9 @@ pub unsafe extern "C" fn z_chunk_alloc_result_loan(
 
 /// Deletes Chunk Alloc Result
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_chunk_alloc_result_drop(this: z_moved_chunk_alloc_result_t) {}
+pub extern "C" fn z_chunk_alloc_result_drop(this_: &mut z_moved_chunk_alloc_result_t) {
+    let _ = this_.take_rust_type();
+}
 
 #[repr(C)]
 pub struct z_buf_alloc_result_t {

--- a/src/shm/provider/types.rs
+++ b/src/shm/provider/types.rs
@@ -145,14 +145,14 @@ fn create_memory_layout(
 
 /// Constructs Memory Layout in its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_memory_layout_null(this: &mut MaybeUninit<z_owned_memory_layout_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_memory_layout_null(this_: &mut MaybeUninit<z_owned_memory_layout_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if `this` is valid.
 #[no_mangle]
-pub extern "C" fn z_memory_layout_check(this: &z_owned_memory_layout_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_memory_layout_check(this_: &z_owned_memory_layout_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Borrows Memory Layout
@@ -217,14 +217,14 @@ pub extern "C" fn z_chunk_alloc_result_new_error(
 
 /// Constructs Chunk Alloc Result in its gravestone value.
 #[no_mangle]
-pub extern "C" fn z_chunk_alloc_result_null(this: &mut MaybeUninit<z_owned_chunk_alloc_result_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_chunk_alloc_result_null(this_: &mut MaybeUninit<z_owned_chunk_alloc_result_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Returns ``true`` if `this` is valid.
 #[no_mangle]
-pub extern "C" fn z_chunk_alloc_result_check(this: &z_owned_chunk_alloc_result_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_chunk_alloc_result_check(this_: &z_owned_chunk_alloc_result_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }
 
 /// Borrows Chunk Alloc Result

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -74,7 +74,8 @@ pub extern "C" fn z_subscriber_null(this_: &mut MaybeUninit<z_owned_subscriber_t
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_subscriber_loan(this_: &z_owned_subscriber_t) -> &z_loaned_subscriber_t {
-    this_.as_rust_type_ref()
+    this_
+        .as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -62,7 +62,6 @@ pub use crate::opaque_types::{z_loaned_subscriber_t, z_moved_subscriber_t, z_own
 decl_c_type!(
     owned(z_owned_subscriber_t, option Subscriber<'static, ()>),
     loaned(z_loaned_subscriber_t),
-    moved(z_moved_subscriber_t)
 );
 
 /// Constructs a subscriber in a gravestone state.
@@ -112,16 +111,13 @@ pub extern "C" fn z_declare_subscriber(
     this: &mut MaybeUninit<z_owned_subscriber_t>,
     session: &z_loaned_session_t,
     key_expr: &z_loaned_keyexpr_t,
-    callback: z_moved_closure_sample_t,
+    callback: &mut z_moved_closure_sample_t,
     options: Option<&mut z_subscriber_options_t>,
 ) -> result::z_result_t {
     let this = this.as_rust_type_mut_uninit();
     let session = session.as_rust_type_ref();
     let key_expr = key_expr.as_rust_type_ref();
-    let Some(callback) = callback.into_rust_type() else {
-        this.write(None);
-        return result::Z_EINVAL;
-    };
+    let callback = callback.into_rust_type();
     let mut subscriber = session
         .declare_subscriber(key_expr)
         .callback(move |sample| {

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -167,8 +167,9 @@ pub extern "C" fn z_undeclare_subscriber(_this: &mut z_moved_subscriber_t) -> re
 
 /// Drops subscriber and resets it to its gravestone state. Also attempts to undeclare it.
 #[no_mangle]
-#[allow(unused_variables)]
-pub extern "C" fn z_subscriber_drop(this: z_moved_subscriber_t) {}
+pub extern "C" fn z_subscriber_drop(this_: &mut z_moved_subscriber_t) {
+    let _ = this_.take_rust_type();
+}
 
 /// Returns ``true`` if subscriber is valid, ``false`` otherwise.
 #[no_mangle]

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -66,15 +66,15 @@ decl_c_type!(
 
 /// Constructs a subscriber in a gravestone state.
 #[no_mangle]
-pub extern "C" fn z_subscriber_null(this: &mut MaybeUninit<z_owned_subscriber_t>) {
-    this.as_rust_type_mut_uninit().write(None);
+pub extern "C" fn z_subscriber_null(this_: &mut MaybeUninit<z_owned_subscriber_t>) {
+    this_.as_rust_type_mut_uninit().write(None);
 }
 
 /// Borrows subscriber.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_subscriber_loan(this: &z_owned_subscriber_t) -> &z_loaned_subscriber_t {
-    this.as_rust_type_ref()
+pub unsafe extern "C" fn z_subscriber_loan(this_: &z_owned_subscriber_t) -> &z_loaned_subscriber_t {
+    this_.as_rust_type_ref()
         .as_ref()
         .unwrap_unchecked()
         .as_loaned_c_type_ref()
@@ -90,8 +90,8 @@ pub struct z_subscriber_options_t {
 
 /// Constructs the default value for `z_subscriber_options_t`.
 #[no_mangle]
-pub extern "C" fn z_subscriber_options_default(this: &mut MaybeUninit<z_subscriber_options_t>) {
-    this.write(z_subscriber_options_t {
+pub extern "C" fn z_subscriber_options_default(this_: &mut MaybeUninit<z_subscriber_options_t>) {
+    this_.write(z_subscriber_options_t {
         reliability: Reliability::DEFAULT.into(),
     });
 }
@@ -155,8 +155,8 @@ pub extern "C" fn z_subscriber_keyexpr(subscriber: &z_loaned_subscriber_t) -> &z
 /// @return 0 in case of success, negative error code otherwise.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn z_undeclare_subscriber(_this: &mut z_moved_subscriber_t) -> result::z_result_t {
-    if let Some(s) = _this.take_rust_type() {
+pub extern "C" fn z_undeclare_subscriber(this_: &mut z_moved_subscriber_t) -> result::z_result_t {
+    if let Some(s) = this_.take_rust_type() {
         if let Err(e) = s.undeclare().wait() {
             tracing::error!("{}", e);
             return result::Z_EGENERIC;
@@ -173,6 +173,6 @@ pub extern "C" fn z_subscriber_drop(this_: &mut z_moved_subscriber_t) {
 
 /// Returns ``true`` if subscriber is valid, ``false`` otherwise.
 #[no_mangle]
-pub extern "C" fn z_subscriber_check(this: &z_owned_subscriber_t) -> bool {
-    this.as_rust_type_ref().is_some()
+pub extern "C" fn z_subscriber_check(this_: &z_owned_subscriber_t) -> bool {
+    this_.as_rust_type_ref().is_some()
 }

--- a/src/transmute.rs
+++ b/src/transmute.rs
@@ -184,6 +184,14 @@ macro_rules! impl_transmute {
             }
         }
     };
+    (into_rust (itself $rust_type:ty)) => {
+        impl $crate::transmute::IntoRustType for $rust_type {
+            type RustType = $rust_type;
+            fn into_rust_type(self) -> Self::RustType {
+                self
+            }
+        }
+    };
     (take_rust ($c_type:ty, $rust_type:ty)) => {
         impl Default for $c_type {
             fn default() -> Self {
@@ -224,7 +232,7 @@ macro_rules! impl_owned {
     (owned rust $c_owned_type:ty, loaned $c_loaned_type:ty) => {
         impl_transmute!(as_c_owned($c_loaned_type, $c_owned_type));
         impl_transmute!(as_c_loaned($c_owned_type, $c_loaned_type));
-        impl_transmute!(into_rust($c_owned_type, $c_owned_type));
+        impl_transmute!(into_rust(itself $c_owned_type));
     };
 }
 

--- a/src/transmute.rs
+++ b/src/transmute.rs
@@ -55,13 +55,17 @@ pub(crate) trait IntoCType: Sized {
 pub(crate) trait TakeRustType: Sized {
     type RustType;
     fn take_rust_type(&mut self) -> Self::RustType;
-} 
+}
 pub(crate) trait TakeCType: Sized {
     type CType;
     fn take_c_type(&mut self) -> Self::CType;
-} 
+}
 
-impl<P, Q> TakeRustType for P where P: TakeCType<CType = Q>, Q: IntoRustType {
+impl<P, Q> TakeRustType for P
+where
+    P: TakeCType<CType = Q>,
+    Q: IntoRustType,
+{
     type RustType = Q::RustType;
     fn take_rust_type(&mut self) -> Self::RustType {
         self.take_c_type().into_rust_type()
@@ -91,7 +95,7 @@ macro_rules! validate_equivalence {
             }
             const SIZE_A: usize = std::mem::size_of::<$type_a>();
             const SIZE_B: usize = std::mem::size_of::<$type_b>();
-            if SIZE_A != SIZE_B {       
+            if SIZE_A != SIZE_B {
                 const ERR_MESSAGE: &str = concatcp!(
                     "Size mismatch: type ",
                     TYPE_NAME_A,
@@ -110,7 +114,6 @@ macro_rules! validate_equivalence {
 
 #[macro_export]
 macro_rules! impl_transmute {
-
     (as_c ($rust_type:ty, $c_type:ty)) => {
         impl $crate::transmute::CTypeRef for $rust_type {
             type CType = $c_type;

--- a/tests/z_api_shm_test.c
+++ b/tests/z_api_shm_test.c
@@ -39,11 +39,11 @@
         return -200;          \
     }
 
-int test_shm_buffer(z_moved_shm_mut_t mbuf) {
-    assert(mbuf._ptr != NULL);
+int test_shm_buffer(z_moved_shm_mut_t* mbuf) {
+    ASSERT_CHECK(mbuf->_this);
     z_owned_shm_mut_t buf;
     z_take(&buf, mbuf);
-    assert(mbuf._ptr == NULL);
+    ASSERT_CHECK_ERR(mbuf->_this);
     ASSERT_CHECK(buf);
 
     { z_loaned_shm_mut_t* loaned = z_loan_mut(buf); }
@@ -51,7 +51,7 @@ int test_shm_buffer(z_moved_shm_mut_t mbuf) {
     z_owned_shm_t immut;
     z_shm_from_mut(&immut, z_move(buf));
     ASSERT_CHECK(immut);
-    assert(buf->_ptr == NULL);
+    ASSERT_CHECK_ERR(buf);
 
     { const z_loaned_shm_t* loaned = z_loan(immut); }
 


### PR DESCRIPTION
The approach with wrapping pointer to structure `z_xxx_move_t` and passing this structure by value works well as a way to force user to use `z_move` operation when necessary. But, as it was found by @yellowhatter, that easily leads to mistakes for C developers.
It's absolutely unclear that, for example, this sequence of operations is unsafe:
```C
z_xxx_moved_t foo() {
   z_xxx_owned_t foo;
   return z_move(foo);
}
```
The type `z_xxx_moved_t` gives no hint that it doesn't contain the data, but just a reference to `z_xxx_owned_t*`

This update fixes this API problem by making `z_xxx_moved_t` equal to `z_xxx_owned_t` and accepting pointer to `z_xxx_moved_t*`. This still forces user to call `z_move` when function takes ownership of the parameter, but makes the code above visibly wrong: C developer will feel immediate pain seeing returning the pointer made from something from stack:
```C
z_xxx_moved_t* foo() {
   z_xxx_owned_t foo;
   return z_move(foo);
}
```

Also this update renames all `this` parameters to `this_` to avoid conflicts with C++ keyword