### PR TITLE
fix: add `accept_replies` to `z_get_options_t` and use it in `ze_querying_subscriber_get`

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -677,6 +677,7 @@ typedef struct z_get_options_t {
   struct z_value_t value;
   struct z_attachment_t attachment;
   uint64_t timeout_ms;
+  enum zcu_reply_keyexpr_t accept_replies;
 } z_get_options_t;
 /**
  * An borrowed array of borrowed, zenoh allocated, NULL terminated strings.

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -2672,7 +2672,7 @@ ZENOHC_API bool ze_querying_subscriber_check(const struct ze_owned_querying_subs
 ZENOHC_API
 int8_t ze_querying_subscriber_get(struct ze_querying_subscriber_t sub,
                                   struct z_keyexpr_t selector,
-                                  const struct ze_querying_subscriber_options_t *options);
+                                  const struct z_get_options_t *options);
 /**
  * Returns a :c:type:`ze_querying_subscriber_loan` loaned from `p`.
  */

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -2672,7 +2672,7 @@ ZENOHC_API bool ze_querying_subscriber_check(const struct ze_owned_querying_subs
 ZENOHC_API
 int8_t ze_querying_subscriber_get(struct ze_querying_subscriber_t sub,
                                   struct z_keyexpr_t selector,
-                                  const struct z_get_options_t *options);
+                                  const struct ze_querying_subscriber_options_t *options);
 /**
  * Returns a :c:type:`ze_querying_subscriber_loan` loaned from `p`.
  */

--- a/src/get.rs
+++ b/src/get.rs
@@ -35,8 +35,8 @@ use crate::attachment::{
 };
 use crate::{
     impl_guarded_transmute, z_bytes_t, z_closure_reply_call, z_encoding_default, z_encoding_t,
-    z_keyexpr_t, z_owned_closure_reply_t, z_sample_t, z_session_t, GuardedTransmute,
-    LOG_INVALID_SESSION,
+    z_keyexpr_t, z_owned_closure_reply_t, z_sample_t, z_session_t, zcu_reply_keyexpr_default,
+    zcu_reply_keyexpr_t, GuardedTransmute, LOG_INVALID_SESSION,
 };
 
 type ReplyInner = Option<Reply>;
@@ -168,6 +168,7 @@ pub struct z_get_options_t {
     pub value: z_value_t,
     pub attachment: z_attachment_t,
     pub timeout_ms: u64,
+    pub accept_replies: zcu_reply_keyexpr_t,
 }
 #[no_mangle]
 pub extern "C" fn z_get_options_default() -> z_get_options_t {
@@ -182,6 +183,7 @@ pub extern "C" fn z_get_options_default() -> z_get_options_t {
             }
         },
         attachment: z_attachment_null(),
+        accept_replies: zcu_reply_keyexpr_default(),
     }
 }
 

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -37,12 +37,12 @@ type FetchingSubscriber = Option<Box<FetchingSubscriberWrapper>>;
 
 /// An owned zenoh querying subscriber. Destroying the subscriber cancels the subscription.
 ///
-/// Like most `ze_owned_X_t` types, you may obtain an instance of `z_X_t` by loaning it using `z_X_loan(&val)`.  
-/// The `z_loan(val)` macro, available if your compiler supports C11's `_Generic`, is equivalent to writing `z_X_loan(&val)`.  
+/// Like most `ze_owned_X_t` types, you may obtain an instance of `z_X_t` by loaning it using `z_X_loan(&val)`.
+/// The `z_loan(val)` macro, available if your compiler supports C11's `_Generic`, is equivalent to writing `z_X_loan(&val)`.
 ///
-/// Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.  
-/// To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.  
-/// After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.  
+/// Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.
+/// To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.
+/// After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.
 ///
 /// To check if `val` is still valid, you may use `z_X_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
 #[repr(C)]
@@ -132,8 +132,8 @@ pub extern "C" fn ze_querying_subscriber_options_default() -> ze_querying_subscr
 ///    To check if the subscription succeeded and if the querying subscriber is still valid,
 ///    you may use `ze_querying_subscriber_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
 ///
-///    Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.  
-///    To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.  
+///    Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.
+///    To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.
 ///    After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.
 ///
 /// Example:
@@ -234,6 +234,7 @@ pub unsafe extern "C" fn ze_querying_subscriber_get(
                                 .target(options.target.into())
                                 .consolidation(options.consolidation)
                                 .timeout(std::time::Duration::from_millis(options.timeout_ms))
+                                .accept_replies(options.accept_replies.into())
                                 .callback(cb)
                                 .res_sync(),
                             None => s.get(selector).callback(cb).res_sync(),

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -37,12 +37,12 @@ type FetchingSubscriber = Option<Box<FetchingSubscriberWrapper>>;
 
 /// An owned zenoh querying subscriber. Destroying the subscriber cancels the subscription.
 ///
-/// Like most `ze_owned_X_t` types, you may obtain an instance of `z_X_t` by loaning it using `z_X_loan(&val)`.
-/// The `z_loan(val)` macro, available if your compiler supports C11's `_Generic`, is equivalent to writing `z_X_loan(&val)`.
+/// Like most `ze_owned_X_t` types, you may obtain an instance of `z_X_t` by loaning it using `z_X_loan(&val)`.  
+/// The `z_loan(val)` macro, available if your compiler supports C11's `_Generic`, is equivalent to writing `z_X_loan(&val)`.  
 ///
-/// Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.
-/// To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.
-/// After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.
+/// Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.  
+/// To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.  
+/// After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.  
 ///
 /// To check if `val` is still valid, you may use `z_X_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
 #[repr(C)]
@@ -132,8 +132,8 @@ pub extern "C" fn ze_querying_subscriber_options_default() -> ze_querying_subscr
 ///    To check if the subscription succeeded and if the querying subscriber is still valid,
 ///    you may use `ze_querying_subscriber_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
 ///
-///    Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.
-///    To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.
+///    Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.  
+///    To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.  
 ///    After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.
 ///
 /// Example:
@@ -217,7 +217,7 @@ pub unsafe extern "C" fn ze_declare_querying_subscriber(
 pub unsafe extern "C" fn ze_querying_subscriber_get(
     sub: ze_querying_subscriber_t,
     selector: z_keyexpr_t,
-    options: Option<&ze_querying_subscriber_options_t>,
+    options: Option<&z_get_options_t>,
 ) -> i8 {
     unsafe impl Sync for z_get_options_t {}
 
@@ -229,19 +229,13 @@ pub unsafe extern "C" fn ze_querying_subscriber_get(
                     .fetch({
                         let selector = KeyExpr::try_from(selector).unwrap();
                         move |cb| match options {
-                            Some(options) => {
-                                let mut get_builder = s
-                                    .get(selector)
-                                    .accept_replies(options.query_accept_replies.into())
-                                    .consolidation(options.query_consolidation);
-
-                                if options.query_timeout_ms != 0 {
-                                    get_builder = get_builder.timeout(
-                                        std::time::Duration::from_millis(options.query_timeout_ms),
-                                    );
-                                }
-                                get_builder.callback(cb).res_sync()
-                            }
+                            Some(options) => s
+                                .get(selector)
+                                .target(options.target.into())
+                                .consolidation(options.consolidation)
+                                .timeout(std::time::Duration::from_millis(options.timeout_ms))
+                                .callback(cb)
+                                .res_sync(),
                             None => s.get(selector).callback(cb).res_sync(),
                         }
                     })

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -37,12 +37,12 @@ type FetchingSubscriber = Option<Box<FetchingSubscriberWrapper>>;
 
 /// An owned zenoh querying subscriber. Destroying the subscriber cancels the subscription.
 ///
-/// Like most `ze_owned_X_t` types, you may obtain an instance of `z_X_t` by loaning it using `z_X_loan(&val)`.  
-/// The `z_loan(val)` macro, available if your compiler supports C11's `_Generic`, is equivalent to writing `z_X_loan(&val)`.  
+/// Like most `ze_owned_X_t` types, you may obtain an instance of `z_X_t` by loaning it using `z_X_loan(&val)`.
+/// The `z_loan(val)` macro, available if your compiler supports C11's `_Generic`, is equivalent to writing `z_X_loan(&val)`.
 ///
-/// Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.  
-/// To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.  
-/// After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.  
+/// Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.
+/// To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.
+/// After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.
 ///
 /// To check if `val` is still valid, you may use `z_X_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
 #[repr(C)]
@@ -132,8 +132,8 @@ pub extern "C" fn ze_querying_subscriber_options_default() -> ze_querying_subscr
 ///    To check if the subscription succeeded and if the querying subscriber is still valid,
 ///    you may use `ze_querying_subscriber_check(&val)` or `z_check(val)` if your compiler supports `_Generic`, which will return `true` if `val` is valid.
 ///
-///    Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.  
-///    To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.  
+///    Like all `ze_owned_X_t`, an instance will be destroyed by any function which takes a mutable pointer to said instance, as this implies the instance's inners were moved.
+///    To make this fact more obvious when reading your code, consider using `z_move(val)` instead of `&val` as the argument.
 ///    After a move, `val` will still exist, but will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your `val` is valid.
 ///
 /// Example:
@@ -217,7 +217,7 @@ pub unsafe extern "C" fn ze_declare_querying_subscriber(
 pub unsafe extern "C" fn ze_querying_subscriber_get(
     sub: ze_querying_subscriber_t,
     selector: z_keyexpr_t,
-    options: Option<&z_get_options_t>,
+    options: Option<&ze_querying_subscriber_options_t>,
 ) -> i8 {
     unsafe impl Sync for z_get_options_t {}
 
@@ -229,13 +229,19 @@ pub unsafe extern "C" fn ze_querying_subscriber_get(
                     .fetch({
                         let selector = KeyExpr::try_from(selector).unwrap();
                         move |cb| match options {
-                            Some(options) => s
-                                .get(selector)
-                                .target(options.target.into())
-                                .consolidation(options.consolidation)
-                                .timeout(std::time::Duration::from_millis(options.timeout_ms))
-                                .callback(cb)
-                                .res_sync(),
+                            Some(options) => {
+                                let mut get_builder = s
+                                    .get(selector)
+                                    .accept_replies(options.query_accept_replies.into())
+                                    .consolidation(options.query_consolidation);
+
+                                if options.query_timeout_ms != 0 {
+                                    get_builder = get_builder.timeout(
+                                        std::time::Duration::from_millis(options.query_timeout_ms),
+                                    );
+                                }
+                                get_builder.callback(cb).res_sync()
+                            }
                             None => s.get(selector).callback(cb).res_sync(),
                         }
                     })


### PR DESCRIPTION
We need this fix to resolve the issue in rmw_zenoh_cpp. 
- https://github.com/ros2/rmw_zenoh/issues/263
- https://github.com/ros2/rmw_zenoh/pull/269