### PR TITLE
Ensure build directory contains a copy of rust-toolchain.toml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,16 @@ else()
 endif()
 
 #
+# Copy toolchain configuration to build directory to ensure it is used when cargo is invoked from a directory other
+# than the directory containing the manifest file
+#
+if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/rust-toolchain.toml")
+	file(COPY
+		${CMAKE_CURRENT_SOURCE_DIR}/rust-toolchain.toml
+		DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
+#
 # Configure result library names
 #
 macro(set_lib list var value)


### PR DESCRIPTION
When building using cargo's --manifest-path option the toolchain configuration file within the manifest directory is ignored. Ensuring a copy of the rust-toolchain.toml file is in the build directory ensures the toolchain settings are picked up when building via cmake.