### PR TITLE
build in separate directory failure fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,10 @@ jobs:
       - name: Build examples with zenoh-c as subbroject and static library and in debug mode and in separate directory
         shell: bash
         run: |
-          mkdir -p $CI_PROJECT_DIR/build_examples
-          cmake -S examples -B $CI_PROJECT_DIR/build_examples -DCMAKE_BUILD_TYPE=Debug -DZENOHC_LIB_STATIC=TRUE
-          cmake --build $CI_PROJECT_DIR/build_examples --config Debug
-          rm -rf $CI_PROJECT_DIR/build_examples
+          mkdir -p ../build_examples
+          cmake -S examples -B ../build_examples -DCMAKE_BUILD_TYPE=Debug -DZENOHC_LIB_STATIC=TRUE
+          cmake --build ../build_examples --config Debug
+          rm -rf ../build_examples
 
       - name: Build examples with zenoh-c as installed package
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,10 @@ jobs:
       - name: Build examples with zenoh-c as subbroject and static library and in debug mode and in separate directory
         shell: bash
         run: |
-          mkdir -p $CI_BUILDS_DIR/build_examples
-          cmake -S examples -B $CI_BUILDS_DIR/build_examples -DCMAKE_BUILD_TYPE=Debug -DZENOHC_LIB_STATIC=TRUE
-          cmake --build $CI_BUILDS_DIR/build_examples --config Debug
-          rm -rf $CI_BUILDS_DIR/build_examples
+          mkdir -p $CI_PROJECT_DIR/build_examples
+          cmake -S examples -B $CI_PROJECT_DIR/build_examples -DCMAKE_BUILD_TYPE=Debug -DZENOHC_LIB_STATIC=TRUE
+          cmake --build $CI_PROJECT_DIR/build_examples --config Debug
+          rm -rf $CI_PROJECT_DIR/build_examples
 
       - name: Build examples with zenoh-c as installed package
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,10 @@ jobs:
       - name: Build examples with zenoh-c as subbroject and static library and in debug mode and in separate directory
         shell: bash
         run: |
-          cd .. & mkdir -p build_examples
-          cmake -S zenoh-c/examples -B build_examples -DCMAKE_BUILD_TYPE=Debug -DZENOHC_LIB_STATIC=TRUE
-          cmake --build build_examples --config Debug
-          rm -rf build_examples
+          mkdir -p $CI_BUILDS_DIR/build_examples
+          cmake -S examples -B $CI_BUILDS_DIR/build_examples -DCMAKE_BUILD_TYPE=Debug -DZENOHC_LIB_STATIC=TRUE
+          cmake --build $CI_BUILDS_DIR/build_examples --config Debug
+          rm -rf $CI_BUILDS_DIR/build_examples
 
       - name: Build examples with zenoh-c as installed package
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,13 +86,13 @@ jobs:
           cd build
           cmake --build . --target examples
 
-      - name: Build examples with zenoh-c as subbroject and static library and in debug mode
+      - name: Build examples with zenoh-c as subbroject and static library and in debug mode and in separate directory
         shell: bash
         run: |
-          mkdir -p build_examples && cd build_examples
-          cmake ../examples -DCMAKE_BUILD_TYPE=Debug -DZENOHC_LIB_STATIC=TRUE
-          cmake --build . --config Debug
-          cd .. && rm -rf build_examples
+          cd .. & mkdir -p build_examples
+          cmake -S zenoh-c/examples -B build_examples -DCMAKE_BUILD_TYPE=Debug -DZENOHC_LIB_STATIC=TRUE
+          cmake --build build_examples --config Debug
+          rm -rf build_examples
 
       - name: Build examples with zenoh-c as installed package
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,9 +594,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -1531,6 +1534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1871,12 @@ dependencies = [
  "pin-project-lite",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2771,12 +2786,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -2784,16 +2801,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/src/transmute.rs
+++ b/src/transmute.rs
@@ -14,48 +14,57 @@
 
 use std::mem::MaybeUninit;
 
+#[allow(dead_code)]
 pub(crate) trait CTypeRef: Sized {
     type CType;
     fn as_ctype_ref(&self) -> &Self::CType;
     fn as_ctype_mut(&mut self) -> &mut Self::CType;
 }
+#[allow(dead_code)]
 pub(crate) trait OwnedCTypeRef: Sized {
     type OwnedCType;
     fn as_owned_c_type_ref(&self) -> &Self::OwnedCType;
     fn as_owned_c_type_mut(&mut self) -> &mut Self::OwnedCType;
 }
+#[allow(dead_code)]
 pub(crate) trait LoanedCTypeRef: Sized {
     type LoanedCType;
     fn as_loaned_c_type_ref(&self) -> &Self::LoanedCType;
     fn as_loaned_c_type_mut(&mut self) -> &mut Self::LoanedCType;
 }
+#[allow(dead_code)]
 pub(crate) trait ViewCTypeRef: Sized {
     type ViewCType;
     fn as_view_c_type_ref(&self) -> &Self::ViewCType;
     fn as_view_c_type_mut(&mut self) -> &mut Self::ViewCType;
 }
+#[allow(dead_code)]
 pub(crate) trait RustTypeRef: Sized {
     type RustType;
     fn as_rust_type_ref(&self) -> &Self::RustType;
     fn as_rust_type_mut(&mut self) -> &mut Self::RustType;
 }
+#[allow(dead_code)]
 pub(crate) trait RustTypeRefUninit: Sized {
     type RustType;
     fn as_rust_type_mut_uninit(&mut self) -> &mut MaybeUninit<Self::RustType>;
 }
+#[allow(dead_code)]
 pub(crate) trait IntoRustType: Sized {
     type RustType;
     fn into_rust_type(self) -> Self::RustType;
 }
+#[allow(dead_code)]
 pub(crate) trait IntoCType: Sized {
     type CType;
     fn into_c_type(self) -> Self::CType;
 }
-
+#[allow(dead_code)]
 pub(crate) trait TakeRustType: Sized {
     type RustType;
     fn take_rust_type(&mut self) -> Self::RustType;
 }
+#[allow(dead_code)]
 pub(crate) trait TakeCType: Sized {
     type CType;
     fn take_c_type(&mut self) -> Self::CType;


### PR DESCRIPTION
Fix for build outside of source directory like this:
```bash
md foo
cmake -S zenoh-c -B foo
cmake --build foo
```

The error comes from crate "time 0.3.28", this is known issue resolved in further versions:
https://users.rust-lang.org/t/time-crate-compilation-error/111789/5
```
error[E0282]: type annotations needed for `Box<_>`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.28/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
help: consider giving `items` an explicit type, where the placeholders `_` are specified
   |
83 |     let items: Box<_> = format_items
   |              ++++++++
```