### PR TITLE
fix: misuse the callback in z_info

### DIFF
--- a/examples/z_info.c
+++ b/examples/z_info.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
     // we'll just have to make sure we `z_move` it again to avoid mem-leaks.
     printf("peers ids:\n");
     z_owned_closure_zid_t callback2;
-    z_closure(&callback, print_zid, NULL, NULL);
+    z_closure(&callback2, print_zid, NULL, NULL);
     z_info_peers_zid(z_loan(s), z_move(callback2));
 
     z_close(z_move(s));


### PR DESCRIPTION
This PR has partially fixed #601. The remaining task is aligning the ZID order with the Rust side. Despite the same underlying`[u8; 16]`, we display the ZID in LSB order in Rust. That's why we saw a mismatch (actually they are the reverse of each other). 

1. Modify the example z_info (and any other usages) to print ZID reversely.
2. Provide a `zid_to_string` function to avoid any confusion.
3. Change LSB order formatting in [the uhlc crate](https://github.com/atolab/uhlc-rs).
 