### PR TITLE
cmake clean up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           cd build
-          cmake .. -DZENOHC_LIB_STATIC=FALSE -DCMAKE_BUILD_TYPE=Release -DZENOHC_BUILD_WITH_SHARED_MEMORY=${{ matrix.shm }} -DZENOHC_BUILD_WITH_UNSTABLE_API=${{ matrix.unstable }}
+          cmake .. -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DZENOHC_BUILD_WITH_SHARED_MEMORY=${{ matrix.shm }} -DZENOHC_BUILD_WITH_UNSTABLE_API=${{ matrix.unstable }}
           cmake --build . --target tests --config Release
           ctest -C Release --output-on-failure -E "(unit_z_api_alignment_test|build_z_build_static)"
 
@@ -71,14 +71,14 @@ jobs:
         shell: bash
         run: |
           cd build
-          cmake .. -DZENOHC_LIB_STATIC=TRUE -DCMAKE_BUILD_TYPE=Debug -DZENOHC_BUILD_TESTS_WITH_CXX=TRUE -DZENOHC_BUILD_WITH_SHARED_MEMORY=${{ matrix.shm }} -DZENOHC_BUILD_WITH_UNSTABLE_API=${{ matrix.unstable }}
+          cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Debug -DZENOHC_BUILD_TESTS_WITH_CXX=TRUE -DZENOHC_BUILD_WITH_SHARED_MEMORY=${{ matrix.shm }} -DZENOHC_BUILD_WITH_UNSTABLE_API=${{ matrix.unstable }}
           cmake --build . --target tests --config Debug
 
       - name: Run cmake tests with zenoh-c as static library
         shell: bash
         run: |
           cd build
-          cmake .. -DZENOHC_LIB_STATIC=TRUE -DCMAKE_BUILD_TYPE=Release -DZENOHC_BUILD_WITH_SHARED_MEMORY=${{ matrix.shm }} -DZENOHC_BUILD_WITH_UNSTABLE_API=${{ matrix.unstable }}
+          cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DZENOHC_BUILD_WITH_SHARED_MEMORY=${{ matrix.shm }} -DZENOHC_BUILD_WITH_UNSTABLE_API=${{ matrix.unstable }}
           cmake --build . --target tests --config Release
           ctest -C Release --output-on-failure -E "(unit_z_api_alignment_test|build_z_build_shared)"
 
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ../build_examples
-          cmake -S examples -B ../build_examples -DCMAKE_BUILD_TYPE=Debug -DZENOHC_LIB_STATIC=TRUE
+          cmake -S examples -B ../build_examples -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF
           cmake --build ../build_examples --config Debug
           rm -rf ../build_examples
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ enable_testing()
 #
 # Build zenohc library from rust sources
 #
-# target zenohc::lib - for linking zenoh-c as static or dynamic library depending on ZENOHC_STATIC boolean cache var
+# target zenohc::lib - for linking zenoh-c as static or dynamic library depending on BUILD_SHARED_LIBS boolean cache var
 # target zenohc::static - for linking zenoh-c as static library
 # target zenohc::shared - for linking zenoh-c as dynamic library
 #
@@ -34,7 +34,7 @@ declare_cache_var(ZENOHC_BUILD_TESTS_WITH_CXX FALSE BOOL "Use C++ compiler for b
 declare_cache_var(ZENOHC_CUSTOM_TARGET "" STRING "Rust target for cross compilation, 'aarch64-unknown-linux-gnu' for example")
 declare_cache_var(ZENOHC_CARGO_CHANNEL "" STRING "Cargo channel parameter. Should be '+stable', '+nightly' or empty value")
 declare_cache_var(ZENOHC_CARGO_FLAGS "" STRING "Additional cargo flags")
-declare_cache_var(ZENOHC_LIB_STATIC FALSE BOOL "Alias zenohc::lib target to zenohc::static if TRUE, to zenohc::shared if FALSE")
+declare_cache_var(BUILD_SHARED_LIBS TRUE BOOL "Alias zenohc::lib target to zenohc::shared if TRUE, to zenohc::static if FALSE")
 
 #
 # Setup project version
@@ -234,31 +234,6 @@ add_custom_target(cargo ALL DEPENDS "${libs}")
 #
 # Define libraries built by cargo as targets
 #
-add_library(zenohc_static STATIC IMPORTED GLOBAL)
-add_library(zenohc_shared SHARED IMPORTED GLOBAL)
-add_library(zenohc::static ALIAS zenohc_static)
-add_library(zenohc::shared ALIAS zenohc_shared)
-if (ZENOHC_LIB_STATIC)
-	add_library(zenohc::lib ALIAS zenohc_static)
-else()
-	add_library(zenohc::lib ALIAS zenohc_shared)
-endif()
-add_dependencies(zenohc_static cargo)
-add_dependencies(zenohc_shared cargo)
-
-#
-# Setup additional properties for library targets
-# *IMPORTANT* any options in this section should be repeated in install/PackageConfig.cmake.in
-# to achieve correct behavior of find_package(zenohc)
-#
-get_required_static_libs(NATIVE_STATIC_LIBS)
-target_link_libraries(zenohc_static INTERFACE ${NATIVE_STATIC_LIBS})
-target_compile_definitions(zenohc_shared INTERFACE ZENOHC_DYN_LIB)
-
-# Workaroud for https://github.com/rust-lang/cargo/issues/5045
-# mentioned in https://github.com/eclipse-zenoh/zenoh-c/issues/138
-# If it's fixed, do not forget to correct PackageConfig.cmake.in also
-set_target_properties(zenohc_shared PROPERTIES IMPORTED_NO_SONAME TRUE)
 
 function(set_target_imported_locations target libr libd)
 	set_target_properties(${target}
@@ -282,26 +257,38 @@ function(set_target_imported_implib target libr libd)
 	)
 endfunction()
 
-set_target_imported_locations(zenohc_static ${staticlibr} ${staticlibd})
-set_target_imported_locations(zenohc_shared ${dylibr} ${dylibd})
-
-if(DEFINED implibr)
-	set_target_imported_implib(zenohc_shared ${implibr} ${implibd})
-endif()
-
-# Define include directories for library targets
-status_print(source_include_dir)
-status_print(cargo_generated_include_dir)
-
-if(NOT(cargo_generated_include_dir STREQUAL ${source_include_dir}))
-	target_include_directories(zenohc_static INTERFACE ${cargo_generated_include_dir})
+#
+# Setup additional properties for library targets
+# *IMPORTANT* any options in this section should be repeated in install/PackageConfig.cmake.in
+# to achieve correct behavior of find_package(zenohc)
+#
+if (BUILD_SHARED_LIBS)
+	add_library(zenohc_shared SHARED IMPORTED GLOBAL)
+	add_library(zenohc::lib ALIAS zenohc_shared)
+	add_dependencies(zenohc_shared cargo)
+	target_compile_definitions(zenohc_shared INTERFACE ZENOHC_DYN_LIB)
+	# Workaroud for https://github.com/rust-lang/cargo/issues/5045
+	# mentioned in https://github.com/eclipse-zenoh/zenoh-c/issues/138
+	# If it's fixed, do not forget to correct PackageConfig.cmake.in also
+	set_target_properties(zenohc_shared PROPERTIES IMPORTED_NO_SONAME TRUE)
+	set_target_imported_locations(zenohc_shared ${dylibr} ${dylibd})
+	if(DEFINED implibr)
+		set_target_imported_implib(zenohc_shared ${implibr} ${implibd})
+	endif()
 	target_include_directories(zenohc_shared INTERFACE ${cargo_generated_include_dir})
+	set_target_properties(zenohc_shared PROPERTIES IMPORTED_GLOBAL TRUE)
 else()
-	target_include_directories(zenohc_static INTERFACE ${source_include_dir})
-	target_include_directories(zenohc_shared INTERFACE ${source_include_dir})
+	add_library(zenohc_static STATIC IMPORTED GLOBAL)
+	add_library(zenohc::lib ALIAS zenohc_static)
+	add_library(zenohc::static ALIAS zenohc_static)
+	add_dependencies(zenohc_static cargo)
+	get_required_static_libs(NATIVE_STATIC_LIBS)
+	target_link_libraries(zenohc_static INTERFACE ${NATIVE_STATIC_LIBS})
+	set_target_imported_locations(zenohc_static ${staticlibr} ${staticlibd})
+	target_include_directories(zenohc_static INTERFACE ${cargo_generated_include_dir})
+	set_target_properties(zenohc_static PROPERTIES IMPORTED_GLOBAL TRUE)
 endif()
 
-set_target_properties(zenohc_shared zenohc_static PROPERTIES IMPORTED_GLOBAL TRUE)
 
 #
 # Components included only if project is the root project

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ This repository provides a C binding based on the main [Zenoh implementation wri
    cmake --build . --target install
    ```
 
-   By default only dynamic library is installed. Set `ZENOHC_INSTALL_STATIC_LIBRARY` variable to true to install static library also:
+   By default only dynamic library is built and installed. Set `BUILD_SHARED_LIBS` variable to false to build and install static library:
 
    ```bash
-   cmake ../zenoh-c -DCMAKE_INSTALL_PREFIX=~/.local -DZENOHC_INSTALL_STATIC_LIBRARY=TRUE
+   cmake ../zenoh-c -DCMAKE_INSTALL_PREFIX=~/.local -DBUILD_SHARED_LIBS=FALSE
    cmake --build . --target install
    ```
 
@@ -100,7 +100,7 @@ This repository provides a C binding based on the main [Zenoh implementation wri
 
    - `zenohc::shared` for linking dynamic library
    - `zenohc::static` for linking static library
-   - `zenohc::lib` for linking static or dynamic library depending on boolean variable `ZENOHC_LIB_STATIC`
+   - `zenohc::lib` for linking static or dynamic library depending on boolean variable `BUILD_SHARED_LIBS`
 
    For `Debug` configuration suffix `d` is added to names of library files (libzenohc**d**.so).
 

--- a/install/CMakeLists.txt
+++ b/install/CMakeLists.txt
@@ -1,7 +1,5 @@
 message(STATUS "zenoh-c install")
 
-declare_cache_var(ZENOHC_INSTALL_STATIC_LIBRARY FALSE BOOL "Install zenoh-c static library")
-
 #
 # Installation
 # For debug configuration installs libraries with 'd' added to filename
@@ -12,29 +10,35 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 function(install_zenohc_lib configurations property_postfix package_name)
-    # Prepare parameters for PackageConfig.cmake.in
-    get_target_property(dylib_path zenohc::lib IMPORTED_LOCATION_${property_postfix})
-    get_target_property_if_set(implib_path zenohc::lib IMPORTED_IMPLIB_${property_postfix})
-    get_target_property(staticlib_path zenohc::static IMPORTED_LOCATION_${property_postfix})
-    get_target_property(NATIVE_STATIC_LIBS zenohc::static INTERFACE_LINK_LIBRARIES)
-    get_filename_component(DYLIB ${dylib_path} NAME)
-    get_filename_component(IMPLIB "${implib_path}" NAME)
-    get_filename_component(STATICLIB ${staticlib_path} NAME)
-
-    # Install dynamic, import and static library
-
-    # On Windows .dll need to be installed in ${CMAKE_INSTALL_BINDIR}, 
-    # while on Linux and macOS .so and .dylib need to be installed in ${CMAKE_INSTALL_LIBDIR}
-    if(WIN32)
-        set(ZENOHC_INSTALL_DYLIBDIR ${CMAKE_INSTALL_BINDIR})
+    if (BUILD_SHARED_LIBS)
+        get_target_property(dylib_path zenohc::lib IMPORTED_LOCATION_${property_postfix})
+        get_target_property_if_set(implib_path zenohc::lib IMPORTED_IMPLIB_${property_postfix})
+        get_filename_component(DYLIB ${dylib_path} NAME)
+        get_filename_component(IMPLIB "${implib_path}" NAME)
+        # On Windows .dll need to be installed in ${CMAKE_INSTALL_BINDIR}, 
+        # while on Linux and macOS .so and .dylib need to be installed in ${CMAKE_INSTALL_LIBDIR}
+        if(WIN32)
+            set(ZENOHC_INSTALL_DYLIBDIR ${CMAKE_INSTALL_BINDIR})
+        else()
+            set(ZENOHC_INSTALL_DYLIBDIR ${CMAKE_INSTALL_LIBDIR})
+        endif()
+        install(FILES ${dylib_path} DESTINATION ${ZENOHC_INSTALL_DYLIBDIR} CONFIGURATIONS ${configurations})
+        if(DEFINED implib_path)
+            install(FILES ${implib_path} DESTINATION ${CMAKE_INSTALL_LIBDIR} CONFIGURATIONS ${configurations})
+        endif()
+        if((APPLE OR UNIX))
+            get_filename_component(LIBNAME ${DYLIB} NAME_WE)
+            configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zenohc.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${package_name}_${property_postfix}.pc @ONLY)
+            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${package_name}_${property_postfix}.pc 
+                DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" 
+                CONFIGURATIONS ${configurations}
+                RENAME ${package_name}.pc
+                OPTIONAL)
+        endif()
     else()
-        set(ZENOHC_INSTALL_DYLIBDIR ${CMAKE_INSTALL_LIBDIR})
-    endif()
-    install(FILES ${dylib_path} DESTINATION ${ZENOHC_INSTALL_DYLIBDIR} CONFIGURATIONS ${configurations})
-    if(DEFINED implib_path)
-        install(FILES ${implib_path} DESTINATION ${CMAKE_INSTALL_LIBDIR} CONFIGURATIONS ${configurations})
-    endif()
-    if(ZENOHC_INSTALL_STATIC_LIBRARY)
+        get_target_property(staticlib_path zenohc::static IMPORTED_LOCATION_${property_postfix})
+        get_target_property(NATIVE_STATIC_LIBS zenohc::static INTERFACE_LINK_LIBRARIES)
+        get_filename_component(STATICLIB ${staticlib_path} NAME)
         install(FILES ${staticlib_path} DESTINATION ${CMAKE_INSTALL_LIBDIR} CONFIGURATIONS ${configurations})
     endif()
 
@@ -66,15 +70,7 @@ function(install_zenohc_lib configurations property_postfix package_name)
         RENAME ${package_name}ConfigVersion.cmake
         COMPONENT dev)
 
-    if(APPLE OR UNIX)
-        get_filename_component(LIBNAME ${DYLIB} NAME_WE)
-        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zenohc.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${package_name}_${property_postfix}.pc @ONLY)
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${package_name}_${property_postfix}.pc 
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" 
-            CONFIGURATIONS ${configurations}
-            RENAME ${package_name}.pc
-            OPTIONAL)
-    endif()
+
 endfunction()
 
 

--- a/install/PackageConfig.cmake.in
+++ b/install/PackageConfig.cmake.in
@@ -25,35 +25,30 @@ if(_IMPORT_PREFIX STREQUAL "/")
   set(_IMPORT_PREFIX "")
 endif()
 
-if(NOT TARGET __zenohc_static)
-  add_library(__zenohc_static STATIC IMPORTED GLOBAL)
-  add_library(zenohc::static ALIAS __zenohc_static)
-  target_link_libraries(__zenohc_static INTERFACE @NATIVE_STATIC_LIBS@)
-  set_target_properties(__zenohc_static PROPERTIES
-      IMPORTED_LOCATION "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@STATICLIB@"
-      INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
-  )
-endif()
-
-if(NOT TARGET __zenohc_shared)
-  add_library(__zenohc_shared SHARED IMPORTED GLOBAL)
-  add_library(zenohc::shared ALIAS __zenohc_shared)
-  set_target_properties(__zenohc_shared PROPERTIES
-      IMPORTED_NO_SONAME TRUE
-      INTERFACE_COMPILE_DEFINITION ZENOHC_DYN_LIB
-      IMPORTED_LOCATION "${_IMPORT_PREFIX}/@ZENOHC_INSTALL_DYLIBDIR@/@DYLIB@"
-      INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
-  )
-endif()
-
-if(NOT ("@IMPLIB@" STREQUAL ""))
-    set_property(TARGET __zenohc_shared PROPERTY IMPORTED_IMPLIB "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@IMPLIB@")
-endif()
-
-if(NOT TARGET zenohc::lib)
-  if(ZENOHC_LIB_STATIC)
-    add_library(zenohc::lib ALIAS __zenohc_static)
-  else()
-    add_library(zenohc::lib ALIAS __zenohc_shared)
-  endif()
+if (@BUILD_SHARED_LIBS@)
+    if(NOT TARGET __zenohc_shared)
+        add_library(__zenohc_shared SHARED IMPORTED GLOBAL)
+        add_library(zenohc::shared ALIAS __zenohc_shared)
+        set_target_properties(__zenohc_shared PROPERTIES
+            IMPORTED_NO_SONAME TRUE
+            INTERFACE_COMPILE_DEFINITION ZENOHC_DYN_LIB
+            IMPORTED_LOCATION "${_IMPORT_PREFIX}/@ZENOHC_INSTALL_DYLIBDIR@/@DYLIB@"
+            INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
+        )
+        add_library(zenohc::lib ALIAS __zenohc_shared)
+        if(NOT ("@IMPLIB@" STREQUAL ""))
+            set_property(TARGET __zenohc_shared PROPERTY IMPORTED_IMPLIB "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@IMPLIB@")
+        endif()
+    endif()
+else()
+    if(NOT TARGET __zenohc_static)
+        add_library(__zenohc_static STATIC IMPORTED GLOBAL)
+        add_library(zenohc::static ALIAS __zenohc_static)
+        target_link_libraries(__zenohc_static INTERFACE @NATIVE_STATIC_LIBS@)
+        set_target_properties(__zenohc_static PROPERTIES
+            IMPORTED_LOCATION "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@STATICLIB@"
+            INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
+        )
+        add_library(zenohc::lib ALIAS __zenohc_static)
+    endif()
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,13 @@ foreach(file ${files})
         endif()
     endif()
 
+    if (BUILD_SHARED_LIBS AND (${target} MATCHES "^.*_build_static.*$"))
+        continue()
+    endif()
+    if (NOT BUILD_SHARED_LIBS AND (${target} MATCHES "^.*_build_shared.*$"))
+        continue()
+    endif()
+
     # Check the filename prefix to determine the test type
     if (${file} MATCHES "^.*z_api_.*$")
         set(test_type "unit")


### PR DESCRIPTION
- replace ZENOHC_LIB_STATIC with more common BUILD_SHARED_LIBS
- only install either shared or static libraries depending on BUILD_SHARED_LIBS
- do not build shared/static build test depending on BUILD_SHARED_LIBS
- rearrange cmake lines to make clearer to which type of lib they refer