### PR TITLE
Moved as ptr merge main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,8 @@ include/zenoh_opaque.h
 # Build resources
 .build_resources*
 src/opaque_types/mod.rs
+
+# CMake
+CMakeFiles/
+debug/
+release/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ phf = { version = "0.11.2", features = ["macros"] }
 
 [lib]
 path = "src/lib.rs"
-name = "zenohc"
+name = "zenohcd"
 crate-type = ["cdylib", "staticlib"]
 doctest = false
 

--- a/build.rs
+++ b/build.rs
@@ -1507,6 +1507,20 @@ pub fn generate_generic_cpp(
     generic_name: &str,
     decay: bool,
 ) -> String {
+    if decay {
+        let mut out = generate_generic_cpp_impl(macro_func, generic_name, false);
+        out += &generate_generic_cpp_impl(macro_func, generic_name, true);
+        out
+    } else {
+        generate_generic_cpp_impl(macro_func, generic_name, false)
+    }
+}
+
+pub fn generate_generic_cpp_impl(
+    macro_func: &[FunctionSignature],
+    generic_name: &str,
+    decay: bool,
+) -> String {
     let mut out = "".to_owned();
 
     let (body_start, body_end) = if macro_func.iter().any(|f| f.args.len() > 1) {

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -182,7 +182,7 @@ void parse_zenoh_common_args(const int argc, char** argv, z_owned_config_t* conf
     // -c: A configuration file.
     const char* config_file = parse_opt(argc, argv, "c", true);
     if (config_file) {
-        *config = zc_config_from_file(config_file);
+        zc_config_from_file(config, config_file);
     }
     // -m: The Zenoh session mode [default: peer].
     const char* mode = parse_opt(argc, argv, "m", true);

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -1,0 +1,213 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "zenoh.h"
+
+#define COMMON_HELP \
+    "\
+        -c <CONFIG> (optional, string): The path to a configuration file for the session. If this option isn't passed, the default configuration will be used.\n\
+        -m <MODE> (optional, string, default='peer'): The zenoh session mode. [possible values: peer, client, router]\n\
+        -e <CONNECT> (optional, string): endpoint to connect to. Repeat option to pass multiple endpoints. If none are given, endpoints will be discovered through multicast-scouting if it is enabled.\n\
+            e.g.: '-e tcp/192.168.1.1:7447'\n\
+        -l <LISTEN> (optional, string): locator to listen on. Repeat option to pass multiple locators. If none are given, the default configuration will be used.\n\
+            e.g.: '-l tcp/192.168.1.1:7447'\n\
+        --no-multicast-scouting (optional): By default zenohd replies to multicast scouting messages for being discovered by peers and clients. This option disables this feature.\n\
+"
+
+/**
+ * Parse an option of format `-f`, `--flag`, `-f <value>` or `--flag <value>` from `argv`. If found, the option and its
+ * eventual value are each replaced by NULL in `argv`
+ * @param argc: argc passed from `main` function
+ * @param argv: argv passed from `main` function
+ * @param opt: option to parse (without `-` or `--` prefix)
+ * @param opt_has_value: if true, the option is of format `-f <value>` or `--flag <value>` and `value` will be returned
+ * if found, else an error message is printed and program will exit. If false, option has no value and a non-null
+ * pointer will be returned if option is found.
+ * @returns NULL if option was not found, else a non-null value depending on if `opt_has_value`.
+ */
+const char* parse_opt(int argc, char** argv, const char* opt, bool opt_has_value) {
+    size_t optlen = strlen(opt);
+    for (int i = 1; i < argc; i++) {
+        if (argv[i] == NULL) {
+            continue;
+        }
+        size_t len = strlen(argv[i]);
+        if (len < 2) {
+            continue;
+        }
+        if (optlen == 1) {
+            if (argv[i][0] == '-' && argv[i][1] == opt[0]) {
+                argv[i] = NULL;
+                if (!opt_has_value) {
+                    return (char*)opt;
+                } else if (i + 1 < argc && argv[i + 1]) {
+                    char* value = argv[i + 1];
+                    argv[i + 1] = NULL;
+                    return value;
+                } else {
+                    printf("Option -%s given without a value\n", opt);
+                    exit(-1);
+                }
+            }
+        } else if (optlen > 1 && len > 3 && argv[i][0] == '-' && argv[i][1] == '-') {
+            // Note: support for '--arg=<value>' syntax can be added here
+            if (strcmp(argv[i] + 2, opt) == 0) {
+                argv[i] = NULL;
+                if (!opt_has_value) {
+                    return (char*)opt;
+                } else if (i + 1 < argc && argv[i + 1]) {
+                    char* value = argv[i + 1];
+                    argv[i + 1] = NULL;
+                    return value;
+                } else {
+                    printf("Option --%s given without a value\n", opt);
+                    exit(-1);
+                }
+            }
+        }
+    }
+    return NULL;
+}
+
+/**
+ * Check if any options remains in `argv`. Must be called after all expected options are parsed
+ * @param argc
+ * @param argv
+ * @returns NULL if no option was found, else the first option string that was found
+ */
+const char* check_unknown_opts(int argc, char** const argv) {
+    for (int i = 1; i < argc; i++) {
+        if (argv[i] && argv[i][0] == '-') {
+            return argv[i];
+        }
+    }
+    return NULL;
+}
+
+/**
+ * Parse positional arguments from `argv`. Must be called after all expected options are parsed, and after checking that
+ * no unknown options remain in `argv`
+ * @param argc
+ * @param argv
+ * @param nb_args: number of expected positional arguments
+ * @returns NULL if found more positional arguments than `nb_args`. Else an array of found arguments in order, followed
+ * by NULL values if found less positional arguments than `nb_args`
+ * @note Returned pointer is dynamically allocated and must be freed
+ */
+char** parse_pos_args(const int argc, char** argv, const size_t nb_args) {
+    char** pos_argv = (char**)calloc(nb_args, sizeof(char*));
+    size_t pos_argc = 0;
+    for (int i = 1; i < argc; i++) {
+        if (argv[i]) {
+            pos_argc++;
+            if (pos_argc > nb_args) {
+                free(pos_argv);
+                return NULL;
+            }
+            pos_argv[pos_argc - 1] = argv[i];
+        }
+    }
+    return pos_argv;
+}
+
+/**
+ * Parse zenoh options that require a JSON-serialized list (-e, -l from common args) and add them to
+ * `config`. Prints error message and exits if fails to insert parsed values
+ * @param argc
+ * @param argv
+ * @param opt: option to parse (without `-` or `--` prefix)
+ * @param config: address of an owned zenoh configuration
+ * @param config_key: zenoh configuration key under which the parsed values will be inserted
+ */
+void parse_zenoh_json_list_config(int argc, char** argv, const char* opt, const char* config_key,
+                                  const z_owned_config_t* config) {
+    char* buf = (char*)calloc(1, sizeof(char));
+    const char* value = parse_opt(argc, argv, opt, true);
+    while (value) {
+        size_t len_newbuf = strlen(buf) + strlen(value) + 4;  // value + quotes + comma + nullbyte
+        char* newbuf = (char*)malloc(len_newbuf);
+        snprintf(newbuf, len_newbuf, "%s'%s',", buf, value);
+        free(buf);
+        buf = newbuf;
+        value = parse_opt(argc, argv, opt, true);
+    }
+    size_t buflen = strlen(buf);
+    if (buflen > 0) {
+        // remove trailing comma
+        buf[buflen - 1] = '\0';
+        buflen--;
+        // add list delimiters
+        size_t json_list_len = buflen + 3;  // buf + brackets + nullbyte
+        char* json_list = (char*)malloc(json_list_len);
+        snprintf(json_list, json_list_len, "[%s]", buf);
+        // insert in config
+        if (zc_config_insert_json(z_loan(*config), config_key, json_list) < 0) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`\n`%s` is either not a JSON-serialized list of "
+                "strings, or values within the list do not respect expected format for `%s`\n",
+                json_list, config_key, json_list, config_key);
+            free(json_list);
+            exit(-1);
+        }
+        free(json_list);
+    }
+    free(buf);
+}
+
+/**
+ * Parse zenoh options that are common to all examples (-c, -m, -e, -l, --no-multicast-scouting) and add them to
+ * `config`
+ * @param argc
+ * @param argv
+ * @param config: address of an owned zenoh configuration
+ */
+void parse_zenoh_common_args(const int argc, char** argv, z_owned_config_t* config) {
+    // -c: A configuration file.
+    const char* config_file = parse_opt(argc, argv, "c", true);
+    if (config_file) {
+        *config = zc_config_from_file(config_file);
+    }
+    // -m: The Zenoh session mode [default: peer].
+    const char* mode = parse_opt(argc, argv, "m", true);
+    if (mode) {
+        size_t buflen = strlen(mode) + 3;  // mode + quotes + nullbyte
+        char* buf = (char*)malloc(buflen);
+        snprintf(buf, buflen, "'%s'", mode);
+        if (zc_config_insert_json(z_loan(*config), Z_CONFIG_MODE_KEY, buf) < 0) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. Value must be one of: 'client', 'peer' or "
+                "'router'\n",
+                mode, Z_CONFIG_MODE_KEY);
+            free(buf);
+            exit(-1);
+        }
+        free(buf);
+    }
+    // -e: Endpoint to connect to. Can be repeated
+    parse_zenoh_json_list_config(argc, argv, "e", Z_CONFIG_CONNECT_KEY, config);
+    // -l: Endpoint to listen on. Can be repeated
+    parse_zenoh_json_list_config(argc, argv, "l", Z_CONFIG_LISTEN_KEY, config);
+    // --no-multicast-scrouting: Disable the multicast-based scouting mechanism.
+    const char* no_multicast_scouting = parse_opt(argc, argv, "no-multicast-scouting", false);
+    if (no_multicast_scouting && zc_config_insert_json(z_loan(*config), Z_CONFIG_MULTICAST_SCOUTING_KEY, "false") < 0) {
+        printf("Couldn't disable multicast-scouting.\n");
+        exit(-1);
+    }
+}

--- a/examples/z_delete.c
+++ b/examples/z_delete.c
@@ -14,24 +14,20 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *keyexpr = "demo/example/zenoh-c-put";
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-put"
 
-    if (argc > 1) keyexpr = argv[1];
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
+int main(int argc, char** argv) {
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 3) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s;
@@ -40,9 +36,9 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Deleting resources matching '%s'...\n", keyexpr);
+    printf("Deleting resources matching '%s'...\n", args.keyexpr);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_str(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, args.keyexpr);
     int res = z_delete(z_loan(s), z_loan(ke), NULL);
     if (res < 0) {
         printf("Delete failed...\n");
@@ -50,4 +46,42 @@ int main(int argc, char **argv) {
 
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_delete [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression to write to\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -14,37 +14,27 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *expr = "demo/example/**";
-    char *value = NULL;
-    switch (argc) {
-        default:
-        case 3:
-            value = argv[2];
-        case 2:
-            expr = argv[1];
-            break;
-        case 1:
-            value = "Test Value";
-            break;
-    }
-    z_view_keyexpr_t keyexpr;
-    if (z_view_keyexpr_from_str(&keyexpr, expr) < 0) {
-        printf("%s is not a valid key expression", expr);
-        exit(-1);
-    }
+#define DEFAULT_SELECTOR "demo/example/**"
+#define DEFAULT_VALUE NULL
+
+struct args_t {
+    char* selector;  // -s
+    char* value;     // -v
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+int main(int argc, char** argv) {
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 3) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
+    struct args_t args = parse_args(argc, argv, &config);
+
+    z_view_keyexpr_t keyexpr;
+    if (z_view_keyexpr_from_str(&keyexpr, args.selector) < 0) {
+        printf("%s is not a valid key expression", args.selector);
+        exit(-1);
     }
 
     printf("Opening session...\n");
@@ -54,7 +44,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Sending Query '%s'...\n", expr);
+    printf("Sending Query '%s'...\n", args.selector);
     z_owned_fifo_handler_reply_t handler;
     z_owned_closure_reply_t closure;
     z_fifo_channel_reply_new(&closure, &handler, 16);
@@ -63,8 +53,8 @@ int main(int argc, char **argv) {
     z_get_options_default(&opts);
 
     z_owned_bytes_t payload;
-    if (value != NULL) {
-        z_bytes_from_static_str(&payload, value);
+    if (args.value != NULL) {
+        z_bytes_from_static_str(&payload, args.value);
         opts.payload = z_move(payload);
     }
     z_get(z_loan(s), z_loan(keyexpr), "", z_move(closure),
@@ -73,7 +63,7 @@ int main(int argc, char **argv) {
 
     for (z_result_t res = z_recv(z_loan(handler), &reply); res == Z_OK; res = z_recv(z_loan(handler), &reply)) {
         if (z_reply_is_ok(z_loan(reply))) {
-            const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));
+            const z_loaned_sample_t* sample = z_reply_ok(z_loan(reply));
 
             z_view_string_t key_str;
             z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_str);
@@ -93,4 +83,47 @@ int main(int argc, char **argv) {
     z_drop(z_move(handler));
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_get [OPTIONS]\n\n\
+    Options:\n\
+        -s <SELECTOR> (optional, string, default='%s'): The selection of resources to query\n\
+        -v <VALUE> (optional, string): An optional value to put in the query\n",
+        DEFAULT_SELECTOR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* selector = parse_opt(argc, argv, "s", true);
+    if (!selector) {
+        selector = DEFAULT_SELECTOR;
+    }
+    const char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.selector = (char*)selector, .value = (char*)value};
 }

--- a/examples/z_get_liveliness.c
+++ b/examples/z_get_liveliness.c
@@ -14,30 +14,25 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *expr = "group1/**";
-    if (argc > 1) {
-        expr = argv[1];
-    }
+#define DEFAULT_KEYEXPR "group1/**"
 
-    z_view_keyexpr_t keyexpr;
-    if (z_view_keyexpr_from_str(&keyexpr, expr) < 0) {
-        printf("%s is not a valid key expression\n", expr);
-        exit(-1);
-    }
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
+int main(int argc, char** argv) {
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
+    struct args_t args = parse_args(argc, argv, &config);
+
+    z_view_keyexpr_t keyexpr;
+    if (z_view_keyexpr_from_str(&keyexpr, args.keyexpr) < 0) {
+        printf("%s is not a valid key expression\n", args.keyexpr);
+        exit(-1);
     }
 
     z_owned_session_t s;
@@ -47,7 +42,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Sending liveliness query '%s'...\n", expr);
+    printf("Sending liveliness query '%s'...\n", args.keyexpr);
     z_owned_fifo_handler_reply_t handler;
     z_owned_closure_reply_t closure;
     z_fifo_channel_reply_new(&closure, &handler, 16);
@@ -55,7 +50,7 @@ int main(int argc, char **argv) {
     z_owned_reply_t reply;
     for (z_result_t res = z_recv(z_loan(handler), &reply); res == Z_OK; res = z_recv(z_loan(handler), &reply)) {
         if (z_reply_is_ok(z_loan(reply))) {
-            const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));
+            const z_loaned_sample_t* sample = z_reply_ok(z_loan(reply));
             z_view_string_t key_str;
             z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_str);
             printf(">> Alive token ('%.*s')\n", (int)z_string_len(z_loan(key_str)), z_string_data(z_loan(key_str)));
@@ -68,4 +63,42 @@ int main(int argc, char **argv) {
     z_drop(z_move(handler));
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_get_liveliness [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression to query\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_info.c
+++ b/examples/z_info.c
@@ -13,27 +13,22 @@
 
 #include <stdio.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-void print_zid(const z_id_t *id, void *ctx) {
+void parse_args(int argc, char** argv, z_owned_config_t* config);
+
+void print_zid(const z_id_t* id, void* ctx) {
     for (int i = 0; i < 16; i++) {
         printf("%02x", id->id[i]);
     }
     printf("\n");
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 1) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[1]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[1], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s;
@@ -59,4 +54,35 @@ int main(int argc, char **argv) {
     z_info_peers_zid(z_loan(s), z_move(callback2));
 
     z_close(z_move(s));
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_info [OPTIONS]\n\n\
+    Options:\n");
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+void parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
 }

--- a/examples/z_liveliness.c
+++ b/examples/z_liveliness.c
@@ -14,30 +14,25 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *expr = "group1/zenoh-c";
-    if (argc > 1) {
-        expr = argv[1];
-    }
+#define DEFAULT_KEYEXPR "group1/zenoh-rs"
 
-    z_view_keyexpr_t keyexpr;
-    if (z_view_keyexpr_from_str(&keyexpr, expr) < 0) {
-        printf("%s is not a valid key expression\n", expr);
-        exit(-1);
-    }
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
+int main(int argc, char** argv) {
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
+    struct args_t args = parse_args(argc, argv, &config);
+
+    z_view_keyexpr_t keyexpr;
+    if (z_view_keyexpr_from_str(&keyexpr, args.keyexpr) < 0) {
+        printf("%s is not a valid key expression\n", args.keyexpr);
+        exit(-1);
     }
 
     printf("Opening session...\n");
@@ -47,26 +42,61 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Declaring liveliness token '%s'...\n", expr);
+    printf("Declaring liveliness token '%s'...\n", args.keyexpr);
     zc_owned_liveliness_token_t token;
     if (zc_liveliness_declare_token(&token, z_loan(s), z_loan(keyexpr), NULL) < 0) {
         printf("Unable to create liveliness token!\n");
         exit(-1);
     }
 
-    printf("Enter 'd' to undeclare liveliness token, 'q' to quit...\n");
-    char c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            z_sleep_s(1);
-        } else if (c == 'd') {
-            printf("Undeclaring liveliness token...\n");
-            z_drop(z_move(token));
-        }
+    printf("Press CTRL-C to undeclare liveliness token and quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
+    // LivelinessTokens are automatically closed when dropped
+    // Use the code below to manually undeclare it if needed
+    printf("Undeclaring liveliness token...\n");
     z_drop(z_move(token));
+
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_liveliness [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression the liveliness token\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_ping.c
+++ b/examples/z_ping.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
 #define DEFAULT_PKT_SIZE 8
@@ -27,32 +28,21 @@ struct args_t {
     unsigned int size;             // -s
     unsigned int number_of_pings;  // -n
     unsigned int warmup_ms;        // -w
-    char* config_path;             // -c
-    uint8_t help_requested;        // -h
 };
-struct args_t parse_args(int argc, char** argv);
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
 int main(int argc, char** argv) {
-    struct args_t args = parse_args(argc, argv);
-    if (args.help_requested) {
-        printf(
-            "\
-		-n (optional, int, default=%d): the number of pings to be attempted\n\
-		-s (optional, int, default=%d): the size of the payload embedded in the ping and repeated by the pong\n\
-		-w (optional, int, default=%d): the warmup time in ms during which pings will be emitted but not measured\n\
-		-c (optional, string): the path to a configuration file for the session. If this option isn't passed, the default configuration will be used.\n\
-		",
-            DEFAULT_PING_NB, DEFAULT_PKT_SIZE, DEFAULT_WARMUP_MS);
-        return 1;
-    }
-    z_mutex_init(&mutex);
-    z_condvar_init(&cond);
+    struct args_t args = parse_args(argc, argv, &config);
+
     z_owned_config_t config;
     if (args.config_path) {
         zc_config_from_file(&config, args.config_path);
     } else {
         z_config_default(&config);
     }
+
+    z_mutex_init(&mutex);
+    z_condvar_init(&cond);
     z_owned_session_t session;
     z_open(&session, z_move(config));
     z_view_keyexpr_t ping;
@@ -110,44 +100,53 @@ int main(int argc, char** argv) {
     z_close(z_move(session));
 }
 
-char* getopt(int argc, char** argv, char option) {
-    for (int i = 0; i < argc; i++) {
-        size_t len = strlen(argv[i]);
-        if (len >= 2 && argv[i][0] == '-' && argv[i][1] == option) {
-            if (len > 2 && argv[i][2] == '=') {
-                return argv[i] + 3;
-            } else if (i + 1 < argc) {
-                return argv[i + 1];
-            }
-        }
-    }
-    return NULL;
+void print_help() {
+    printf(
+        "\
+    Usage: z_ping [OPTIONS]\n\n\
+    Options:\n\
+        -n <SAMPLES> (optional, int, default=%d): The number of pings to be attempted\n\
+        -s <SIZE> (optional, int, default=%d): The size of the payload embedded in the ping and repeated by the pong\n\
+        -w <WARMUP> (optional, int, default=%d): The warmup time in ms during which pings will be emitted but not measured\n",
+        DEFAULT_PKT_SIZE, DEFAULT_PING_NB, DEFAULT_WARMUP_MS);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
 }
 
-struct args_t parse_args(int argc, char** argv) {
-    for (int i = 0; i < argc; i++) {
-        if (strcmp(argv[i], "-h") == 0) {
-            return (struct args_t){.help_requested = 1};
-        }
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
     }
-    char* arg = getopt(argc, argv, 's');
+    const char* arg = parse_opt(argc, argv, "s", true);
     unsigned int size = DEFAULT_PKT_SIZE;
     if (arg) {
         size = atoi(arg);
     }
-    arg = getopt(argc, argv, 'n');
+    arg = parse_opt(argc, argv, "n", true);
     unsigned int number_of_pings = DEFAULT_PING_NB;
     if (arg) {
         number_of_pings = atoi(arg);
     }
-    arg = getopt(argc, argv, 'w');
+    arg = parse_opt(argc, argv, "w", true);
     unsigned int warmup_ms = DEFAULT_WARMUP_MS;
     if (arg) {
         warmup_ms = atoi(arg);
     }
-    return (struct args_t){.help_requested = 0,
-                           .size = size,
-                           .number_of_pings = number_of_pings,
-                           .warmup_ms = warmup_ms,
-                           .config_path = getopt(argc, argv, 'c')};
+    parse_zenoh_common_args(argc, argv, config);
+    arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.size = size, .number_of_pings = number_of_pings, .warmup_ms = warmup_ms};
 }

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -14,10 +14,20 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-#ifdef UNSTABLE
-void matching_status_handler(const zc_matching_status_t *matching_status, void *arg) {
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-pub"
+#define DEFAULT_VALUE "Pub from C!"
+
+struct args_t {
+    char* keyexpr;               // -k
+    char* value;                 // -v
+    bool add_matching_listener;  // --add-matching-listener
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+void matching_status_handler(const zc_matching_status_t* matching_status, void* arg) {
     if (matching_status->matching) {
         printf("Subscriber matched\n");
     } else {
@@ -26,26 +36,10 @@ void matching_status_handler(const zc_matching_status_t *matching_status, void *
 }
 #endif
 
-int main(int argc, char **argv) {
-    char *keyexpr = "demo/example/zenoh-c-pub";
-    char *value = "Pub from C!";
-    bool add_matching_listener = false;
-
-    if (argc > 1) keyexpr = argv[1];
-    if (argc > 2) value = argv[2];
-    if (argc > 3) add_matching_listener = atoi(argv[3]);
-
+int main(int argc, char** argv) {
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 4) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[4]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[4], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s;
@@ -54,10 +48,10 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Declaring Publisher on '%s'...\n", keyexpr);
+    printf("Declaring Publisher on '%s'...\n", args.keyexpr);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_str(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, args.keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare Publisher for key expression!\n");
         exit(-1);
@@ -65,7 +59,7 @@ int main(int argc, char **argv) {
 
 #ifdef UNSTABLE
     zc_owned_matching_listener_t listener;
-    if (add_matching_listener) {
+    if (args.add_matching_listener) {
         zc_owned_closure_matching_status_t callback;
         z_closure(&callback, matching_status_handler, NULL, NULL);
         zc_publisher_matching_listener_declare(&listener, z_loan(pub), z_move(callback));
@@ -77,11 +71,12 @@ int main(int argc, char **argv) {
     }
 #endif
 
+    printf("Press CTRL-C to quit...\n");
     char buf[256] = {};
     for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);
-        sprintf(buf, "[%4d] %s", idx, value);
-        printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
+        sprintf(buf, "[%4d] %s", idx, args.value);
+        printf("Putting Data ('%s': '%s')...\n", args.keyexpr, buf);
         z_publisher_put_options_t options;
         z_publisher_put_options_default(&options);
 
@@ -99,4 +94,54 @@ int main(int argc, char **argv) {
     z_undeclare_publisher(z_move(pub));
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_pub [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEYEXPR> (optional, string, default='%s'): The key expression to write to\n\
+        -v <VALUE> (optional, string, default='%s'): The value to write\n\
+        --add-matching-listener (optional): Add matching listener\n",
+        DEFAULT_KEYEXPR, DEFAULT_VALUE);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    const char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    const char* arg = parse_opt(argc, argv, "add-matching-listener", false);
+    bool add_matching_listener = false;
+    if (arg) {
+        add_matching_listener = true;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){
+        .keyexpr = (char*)keyexpr, .value = (char*)value, .add_matching_listener = add_matching_listener};
 }

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -14,7 +14,11 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
+
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-pub"
+#define DEFAULT_VALUE "Pub from C!"
 
 typedef struct kv_pair_t {
     const char* key;
@@ -39,24 +43,16 @@ bool create_attachment_iter(z_owned_bytes_t* kv_pair, void* context) {
     return true;
 };
 
+struct args_t {
+    char* keyexpr;  // -k
+    char* value;    // -v
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
 int main(int argc, char** argv) {
-    char* keyexpr = "demo/example/zenoh-c-pub";
-    char* value = "Pub from C!";
-
-    if (argc > 1) keyexpr = argv[1];
-    if (argc > 2) value = argv[2];
-
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 3) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s;
@@ -65,9 +61,9 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
-    printf("Declaring Publisher on '%s'...\n", keyexpr);
+    printf("Declaring Publisher on '%s'...\n", args.keyexpr);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_str(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, args.keyexpr);
     z_owned_publisher_t pub;
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL)) {
         printf("Unable to declare Publisher for key expression!\n");
@@ -84,6 +80,7 @@ int main(int argc, char** argv) {
     z_owned_bytes_t attachment;
     z_owned_bytes_t payload;
 
+    printf("Press CTRL-C to quit...\n");
     char buf[256];
     char buf_ind[16];
     for (int idx = 0; 1; ++idx) {
@@ -96,8 +93,8 @@ int main(int argc, char** argv) {
         z_bytes_from_iter(&attachment, create_attachment_iter, (void*)&it);
         options.attachment = z_move(attachment);
 
-        sprintf(buf, "[%4d] %s", idx, value);
-        printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
+        sprintf(buf, "[%4d] %s", idx, args.value);
+        printf("Putting Data ('%s': '%s')...\n", args.keyexpr, buf);
 
         z_bytes_serialize_from_str(&payload, buf);
         z_publisher_put(z_loan(pub), z_move(payload), &options);
@@ -108,4 +105,47 @@ int main(int argc, char** argv) {
     z_close(z_move(s));
 
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_pub_attachement [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEYEXPR> (optional, string, default='%s'): The key expression to write to\n\
+        -v <VALUE> (optional, string, default='%s'): The value to write\n",
+        DEFAULT_KEYEXPR, DEFAULT_VALUE);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    const char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.keyexpr = (char*)keyexpr, .value = (char*)value};
 }

--- a/examples/z_pub_cache.c
+++ b/examples/z_pub_cache.c
@@ -14,26 +14,24 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *keyexpr = "demo/example/zenoh-c-pub";
-    char *value = "Pub from C!";
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-pub"
+#define DEFAULT_VALUE "Pub from C!"
+#define DEFAULT_HISTORY 1
 
-    if (argc > 1) keyexpr = argv[1];
-    if (argc > 2) value = argv[2];
+struct args_t {
+    char* keyexpr;         // -k
+    char* value;           // -v
+    unsigned int history;  // -i
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
+int main(int argc, char** argv) {
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 3) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_ADD_TIMESTAMP_KEY, "true") < 0) {
         printf("Unable to configure timestamps!\n");
@@ -52,21 +50,22 @@ int main(int argc, char **argv) {
     pub_cache_opts.history = 42;
     pub_cache_opts.queryable_complete = false;
 
-    printf("Declaring publication cache on '%s'...\n", keyexpr);
+    printf("Declaring publication cache on '%s'...\n", args.keyexpr);
     ze_owned_publication_cache_t pub_cache;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_str(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, args.keyexpr);
 
     if (ze_declare_publication_cache(&pub_cache, z_loan(s), z_loan(ke), &pub_cache_opts) != Z_OK) {
         printf("Unable to declare publication cache for key expression!\n");
         exit(-1);
     }
 
+    printf("Press CTRL-C to quit...\n");
     char buf[256];
     for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);
-        sprintf(buf, "[%4d] %s", idx, value);
-        printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
+        sprintf(buf, "[%4d] %s", idx, args.value);
+        printf("Putting Data ('%s': '%s')...\n", args.keyexpr, buf);
         z_owned_bytes_t payload;
         z_bytes_serialize_from_str(&payload, buf);
 
@@ -77,4 +76,53 @@ int main(int argc, char **argv) {
     z_close(z_move(s));
 
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_pub_cache [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEYEXPR> (optional, string, default='%s'): The key expression to write to\n\
+        -v <VALUE> (optional, string, default='%s'): The value to write\n\
+        -i <HISTORY> (optional, int, default='%d'): The number of publications to keep in cache\n",
+        DEFAULT_KEYEXPR, DEFAULT_VALUE, DEFAULT_HISTORY);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    const char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    const char* arg = parse_opt(argc, argv, "i", true);
+    unsigned int history = DEFAULT_HISTORY;
+    if (arg) {
+        history = atoi(arg);
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.keyexpr = (char*)keyexpr, .value = (char*)value, .history = history};
 }

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -14,39 +14,24 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-#ifdef UNSTABLE
-void matching_status_handler(const zc_matching_status_t *matching_status, void *arg) {
-    if (matching_status->matching) {
-        printf("Subscriber matched\n");
-    } else {
-        printf("No Subscribers matched\n");
-    }
-}
-#endif
+#define N 10
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-pub-shm"
+#define DEFAULT_VALUE "Pub from C!"
 
-int main(int argc, char **argv) {
-    char *keyexpr = "demo/example/zenoh-c-pub";
-    char *value = "Pub from C SHM!";
-    bool add_matching_listener = false;
+struct args_t {
+    char* keyexpr;  // -k
+    char* value;    // -v
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
-    if (argc > 1) keyexpr = argv[1];
-    if (argc > 2) value = argv[2];
-    if (argc > 3) add_matching_listener = atoi(argv[3]);
-
+int main(int argc, char** argv) {
     z_owned_config_t config;
     z_config_default(&config);
+    struct args_t args = parse_args(argc, argv, &config);
 
-    if (argc > 4) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[4]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[4], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
 
     printf("Opening session...\n");
     z_owned_session_t s;
@@ -55,10 +40,10 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Declaring Publisher on '%s'...\n", keyexpr);
+    printf("Declaring Publisher on '%s'...\n", args.keyexpr);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_str(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, args.keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare Publisher for key expression!\n");
         exit(-1);
@@ -95,9 +80,9 @@ int main(int argc, char **argv) {
         z_shm_provider_alloc_gc_defrag_blocking(&alloc, z_loan(provider), buf_ok_size, alignment);
         if (z_check(alloc.buf)) {
             {
-                uint8_t *buf = z_shm_mut_data_mut(z_loan_mut(alloc.buf));
-                sprintf((char *)buf, "[%4d] %s", idx, value);
-                printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
+                uint8_t* buf = z_shm_mut_data_mut(z_loan_mut(alloc.buf));
+                sprintf((char*)buf, "[%4d] %s", idx, args.value);
+                printf("Putting Data ('%s': '%s')...\n", args.keyexpr, buf);
             }
 
             z_publisher_put_options_t options;
@@ -126,4 +111,47 @@ int main(int argc, char **argv) {
     z_drop(z_move(layout));
 
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_pub_shm [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEYEXPR> (optional, string, default='%s'): The key expression to write to\n\
+        -v <VALUE> (optional, string, default='%s'): The value to write\n",
+        DEFAULT_KEYEXPR, DEFAULT_VALUE);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    const char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.keyexpr = (char*)keyexpr, .value = (char*)value};
 }

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -14,30 +14,22 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    if (argc < 2) {
-        printf("USAGE:\n\tz_pub_thr <payload-size> [<zenoh-locator>]\n\n");
-        exit(-1);
-    }
+struct args_t {
+    unsigned int size;  // positional_1
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
-    char *keyexpr = "test/thr";
-    size_t len = atoi(argv[1]);
-    uint8_t *value = (uint8_t *)z_malloc(len);
-    memset(value, 1, len);
+int main(int argc, char** argv) {
+    char* keyexpr = "test/thr";
 
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
+    uint8_t* value = (uint8_t*)z_malloc(args.size);
+    memset(value, 1, args.size);
 
     z_owned_session_t s;
     if (z_open(&s, z_move(config)) < 0) {
@@ -57,7 +49,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    z_owned_bytes_t payload;
+    printf("Press CTRL-C to quit...\n");
     while (1) {
         z_bytes_from_buf(&payload, value, len, NULL, NULL);
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
@@ -65,4 +57,43 @@ int main(int argc, char **argv) {
 
     z_undeclare_publisher(z_move(pub));
     z_close(z_move(s));
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_pub_thr [OPTIONS] <PAYLOAD_SIZE>\n\n\
+    Arguments:\n\
+        <PAYLOAD_SIZE> (required, int): Size of the payload to publish\n\n\
+    Options:\n");
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args) {
+        printf("Unexpected additional positional arguments\n");
+        exit(-1);
+    }
+    if (!pos_args[0]) {
+        printf("<PAYLOAD_SIZE> argument is required\n");
+        free(pos_args);
+        exit(-1);
+    }
+    unsigned int size = atoi(pos_args[0]);
+    free(pos_args);
+    return (struct args_t){.size = size};
 }

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -13,20 +13,19 @@
 //
 #include <stdio.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-const char *kind_to_str(z_sample_kind_t kind) {
-    switch (kind) {
-        case Z_SAMPLE_KIND_PUT:
-            return "PUT";
-        case Z_SAMPLE_KIND_DELETE:
-            return "DELETE";
-        default:
-            return "UNKNOWN";
-    }
-}
+#define DEFAULT_KEYEXPR "demo/example/**"
 
-void handle_sample(const z_loaned_sample_t *sample) {
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+const char* kind_to_str(z_sample_kind_t kind);
+
+void handle_sample(const z_loaned_sample_t* sample) {
     z_view_string_t keystr;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &keystr);
     z_owned_string_t payload_value;
@@ -37,23 +36,10 @@ void handle_sample(const z_loaned_sample_t *sample) {
     z_drop(z_move(payload_value));
 }
 
-int main(int argc, char **argv) {
-    char *expr = "demo/example/**";
-    if (argc > 1) {
-        expr = argv[1];
-    }
-
+int main(int argc, char** argv) {
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_LISTEN_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s;
@@ -95,4 +81,53 @@ int main(int argc, char **argv) {
     z_undeclare_subscriber(z_move(sub));
     z_close(z_move(s));
     return 0;
+}
+
+const char* kind_to_str(z_sample_kind_t kind) {
+    switch (kind) {
+        case Z_SAMPLE_KIND_PUT:
+            return "PUT";
+        case Z_SAMPLE_KIND_DELETE:
+            return "DELETE";
+        default:
+            return "UNKNOWN";
+    }
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_pull [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression to subscribe to\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_put.c
+++ b/examples/z_put.c
@@ -14,27 +14,23 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
-    char *keyexpr = "demo/example/zenoh-c-put";
-    char *value = "Put from C!";
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-put"
+#define DEFAULT_VALUE "Put from C!"
 
-    if (argc > 1) keyexpr = argv[1];
-    if (argc > 2) value = argv[2];
+struct args_t {
+    char* keyexpr;  // -k
+    char* value;    // -v
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+int main(int argc, char** argv) {
+    struct args_t args = parse_args(argc, argv, &config);
 
     z_owned_config_t config;
     z_config_default(&config);
-
-    if (argc > 3) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[3]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[3], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
 
     printf("Opening session...\n");
     z_owned_session_t s;
@@ -43,17 +39,17 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Putting Data ('%s': '%s')...\n", keyexpr, value);
+    printf("Putting Data ('%s': '%s')...\n", args.keyexpr, args.value);
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_str(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, args.keyexpr);
 
     z_owned_bytes_t payload;
-    z_bytes_from_static_str(&payload, value);
+    z_bytes_from_static_str(&payload, args.value);
 
     z_owned_bytes_t attachment, key, val;
-    z_bytes_from_static_str(&key, (char *)"hello");
-    z_bytes_from_static_str(&val, (char *)"there");
+    z_bytes_from_static_str(&key, (char*)"hello");
+    z_bytes_from_static_str(&val, (char*)"there");
     z_bytes_from_pair(&attachment, z_move(key), z_move(val));
 
     z_put_options_t options;
@@ -68,4 +64,47 @@ int main(int argc, char **argv) {
 
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_put [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEYEXPR> (optional, string, default='%s'): The key expression to write to\n\
+        -v <VALUE> (optional, string, default='%s'): The value to write\n",
+        DEFAULT_KEYEXPR, DEFAULT_VALUE);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    const char* value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.keyexpr = (char*)keyexpr, .value = (char*)value};
 }

--- a/examples/z_query_sub.c
+++ b/examples/z_query_sub.c
@@ -13,40 +13,30 @@
 //
 #include <stdio.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-const char *kind_to_str(z_sample_kind_t kind);
+#define DEFAULT_KEYEXPR "demo/example/**"
 
-void data_handler(const z_loaned_sample_t *sample, void *arg) {
-    z_view_string_t key_string;
-    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
-    z_owned_string_t payload_string;
-    z_bytes_deserialize_into_string(z_sample_payload(sample), &payload_string);
+const char* kind_to_str(z_sample_kind_t kind);
 
-    printf(">> [Subscriber] Received %s ('%.*s': '%.*s')\n", kind_to_str(z_sample_kind(sample)),
-           (int)z_string_len(z_loan(key_string)), z_string_data(z_loan(key_string)),
-           (int)z_string_len(z_loan(payload_string)), z_string_data(z_loan(payload_string)));
-    z_drop(z_move(payload_string));
+void data_handler(const z_sample_t* sample, void* arg) {
+    z_owned_str_t keystr;
+    z_keyexpr_to_string(&keystr, sample->keyexpr);
+    printf(">> [Subscriber] Received %s ('%s': '%.*s')\n", kind_to_str(sample->kind), z_loan(keystr),
+           (int)sample->payload.len, sample->payload.start);
+    z_drop(z_move(keystr));
 }
 
-int main(int argc, char **argv) {
-    char *keyexpr = "demo/example/**";
-    if (argc > 1) {
-        keyexpr = argv[1];
-    }
-
+int main(int argc, char** argv) {
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_LISTEN_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
 
     printf("Opening session...\n");
     z_owned_session_t s;
@@ -56,28 +46,21 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_str(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, args.keyexpr);
 
-    ze_querying_subscriber_options_t sub_opts;
-    ze_querying_subscriber_options_default(&sub_opts);
-
+    ze_querying_subscriber_options_t sub_opts = ze_querying_subscriber_options_default();
     z_owned_closure_sample_t callback;
     z_closure(&callback, data_handler, NULL, NULL);
-    printf("Declaring querying subscriber on '%s'...\n", keyexpr);
-
+    printf("Declaring querying subscriber on '%s'...\n", args.keyexpr);
     ze_owned_querying_subscriber_t sub;
-    if (ze_declare_querying_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), &sub_opts) < 0) {
+    if (ze_declare_querying_subscriber(z_loan(s), z_loan(ke), z_move(callback), &sub_opts) < 0) {
         printf("Unable to declare querying subscriber.\n");
         exit(-1);
     }
 
-    printf("Enter 'q' to quit...\n");
-    char c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            z_sleep_s(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
     ze_undeclare_querying_subscriber(z_move(sub));
@@ -86,7 +69,7 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-const char *kind_to_str(z_sample_kind_t kind) {
+const char* kind_to_str(z_sample_kind_t kind) {
     switch (kind) {
         case Z_SAMPLE_KIND_PUT:
             return "PUT";
@@ -95,4 +78,42 @@ const char *kind_to_str(z_sample_kind_t kind) {
         default:
             return "UNKNOWN";
     }
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_query_sub [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression to subscribe to\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -14,10 +14,11 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-const char *keyexpr = "demo/example/zenoh-c-queryable";
-const char *value = "Queryable from C!";
+#define DEFAULT_KEYEXPR "demo/example/zenoh-c-queryable"
+#define DEFAULT_VALUE "Queryable from C!"
 z_view_keyexpr_t ke;
 
 void query_handler(const z_loaned_query_t *query, void *context) {
@@ -53,20 +54,10 @@ void query_handler(const z_loaned_query_t *query, void *context) {
 }
 
 int main(int argc, char **argv) {
-    if (argc > 1) {
-        keyexpr = argv[1];
-    }
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
+    value = args.value;
 
     printf("Opening session...\n");
     z_owned_session_t s;
@@ -75,14 +66,14 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    if (z_view_keyexpr_from_str(&ke, keyexpr)) {
-        printf("%s is not a valid key expression", keyexpr);
+    if (z_view_keyexpr_from_str(&ke, args.keyexpr)) {
+        printf("%s is not a valid key expression", args.keyexpr);
         exit(-1);
     }
 
-    printf("Declaring Queryable on '%s'...\n", keyexpr);
+    printf("Declaring Queryable on '%s'...\n", args.keyexpr);
     z_owned_closure_query_t callback;
-    z_closure(&callback, query_handler, NULL, (void *)keyexpr);
+    z_closure(&callback, query_handler, NULL, (void *)args.keyexpr);
     z_owned_queryable_t qable;
 
     if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
@@ -90,16 +81,55 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    printf("Enter 'q' to quit...\n");
-    char c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            z_sleep_s(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
     z_undeclare_queryable(z_move(qable));
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_queryable [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEYEXPR> (optional, string, default='%s'): The key expression matching queries to reply to\n\
+        -v <VALUE> (optional, string, default='%s'): The value to reply to queries with\n",
+        DEFAULT_KEYEXPR, DEFAULT_VALUE);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char **argv, z_owned_config_t *config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char *keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    const char *value = parse_opt(argc, argv, "v", true);
+    if (!value) {
+        value = DEFAULT_VALUE;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char *arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char **pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.keyexpr = (char *)keyexpr, .value = (char *)value};
 }

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -14,11 +14,17 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
-const char *kind_to_str(z_sample_kind_t kind);
+#define DEFAULT_KEYEXPR "demo/example/**"
 
-void data_handler(const z_loaned_sample_t *sample, void *arg) {
+struct args_t {
+    char* keyexpr;  // -k
+};
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
+
+void data_handler(const z_loaned_sample_t* sample, void* arg) {
     z_view_string_t key_string;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
 
@@ -29,7 +35,7 @@ void data_handler(const z_loaned_sample_t *sample, void *arg) {
            (int)z_string_len(z_loan(key_string)), z_string_data(z_loan(key_string)),
            (int)z_string_len(z_loan(payload_string)), z_string_data(z_loan(payload_string)));
 
-    const z_loaned_bytes_t *attachment = z_sample_attachment(sample);
+    const z_loaned_bytes_t* attachment = z_sample_attachment(sample);
     // checks if attachment exists
     if (attachment != NULL) {
         // reads full attachment
@@ -55,26 +61,12 @@ void data_handler(const z_loaned_sample_t *sample, void *arg) {
     z_drop(z_move(payload_string));
 }
 
-int main(int argc, char **argv) {
-    char *keyexpr = "demo/example/**";
-    if (argc > 1) {
-        keyexpr = argv[1];
-    }
-
-    z_view_keyexpr_t ke;
-    z_view_keyexpr_from_str(&ke, keyexpr);
-
+int main(int argc, char** argv) {
     z_owned_config_t config;
     z_config_default(&config);
-    if (argc > 2) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_LISTEN_KEY, argv[2]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[2], Z_CONFIG_LISTEN_KEY, Z_CONFIG_LISTEN_KEY);
-            exit(-1);
-        }
-    }
+    struct args_t args = parse_args(argc, argv, &config);
+    z_view_keyexpr_t ke;
+    z_view_keyexpr_from_str(&ke, args.keyexpr);
 
     printf("Opening session...\n");
     z_owned_session_t s;
@@ -85,20 +77,16 @@ int main(int argc, char **argv) {
 
     z_owned_closure_sample_t callback;
     z_closure(&callback, data_handler, NULL, NULL);
-    printf("Declaring Subscriber on '%s'...\n", keyexpr);
+    printf("Declaring Subscriber on '%s'...\n", args.keyexpr);
     z_owned_subscriber_t sub;
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL)) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }
 
-    printf("Enter 'q' to quit...\n");
-    char c = 0;
-    while (c != 'q') {
-        c = getchar();
-        if (c == -1) {
-            z_sleep_s(1);
-        }
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
     z_undeclare_subscriber(z_move(sub));
@@ -106,7 +94,7 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-const char *kind_to_str(z_sample_kind_t kind) {
+const char* kind_to_str(z_sample_kind_t kind) {
     switch (kind) {
         case Z_SAMPLE_KIND_PUT:
             return "PUT";
@@ -115,4 +103,42 @@ const char *kind_to_str(z_sample_kind_t kind) {
         default:
             return "UNKNOWN";
     }
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_sub_attachement [OPTIONS]\n\n\
+    Options:\n\
+        -k <KEY> (optional, string, default='%s'): The key expression to subscribe to\n",
+        DEFAULT_KEYEXPR);
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    const char* keyexpr = parse_opt(argc, argv, "k", true);
+    if (!keyexpr) {
+        keyexpr = DEFAULT_KEYEXPR;
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char* arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char** pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
+    return (struct args_t){.keyexpr = (char*)keyexpr};
 }

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -13,9 +13,12 @@
 //
 #include <stdio.h>
 
+#include "parse_args.h"
 #include "zenoh.h"
 
 #define N 1000000
+
+void parse_args(int argc, char **argv, z_owned_config_t *config);
 
 typedef struct {
     volatile unsigned long count;
@@ -62,16 +65,19 @@ void drop_stats(void *context) {
 int main(int argc, char **argv) {
     z_owned_config_t config;
     z_config_default(&config);
+    parse_args(argc, argv, &config);
 
-    if (argc > 1) {
-        if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_CONNECT_KEY, argv[1]) < 0) {
-            printf(
-                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
-                "JSON-serialized list of strings\n",
-                argv[1], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
-            exit(-1);
-        }
+#ifdef SHARED_MEMORY
+    // A probing procedure for shared memory is performed upon session opening. To operate over shared memory
+    // (and to not fallback on network mode), shared memory needs to be enabled in the configuration.
+    if (zc_config_insert_json(z_loan_mut(config), Z_CONFIG_SHARED_MEMORY_KEY, "true") < 0) {
+        printf(
+            "Couldn't insert value `true` in configuration at `%s`. This is likely because `%s` expects a "
+            "JSON-serialized value\n",
+            Z_CONFIG_SHARED_MEMORY_KEY, Z_CONFIG_SHARED_MEMORY_KEY);
+        exit(-1);
     }
+#endif
 
     z_owned_session_t s;
 
@@ -94,13 +100,44 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    char c = 0;
-    while (c != 'q') {
-        c = fgetc(stdin);
+    printf("Press CTRL-C to quit...\n");
+    while (1) {
+        z_sleep_s(1);
     }
 
     z_undeclare_subscriber(z_move(sub));
     z_undeclare_keyexpr(z_move(declared_ke), z_loan(s));
     z_close(z_move(s));
     return 0;
+}
+
+void print_help() {
+    printf(
+        "\
+    Usage: z_sub_thr [OPTIONS]\n\n\
+    Options:\n");
+    printf(COMMON_HELP);
+    printf(
+        "\
+        -h: print help\n");
+}
+
+void parse_args(int argc, char **argv, z_owned_config_t *config) {
+    if (parse_opt(argc, argv, "h", false)) {
+        print_help();
+        exit(1);
+    }
+    parse_zenoh_common_args(argc, argv, config);
+    const char *arg = check_unknown_opts(argc, argv);
+    if (arg) {
+        printf("Unknown option %s\n", arg);
+        exit(-1);
+    }
+    char **pos_args = parse_pos_args(argc, argv, 1);
+    if (!pos_args || pos_args[0]) {
+        printf("Unexpected positional arguments\n");
+        free(pos_args);
+        exit(-1);
+    }
+    free(pos_args);
 }

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -658,6 +658,37 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
 
 
 
+inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t* this_) { return z_bytes_loan(this_); };
+inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t* closure) { return z_closure_hello_loan(closure); };
+inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t* closure) { return z_closure_query_loan(closure); };
+inline const z_loaned_closure_reply_t* z_loan(const z_owned_closure_reply_t* closure) { return z_closure_reply_loan(closure); };
+inline const z_loaned_closure_sample_t* z_loan(const z_owned_closure_sample_t* closure) { return z_closure_sample_loan(closure); };
+inline const z_loaned_condvar_t* z_loan(const z_owned_condvar_t* this_) { return z_condvar_loan(this_); };
+inline const z_loaned_config_t* z_loan(const z_owned_config_t* this_) { return z_config_loan(this_); };
+inline const z_loaned_encoding_t* z_loan(const z_owned_encoding_t* this_) { return z_encoding_loan(this_); };
+inline const z_loaned_fifo_handler_query_t* z_loan(const z_owned_fifo_handler_query_t* this_) { return z_fifo_handler_query_loan(this_); };
+inline const z_loaned_fifo_handler_reply_t* z_loan(const z_owned_fifo_handler_reply_t* this_) { return z_fifo_handler_reply_loan(this_); };
+inline const z_loaned_fifo_handler_sample_t* z_loan(const z_owned_fifo_handler_sample_t* this_) { return z_fifo_handler_sample_loan(this_); };
+inline const z_loaned_hello_t* z_loan(const z_owned_hello_t* this_) { return z_hello_loan(this_); };
+inline const z_loaned_keyexpr_t* z_loan(const z_owned_keyexpr_t* this_) { return z_keyexpr_loan(this_); };
+inline const z_loaned_publisher_t* z_loan(const z_owned_publisher_t* this_) { return z_publisher_loan(this_); };
+inline const z_loaned_query_t* z_loan(const z_owned_query_t* this_) { return z_query_loan(this_); };
+inline const z_loaned_queryable_t* z_loan(const z_owned_queryable_t* this_) { return z_queryable_loan(this_); };
+inline const z_loaned_reply_err_t* z_loan(const z_owned_reply_err_t* this_) { return z_reply_err_loan(this_); };
+inline const z_loaned_reply_t* z_loan(const z_owned_reply_t* this_) { return z_reply_loan(this_); };
+inline const z_loaned_ring_handler_query_t* z_loan(const z_owned_ring_handler_query_t* this_) { return z_ring_handler_query_loan(this_); };
+inline const z_loaned_ring_handler_reply_t* z_loan(const z_owned_ring_handler_reply_t* this_) { return z_ring_handler_reply_loan(this_); };
+inline const z_loaned_ring_handler_sample_t* z_loan(const z_owned_ring_handler_sample_t* this_) { return z_ring_handler_sample_loan(this_); };
+inline const z_loaned_sample_t* z_loan(const z_owned_sample_t* this_) { return z_sample_loan(this_); };
+inline const z_loaned_session_t* z_loan(const z_owned_session_t* this_) { return z_session_loan(this_); };
+inline const z_loaned_slice_t* z_loan(const z_owned_slice_t* this_) { return z_slice_loan(this_); };
+inline const z_loaned_string_array_t* z_loan(const z_owned_string_array_t* this_) { return z_string_array_loan(this_); };
+inline const z_loaned_string_t* z_loan(const z_owned_string_t* this_) { return z_string_loan(this_); };
+inline const z_loaned_subscriber_t* z_loan(const z_owned_subscriber_t* this_) { return z_subscriber_loan(this_); };
+inline const z_loaned_keyexpr_t* z_loan(const z_view_keyexpr_t* this_) { return z_view_keyexpr_loan(this_); };
+inline const z_loaned_slice_t* z_loan(const z_view_slice_t* this_) { return z_view_slice_loan(this_); };
+inline const z_loaned_string_t* z_loan(const z_view_string_t* this_) { return z_view_string_loan(this_); };
+inline const zc_loaned_closure_log_t* z_loan(const zc_owned_closure_log_t* closure) { return zc_closure_log_loan(closure); };
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& this_) { return z_bytes_loan(&this_); };
 inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t& closure) { return z_closure_hello_loan(&closure); };
 inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t& closure) { return z_closure_query_loan(&closure); };
@@ -691,6 +722,13 @@ inline const z_loaned_string_t* z_loan(const z_view_string_t& this_) { return z_
 inline const zc_loaned_closure_log_t* z_loan(const zc_owned_closure_log_t& closure) { return zc_closure_log_loan(&closure); };
 
 
+inline z_loaned_bytes_t* z_loan_mut(z_owned_bytes_t* this_) { return z_bytes_loan_mut(this_); };
+inline z_loaned_condvar_t* z_loan_mut(z_owned_condvar_t* this_) { return z_condvar_loan_mut(this_); };
+inline z_loaned_config_t* z_loan_mut(z_owned_config_t* this_) { return z_config_loan_mut(this_); };
+inline z_loaned_encoding_t* z_loan_mut(z_owned_encoding_t* this_) { return z_encoding_loan_mut(this_); };
+inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t* this_) { return z_mutex_loan_mut(this_); };
+inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t* this_) { return z_publisher_loan_mut(this_); };
+inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t* this_) { return z_string_array_loan_mut(this_); };
 inline z_loaned_bytes_t* z_loan_mut(z_owned_bytes_t& this_) { return z_bytes_loan_mut(&this_); };
 inline z_loaned_condvar_t* z_loan_mut(z_owned_condvar_t& this_) { return z_condvar_loan_mut(&this_); };
 inline z_loaned_config_t* z_loan_mut(z_owned_config_t& this_) { return z_config_loan_mut(&this_); };
@@ -732,6 +770,36 @@ inline void z_drop(z_moved_task_t* this_) { z_task_drop(this_); };
 inline void z_drop(zc_moved_closure_log_t* closure_) { zc_closure_log_drop(closure_); };
 
 
+inline z_moved_bytes_t* z_move(z_owned_bytes_t* this_) { return z_bytes_move(this_); };
+inline z_moved_closure_hello_t* z_move(z_owned_closure_hello_t* this_) { return z_closure_hello_move(this_); };
+inline z_moved_closure_query_t* z_move(z_owned_closure_query_t* closure_) { return z_closure_query_move(closure_); };
+inline z_moved_closure_reply_t* z_move(z_owned_closure_reply_t* closure_) { return z_closure_reply_move(closure_); };
+inline z_moved_closure_sample_t* z_move(z_owned_closure_sample_t* closure_) { return z_closure_sample_move(closure_); };
+inline z_moved_condvar_t* z_move(z_owned_condvar_t* this_) { return z_condvar_move(this_); };
+inline z_moved_config_t* z_move(z_owned_config_t* this_) { return z_config_move(this_); };
+inline z_moved_encoding_t* z_move(z_owned_encoding_t* this_) { return z_encoding_move(this_); };
+inline z_moved_fifo_handler_query_t* z_move(z_owned_fifo_handler_query_t* this_) { return z_fifo_handler_query_move(this_); };
+inline z_moved_fifo_handler_reply_t* z_move(z_owned_fifo_handler_reply_t* this_) { return z_fifo_handler_reply_move(this_); };
+inline z_moved_fifo_handler_sample_t* z_move(z_owned_fifo_handler_sample_t* this_) { return z_fifo_handler_sample_move(this_); };
+inline z_moved_hello_t* z_move(z_owned_hello_t* this_) { return z_hello_move(this_); };
+inline z_moved_keyexpr_t* z_move(z_owned_keyexpr_t* this_) { return z_keyexpr_move(this_); };
+inline z_moved_mutex_t* z_move(z_owned_mutex_t* this_) { return z_mutex_move(this_); };
+inline z_moved_publisher_t* z_move(z_owned_publisher_t* this_) { return z_publisher_move(this_); };
+inline z_moved_query_t* z_move(z_owned_query_t* this_) { return z_query_move(this_); };
+inline z_moved_queryable_t* z_move(z_owned_queryable_t* this_) { return z_queryable_move(this_); };
+inline z_moved_reply_t* z_move(z_owned_reply_t* this_) { return z_reply_move(this_); };
+inline z_moved_reply_err_t* z_move(z_owned_reply_err_t* this_) { return z_reply_err_move(this_); };
+inline z_moved_ring_handler_query_t* z_move(z_owned_ring_handler_query_t* this_) { return z_ring_handler_query_move(this_); };
+inline z_moved_ring_handler_reply_t* z_move(z_owned_ring_handler_reply_t* this_) { return z_ring_handler_reply_move(this_); };
+inline z_moved_ring_handler_sample_t* z_move(z_owned_ring_handler_sample_t* this_) { return z_ring_handler_sample_move(this_); };
+inline z_moved_sample_t* z_move(z_owned_sample_t* this_) { return z_sample_move(this_); };
+inline z_moved_session_t* z_move(z_owned_session_t* this_) { return z_session_move(this_); };
+inline z_moved_slice_t* z_move(z_owned_slice_t* this_) { return z_slice_move(this_); };
+inline z_moved_string_array_t* z_move(z_owned_string_array_t* this_) { return z_string_array_move(this_); };
+inline z_moved_string_t* z_move(z_owned_string_t* this_) { return z_string_move(this_); };
+inline z_moved_subscriber_t* z_move(z_owned_subscriber_t* this_) { return z_subscriber_move(this_); };
+inline z_moved_task_t* z_move(z_owned_task_t* this_) { return z_task_move(this_); };
+inline zc_moved_closure_log_t* z_move(zc_owned_closure_log_t* closure_) { return zc_closure_log_move(closure_); };
 inline z_moved_bytes_t* z_move(z_owned_bytes_t& this_) { return z_bytes_move(&this_); };
 inline z_moved_closure_hello_t* z_move(z_owned_closure_hello_t& this_) { return z_closure_hello_move(&this_); };
 inline z_moved_closure_query_t* z_move(z_owned_closure_query_t& closure_) { return z_closure_query_move(&closure_); };
@@ -920,6 +988,36 @@ inline void z_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) 
 };
 
 
+inline bool z_check(const z_owned_bytes_t* this_) { return z_bytes_check(this_); };
+inline bool z_check(const z_owned_closure_hello_t* this_) { return z_closure_hello_check(this_); };
+inline bool z_check(const z_owned_closure_query_t* this_) { return z_closure_query_check(this_); };
+inline bool z_check(const z_owned_closure_reply_t* this_) { return z_closure_reply_check(this_); };
+inline bool z_check(const z_owned_closure_sample_t* this_) { return z_closure_sample_check(this_); };
+inline bool z_check(const z_owned_condvar_t* this_) { return z_condvar_check(this_); };
+inline bool z_check(const z_owned_config_t* this_) { return z_config_check(this_); };
+inline bool z_check(const z_owned_encoding_t* this_) { return z_encoding_check(this_); };
+inline bool z_check(const z_owned_fifo_handler_query_t* this_) { return z_fifo_handler_query_check(this_); };
+inline bool z_check(const z_owned_fifo_handler_reply_t* this_) { return z_fifo_handler_reply_check(this_); };
+inline bool z_check(const z_owned_fifo_handler_sample_t* this_) { return z_fifo_handler_sample_check(this_); };
+inline bool z_check(const z_owned_hello_t* this_) { return z_hello_check(this_); };
+inline bool z_check(const z_owned_keyexpr_t* this_) { return z_keyexpr_check(this_); };
+inline bool z_check(const z_owned_mutex_t* this_) { return z_mutex_check(this_); };
+inline bool z_check(const z_owned_publisher_t* this_) { return z_publisher_check(this_); };
+inline bool z_check(const z_owned_query_t* query) { return z_query_check(query); };
+inline bool z_check(const z_owned_queryable_t* this_) { return z_queryable_check(this_); };
+inline bool z_check(const z_owned_reply_t* this_) { return z_reply_check(this_); };
+inline bool z_check(const z_owned_reply_err_t* this_) { return z_reply_err_check(this_); };
+inline bool z_check(const z_owned_ring_handler_query_t* this_) { return z_ring_handler_query_check(this_); };
+inline bool z_check(const z_owned_ring_handler_reply_t* this_) { return z_ring_handler_reply_check(this_); };
+inline bool z_check(const z_owned_ring_handler_sample_t* this_) { return z_ring_handler_sample_check(this_); };
+inline bool z_check(const z_owned_sample_t* this_) { return z_sample_check(this_); };
+inline bool z_check(const z_owned_session_t* this_) { return z_session_check(this_); };
+inline bool z_check(const z_owned_slice_t* this_) { return z_slice_check(this_); };
+inline bool z_check(const z_owned_string_array_t* this_) { return z_string_array_check(this_); };
+inline bool z_check(const z_owned_string_t* this_) { return z_string_check(this_); };
+inline bool z_check(const z_owned_subscriber_t* this_) { return z_subscriber_check(this_); };
+inline bool z_check(const z_owned_task_t* this_) { return z_task_check(this_); };
+inline bool z_check(const zc_owned_closure_log_t* this_) { return zc_closure_log_check(this_); };
 inline bool z_check(const z_owned_bytes_t& this_) { return z_bytes_check(&this_); };
 inline bool z_check(const z_owned_closure_hello_t& this_) { return z_closure_hello_check(&this_); };
 inline bool z_check(const z_owned_closure_query_t& this_) { return z_closure_query_check(&this_); };

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -38,49 +38,167 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
 
 #define z_loan(this_) \
     _Generic((this_), \
+        const z_owned_bytes_t* : z_bytes_loan, \
         z_owned_bytes_t : z_bytes_loan, \
+        const z_owned_closure_hello_t* : z_closure_hello_loan, \
         z_owned_closure_hello_t : z_closure_hello_loan, \
+        const z_owned_closure_query_t* : z_closure_query_loan, \
         z_owned_closure_query_t : z_closure_query_loan, \
+        const z_owned_closure_reply_t* : z_closure_reply_loan, \
         z_owned_closure_reply_t : z_closure_reply_loan, \
+        const z_owned_closure_sample_t* : z_closure_sample_loan, \
         z_owned_closure_sample_t : z_closure_sample_loan, \
+        const z_owned_condvar_t* : z_condvar_loan, \
         z_owned_condvar_t : z_condvar_loan, \
+        const z_owned_config_t* : z_config_loan, \
         z_owned_config_t : z_config_loan, \
+        const z_owned_encoding_t* : z_encoding_loan, \
         z_owned_encoding_t : z_encoding_loan, \
+        const z_owned_fifo_handler_query_t* : z_fifo_handler_query_loan, \
         z_owned_fifo_handler_query_t : z_fifo_handler_query_loan, \
+        const z_owned_fifo_handler_reply_t* : z_fifo_handler_reply_loan, \
         z_owned_fifo_handler_reply_t : z_fifo_handler_reply_loan, \
+        const z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_loan, \
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_loan, \
+        const z_owned_hello_t* : z_hello_loan, \
         z_owned_hello_t : z_hello_loan, \
+        const z_owned_keyexpr_t* : z_keyexpr_loan, \
         z_owned_keyexpr_t : z_keyexpr_loan, \
+        const z_owned_publisher_t* : z_publisher_loan, \
         z_owned_publisher_t : z_publisher_loan, \
+        const z_owned_query_t* : z_query_loan, \
         z_owned_query_t : z_query_loan, \
+        const z_owned_queryable_t* : z_queryable_loan, \
         z_owned_queryable_t : z_queryable_loan, \
+        const z_owned_reply_err_t* : z_reply_err_loan, \
         z_owned_reply_err_t : z_reply_err_loan, \
+        const z_owned_reply_t* : z_reply_loan, \
         z_owned_reply_t : z_reply_loan, \
+        const z_owned_ring_handler_query_t* : z_ring_handler_query_loan, \
         z_owned_ring_handler_query_t : z_ring_handler_query_loan, \
+        const z_owned_ring_handler_reply_t* : z_ring_handler_reply_loan, \
         z_owned_ring_handler_reply_t : z_ring_handler_reply_loan, \
+        const z_owned_ring_handler_sample_t* : z_ring_handler_sample_loan, \
         z_owned_ring_handler_sample_t : z_ring_handler_sample_loan, \
+        const z_owned_sample_t* : z_sample_loan, \
         z_owned_sample_t : z_sample_loan, \
+        const z_owned_session_t* : z_session_loan, \
         z_owned_session_t : z_session_loan, \
+        const z_owned_slice_t* : z_slice_loan, \
         z_owned_slice_t : z_slice_loan, \
+        const z_owned_string_array_t* : z_string_array_loan, \
         z_owned_string_array_t : z_string_array_loan, \
+        const z_owned_string_t* : z_string_loan, \
         z_owned_string_t : z_string_loan, \
+        const z_owned_subscriber_t* : z_subscriber_loan, \
         z_owned_subscriber_t : z_subscriber_loan, \
+        const z_view_keyexpr_t* : z_view_keyexpr_loan, \
         z_view_keyexpr_t : z_view_keyexpr_loan, \
+        const z_view_slice_t* : z_view_slice_loan, \
         z_view_slice_t : z_view_slice_loan, \
+        const z_view_string_t* : z_view_string_loan, \
         z_view_string_t : z_view_string_loan, \
+        const zc_owned_closure_log_t* : zc_closure_log_loan, \
         zc_owned_closure_log_t : zc_closure_log_loan \
-    )(&this_)
+    )(_Generic((this_), \
+        const z_owned_bytes_t* : (this_), \
+        z_owned_bytes_t : (&this_), \
+        const z_owned_closure_hello_t* : (this_), \
+        z_owned_closure_hello_t : (&this_), \
+        const z_owned_closure_query_t* : (this_), \
+        z_owned_closure_query_t : (&this_), \
+        const z_owned_closure_reply_t* : (this_), \
+        z_owned_closure_reply_t : (&this_), \
+        const z_owned_closure_sample_t* : (this_), \
+        z_owned_closure_sample_t : (&this_), \
+        const z_owned_condvar_t* : (this_), \
+        z_owned_condvar_t : (&this_), \
+        const z_owned_config_t* : (this_), \
+        z_owned_config_t : (&this_), \
+        const z_owned_encoding_t* : (this_), \
+        z_owned_encoding_t : (&this_), \
+        const z_owned_fifo_handler_query_t* : (this_), \
+        z_owned_fifo_handler_query_t : (&this_), \
+        const z_owned_fifo_handler_reply_t* : (this_), \
+        z_owned_fifo_handler_reply_t : (&this_), \
+        const z_owned_fifo_handler_sample_t* : (this_), \
+        z_owned_fifo_handler_sample_t : (&this_), \
+        const z_owned_hello_t* : (this_), \
+        z_owned_hello_t : (&this_), \
+        const z_owned_keyexpr_t* : (this_), \
+        z_owned_keyexpr_t : (&this_), \
+        const z_owned_publisher_t* : (this_), \
+        z_owned_publisher_t : (&this_), \
+        const z_owned_query_t* : (this_), \
+        z_owned_query_t : (&this_), \
+        const z_owned_queryable_t* : (this_), \
+        z_owned_queryable_t : (&this_), \
+        const z_owned_reply_err_t* : (this_), \
+        z_owned_reply_err_t : (&this_), \
+        const z_owned_reply_t* : (this_), \
+        z_owned_reply_t : (&this_), \
+        const z_owned_ring_handler_query_t* : (this_), \
+        z_owned_ring_handler_query_t : (&this_), \
+        const z_owned_ring_handler_reply_t* : (this_), \
+        z_owned_ring_handler_reply_t : (&this_), \
+        const z_owned_ring_handler_sample_t* : (this_), \
+        z_owned_ring_handler_sample_t : (&this_), \
+        const z_owned_sample_t* : (this_), \
+        z_owned_sample_t : (&this_), \
+        const z_owned_session_t* : (this_), \
+        z_owned_session_t : (&this_), \
+        const z_owned_slice_t* : (this_), \
+        z_owned_slice_t : (&this_), \
+        const z_owned_string_array_t* : (this_), \
+        z_owned_string_array_t : (&this_), \
+        const z_owned_string_t* : (this_), \
+        z_owned_string_t : (&this_), \
+        const z_owned_subscriber_t* : (this_), \
+        z_owned_subscriber_t : (&this_), \
+        const z_view_keyexpr_t* : (this_), \
+        z_view_keyexpr_t : (&this_), \
+        const z_view_slice_t* : (this_), \
+        z_view_slice_t : (&this_), \
+        const z_view_string_t* : (this_), \
+        z_view_string_t : (&this_), \
+        const zc_owned_closure_log_t* : (this_), \
+        zc_owned_closure_log_t : (&this_) \
+    ))
+
 
 #define z_loan_mut(this_) \
     _Generic((this_), \
+        z_owned_bytes_t* : z_bytes_loan_mut, \
         z_owned_bytes_t : z_bytes_loan_mut, \
+        z_owned_condvar_t* : z_condvar_loan_mut, \
         z_owned_condvar_t : z_condvar_loan_mut, \
+        z_owned_config_t* : z_config_loan_mut, \
         z_owned_config_t : z_config_loan_mut, \
+        z_owned_encoding_t* : z_encoding_loan_mut, \
         z_owned_encoding_t : z_encoding_loan_mut, \
+        z_owned_mutex_t* : z_mutex_loan_mut, \
         z_owned_mutex_t : z_mutex_loan_mut, \
+        z_owned_publisher_t* : z_publisher_loan_mut, \
         z_owned_publisher_t : z_publisher_loan_mut, \
+        z_owned_string_array_t* : z_string_array_loan_mut, \
         z_owned_string_array_t : z_string_array_loan_mut \
-    )(&this_)
+    )(_Generic((this_), \
+        z_owned_bytes_t* : (this_), \
+        z_owned_bytes_t : (&this_), \
+        z_owned_condvar_t* : (this_), \
+        z_owned_condvar_t : (&this_), \
+        z_owned_config_t* : (this_), \
+        z_owned_config_t : (&this_), \
+        z_owned_encoding_t* : (this_), \
+        z_owned_encoding_t : (&this_), \
+        z_owned_mutex_t* : (this_), \
+        z_owned_mutex_t : (&this_), \
+        z_owned_publisher_t* : (this_), \
+        z_owned_publisher_t : (&this_), \
+        z_owned_string_array_t* : (this_), \
+        z_owned_string_array_t : (&this_) \
+    ))
+
 
 #define z_drop(this_) \
     _Generic((this_), \
@@ -116,39 +234,132 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         zc_moved_closure_log_t* : zc_closure_log_drop \
     )(this_)
 
+
 #define z_move(this_) \
     _Generic((this_), \
+        z_owned_bytes_t* : z_bytes_move, \
         z_owned_bytes_t : z_bytes_move, \
+        z_owned_closure_hello_t* : z_closure_hello_move, \
         z_owned_closure_hello_t : z_closure_hello_move, \
+        z_owned_closure_query_t* : z_closure_query_move, \
         z_owned_closure_query_t : z_closure_query_move, \
+        z_owned_closure_reply_t* : z_closure_reply_move, \
         z_owned_closure_reply_t : z_closure_reply_move, \
+        z_owned_closure_sample_t* : z_closure_sample_move, \
         z_owned_closure_sample_t : z_closure_sample_move, \
+        z_owned_condvar_t* : z_condvar_move, \
         z_owned_condvar_t : z_condvar_move, \
+        z_owned_config_t* : z_config_move, \
         z_owned_config_t : z_config_move, \
+        z_owned_encoding_t* : z_encoding_move, \
         z_owned_encoding_t : z_encoding_move, \
+        z_owned_fifo_handler_query_t* : z_fifo_handler_query_move, \
         z_owned_fifo_handler_query_t : z_fifo_handler_query_move, \
+        z_owned_fifo_handler_reply_t* : z_fifo_handler_reply_move, \
         z_owned_fifo_handler_reply_t : z_fifo_handler_reply_move, \
+        z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_move, \
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_move, \
+        z_owned_hello_t* : z_hello_move, \
         z_owned_hello_t : z_hello_move, \
+        z_owned_keyexpr_t* : z_keyexpr_move, \
         z_owned_keyexpr_t : z_keyexpr_move, \
+        z_owned_mutex_t* : z_mutex_move, \
         z_owned_mutex_t : z_mutex_move, \
+        z_owned_publisher_t* : z_publisher_move, \
         z_owned_publisher_t : z_publisher_move, \
+        z_owned_query_t* : z_query_move, \
         z_owned_query_t : z_query_move, \
+        z_owned_queryable_t* : z_queryable_move, \
         z_owned_queryable_t : z_queryable_move, \
+        z_owned_reply_t* : z_reply_move, \
         z_owned_reply_t : z_reply_move, \
+        z_owned_reply_err_t* : z_reply_err_move, \
         z_owned_reply_err_t : z_reply_err_move, \
+        z_owned_ring_handler_query_t* : z_ring_handler_query_move, \
         z_owned_ring_handler_query_t : z_ring_handler_query_move, \
+        z_owned_ring_handler_reply_t* : z_ring_handler_reply_move, \
         z_owned_ring_handler_reply_t : z_ring_handler_reply_move, \
+        z_owned_ring_handler_sample_t* : z_ring_handler_sample_move, \
         z_owned_ring_handler_sample_t : z_ring_handler_sample_move, \
+        z_owned_sample_t* : z_sample_move, \
         z_owned_sample_t : z_sample_move, \
+        z_owned_session_t* : z_session_move, \
         z_owned_session_t : z_session_move, \
+        z_owned_slice_t* : z_slice_move, \
         z_owned_slice_t : z_slice_move, \
+        z_owned_string_array_t* : z_string_array_move, \
         z_owned_string_array_t : z_string_array_move, \
+        z_owned_string_t* : z_string_move, \
         z_owned_string_t : z_string_move, \
+        z_owned_subscriber_t* : z_subscriber_move, \
         z_owned_subscriber_t : z_subscriber_move, \
+        z_owned_task_t* : z_task_move, \
         z_owned_task_t : z_task_move, \
+        zc_owned_closure_log_t* : zc_closure_log_move, \
         zc_owned_closure_log_t : zc_closure_log_move \
-    )(&this_)
+    )(_Generic((this_), \
+        z_owned_bytes_t* : (this_), \
+        z_owned_bytes_t : (&this_), \
+        z_owned_closure_hello_t* : (this_), \
+        z_owned_closure_hello_t : (&this_), \
+        z_owned_closure_query_t* : (this_), \
+        z_owned_closure_query_t : (&this_), \
+        z_owned_closure_reply_t* : (this_), \
+        z_owned_closure_reply_t : (&this_), \
+        z_owned_closure_sample_t* : (this_), \
+        z_owned_closure_sample_t : (&this_), \
+        z_owned_condvar_t* : (this_), \
+        z_owned_condvar_t : (&this_), \
+        z_owned_config_t* : (this_), \
+        z_owned_config_t : (&this_), \
+        z_owned_encoding_t* : (this_), \
+        z_owned_encoding_t : (&this_), \
+        z_owned_fifo_handler_query_t* : (this_), \
+        z_owned_fifo_handler_query_t : (&this_), \
+        z_owned_fifo_handler_reply_t* : (this_), \
+        z_owned_fifo_handler_reply_t : (&this_), \
+        z_owned_fifo_handler_sample_t* : (this_), \
+        z_owned_fifo_handler_sample_t : (&this_), \
+        z_owned_hello_t* : (this_), \
+        z_owned_hello_t : (&this_), \
+        z_owned_keyexpr_t* : (this_), \
+        z_owned_keyexpr_t : (&this_), \
+        z_owned_mutex_t* : (this_), \
+        z_owned_mutex_t : (&this_), \
+        z_owned_publisher_t* : (this_), \
+        z_owned_publisher_t : (&this_), \
+        z_owned_query_t* : (this_), \
+        z_owned_query_t : (&this_), \
+        z_owned_queryable_t* : (this_), \
+        z_owned_queryable_t : (&this_), \
+        z_owned_reply_t* : (this_), \
+        z_owned_reply_t : (&this_), \
+        z_owned_reply_err_t* : (this_), \
+        z_owned_reply_err_t : (&this_), \
+        z_owned_ring_handler_query_t* : (this_), \
+        z_owned_ring_handler_query_t : (&this_), \
+        z_owned_ring_handler_reply_t* : (this_), \
+        z_owned_ring_handler_reply_t : (&this_), \
+        z_owned_ring_handler_sample_t* : (this_), \
+        z_owned_ring_handler_sample_t : (&this_), \
+        z_owned_sample_t* : (this_), \
+        z_owned_sample_t : (&this_), \
+        z_owned_session_t* : (this_), \
+        z_owned_session_t : (&this_), \
+        z_owned_slice_t* : (this_), \
+        z_owned_slice_t : (&this_), \
+        z_owned_string_array_t* : (this_), \
+        z_owned_string_array_t : (&this_), \
+        z_owned_string_t* : (this_), \
+        z_owned_string_t : (&this_), \
+        z_owned_subscriber_t* : (this_), \
+        z_owned_subscriber_t : (&this_), \
+        z_owned_task_t* : (this_), \
+        z_owned_task_t : (&this_), \
+        zc_owned_closure_log_t* : (this_), \
+        zc_owned_closure_log_t : (&this_) \
+    ))
+
 
 #define z_null(this_) \
     _Generic((this_), \
@@ -183,6 +394,7 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_task_t* : z_task_null, \
         zc_owned_closure_log_t* : zc_closure_log_null \
     )(this_)
+
 
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *this_ = x->_this; z_bytes_null(&x->_this); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_closure_hello_null(&x->_this); }
@@ -250,39 +462,132 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         zc_owned_closure_log_t* : zc_closure_log_take \
     )(this_, x)
 
+
 #define z_check(this_) \
     _Generic((this_), \
+        const z_owned_bytes_t* : z_bytes_check, \
         z_owned_bytes_t : z_bytes_check, \
+        const z_owned_closure_hello_t* : z_closure_hello_check, \
         z_owned_closure_hello_t : z_closure_hello_check, \
+        const z_owned_closure_query_t* : z_closure_query_check, \
         z_owned_closure_query_t : z_closure_query_check, \
+        const z_owned_closure_reply_t* : z_closure_reply_check, \
         z_owned_closure_reply_t : z_closure_reply_check, \
+        const z_owned_closure_sample_t* : z_closure_sample_check, \
         z_owned_closure_sample_t : z_closure_sample_check, \
+        const z_owned_condvar_t* : z_condvar_check, \
         z_owned_condvar_t : z_condvar_check, \
+        const z_owned_config_t* : z_config_check, \
         z_owned_config_t : z_config_check, \
+        const z_owned_encoding_t* : z_encoding_check, \
         z_owned_encoding_t : z_encoding_check, \
+        const z_owned_fifo_handler_query_t* : z_fifo_handler_query_check, \
         z_owned_fifo_handler_query_t : z_fifo_handler_query_check, \
+        const z_owned_fifo_handler_reply_t* : z_fifo_handler_reply_check, \
         z_owned_fifo_handler_reply_t : z_fifo_handler_reply_check, \
+        const z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_check, \
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_check, \
+        const z_owned_hello_t* : z_hello_check, \
         z_owned_hello_t : z_hello_check, \
+        const z_owned_keyexpr_t* : z_keyexpr_check, \
         z_owned_keyexpr_t : z_keyexpr_check, \
+        const z_owned_mutex_t* : z_mutex_check, \
         z_owned_mutex_t : z_mutex_check, \
+        const z_owned_publisher_t* : z_publisher_check, \
         z_owned_publisher_t : z_publisher_check, \
+        const z_owned_query_t* : z_query_check, \
         z_owned_query_t : z_query_check, \
+        const z_owned_queryable_t* : z_queryable_check, \
         z_owned_queryable_t : z_queryable_check, \
+        const z_owned_reply_t* : z_reply_check, \
         z_owned_reply_t : z_reply_check, \
+        const z_owned_reply_err_t* : z_reply_err_check, \
         z_owned_reply_err_t : z_reply_err_check, \
+        const z_owned_ring_handler_query_t* : z_ring_handler_query_check, \
         z_owned_ring_handler_query_t : z_ring_handler_query_check, \
+        const z_owned_ring_handler_reply_t* : z_ring_handler_reply_check, \
         z_owned_ring_handler_reply_t : z_ring_handler_reply_check, \
+        const z_owned_ring_handler_sample_t* : z_ring_handler_sample_check, \
         z_owned_ring_handler_sample_t : z_ring_handler_sample_check, \
+        const z_owned_sample_t* : z_sample_check, \
         z_owned_sample_t : z_sample_check, \
+        const z_owned_session_t* : z_session_check, \
         z_owned_session_t : z_session_check, \
+        const z_owned_slice_t* : z_slice_check, \
         z_owned_slice_t : z_slice_check, \
+        const z_owned_string_array_t* : z_string_array_check, \
         z_owned_string_array_t : z_string_array_check, \
+        const z_owned_string_t* : z_string_check, \
         z_owned_string_t : z_string_check, \
+        const z_owned_subscriber_t* : z_subscriber_check, \
         z_owned_subscriber_t : z_subscriber_check, \
+        const z_owned_task_t* : z_task_check, \
         z_owned_task_t : z_task_check, \
+        const zc_owned_closure_log_t* : zc_closure_log_check, \
         zc_owned_closure_log_t : zc_closure_log_check \
-    )(&this_)
+    )(_Generic((this_), \
+        const z_owned_bytes_t* : (this_), \
+        z_owned_bytes_t : (&this_), \
+        const z_owned_closure_hello_t* : (this_), \
+        z_owned_closure_hello_t : (&this_), \
+        const z_owned_closure_query_t* : (this_), \
+        z_owned_closure_query_t : (&this_), \
+        const z_owned_closure_reply_t* : (this_), \
+        z_owned_closure_reply_t : (&this_), \
+        const z_owned_closure_sample_t* : (this_), \
+        z_owned_closure_sample_t : (&this_), \
+        const z_owned_condvar_t* : (this_), \
+        z_owned_condvar_t : (&this_), \
+        const z_owned_config_t* : (this_), \
+        z_owned_config_t : (&this_), \
+        const z_owned_encoding_t* : (this_), \
+        z_owned_encoding_t : (&this_), \
+        const z_owned_fifo_handler_query_t* : (this_), \
+        z_owned_fifo_handler_query_t : (&this_), \
+        const z_owned_fifo_handler_reply_t* : (this_), \
+        z_owned_fifo_handler_reply_t : (&this_), \
+        const z_owned_fifo_handler_sample_t* : (this_), \
+        z_owned_fifo_handler_sample_t : (&this_), \
+        const z_owned_hello_t* : (this_), \
+        z_owned_hello_t : (&this_), \
+        const z_owned_keyexpr_t* : (this_), \
+        z_owned_keyexpr_t : (&this_), \
+        const z_owned_mutex_t* : (this_), \
+        z_owned_mutex_t : (&this_), \
+        const z_owned_publisher_t* : (this_), \
+        z_owned_publisher_t : (&this_), \
+        const z_owned_query_t* : (this_), \
+        z_owned_query_t : (&this_), \
+        const z_owned_queryable_t* : (this_), \
+        z_owned_queryable_t : (&this_), \
+        const z_owned_reply_t* : (this_), \
+        z_owned_reply_t : (&this_), \
+        const z_owned_reply_err_t* : (this_), \
+        z_owned_reply_err_t : (&this_), \
+        const z_owned_ring_handler_query_t* : (this_), \
+        z_owned_ring_handler_query_t : (&this_), \
+        const z_owned_ring_handler_reply_t* : (this_), \
+        z_owned_ring_handler_reply_t : (&this_), \
+        const z_owned_ring_handler_sample_t* : (this_), \
+        z_owned_ring_handler_sample_t : (&this_), \
+        const z_owned_sample_t* : (this_), \
+        z_owned_sample_t : (&this_), \
+        const z_owned_session_t* : (this_), \
+        z_owned_session_t : (&this_), \
+        const z_owned_slice_t* : (this_), \
+        z_owned_slice_t : (&this_), \
+        const z_owned_string_array_t* : (this_), \
+        z_owned_string_array_t : (&this_), \
+        const z_owned_string_t* : (this_), \
+        z_owned_string_t : (&this_), \
+        const z_owned_subscriber_t* : (this_), \
+        z_owned_subscriber_t : (&this_), \
+        const z_owned_task_t* : (this_), \
+        z_owned_task_t : (&this_), \
+        const zc_owned_closure_log_t* : (this_), \
+        zc_owned_closure_log_t : (&this_) \
+    ))
+
 
 #define z_call(closure, hello) \
     _Generic((closure), \
@@ -291,6 +596,7 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         const z_loaned_closure_reply_t* : z_closure_reply_call, \
         const z_loaned_closure_sample_t* : z_closure_sample_call \
     )(closure, hello)
+
 
 #define z_closure(x, callback, dropper, ctx) \
     {{(x)->context = (void*)(ctx); (x)->call = (callback); (x)->drop = (dropper);}}
@@ -305,6 +611,7 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         const z_loaned_ring_handler_sample_t* : z_ring_handler_sample_try_recv \
     )(this_, query)
 
+
 #define z_recv(this_, query) \
     _Generic((this_), \
         const z_loaned_fifo_handler_query_t* : z_fifo_handler_query_recv, \
@@ -314,6 +621,7 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         const z_loaned_ring_handler_reply_t* : z_ring_handler_reply_recv, \
         const z_loaned_ring_handler_sample_t* : z_ring_handler_sample_recv \
     )(this_, query)
+
 #else  // #ifndef __cplusplus
 
 

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -78,7 +78,7 @@ unsafe fn keyexpr_create(
         Ok(name) => match keyexpr_create_inner(name, should_auto_canonize, should_copy) {
             Ok(v) => Ok(v),
             Err(e) => {
-                tracing::error!("Couldn't construct a keyexpr: {}", e);
+                tracing::error!("Couldn't construct keyexpr: {}", e);
                 Err(result::Z_EINVAL)
             }
         },

--- a/src/liveliness.rs
+++ b/src/liveliness.rs
@@ -101,7 +101,7 @@ pub extern "C" fn zc_liveliness_declare_token(
             result::Z_OK
         }
         Err(e) => {
-            tracing::error!("Failed to undeclare token: {e}");
+            tracing::error!("Failed to undeclare liveliness token: {e}");
             this.write(None);
             result::Z_EGENERIC
         }


### PR DESCRIPTION
- merged "main" branch
- allowed to use macroses "z_move", "z_loan", etc both with value and pointer. This is necessary if user want to use e.g. `z_loan` macro with `const z_owned_xxx_t* p` value:
```c
void foo(const z_owned_xxx_t* v) {
   z_xxx_read(z_loan(v)); // z_loan accepts pointer, no need to write "z_loan(*v)"
}
```
the variant with `z_loan(*v)` doesn't work because of "losing const modifier" warning 