### PR TITLE
make z_drop on zenoh entities call actual drop instead of undeclare

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -3247,7 +3247,7 @@ z_result_t z_publisher_delete(const struct z_loaned_publisher_t *publisher,
  */
 ZENOHC_API void z_publisher_delete_options_default(struct z_publisher_delete_options_t *this_);
 /**
- * Frees memory and resets publisher to its gravestone state. Also attempts undeclare publisher.
+ * Frees memory and resets publisher to its gravestone state.
  */
 ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t *this_);
 /**
@@ -3466,7 +3466,7 @@ ZENOHC_API void z_query_reply_options_default(struct z_query_reply_options_t *th
  */
 ZENOHC_API enum z_query_target_t z_query_target_default(void);
 /**
- * Frees memory and resets it to its gravesztone state. Will also attempt to undeclare queryable.
+ * Frees memory and resets queryable to its gravestone state.
  */
 ZENOHC_API void z_queryable_drop(struct z_moved_queryable_t *this_);
 ZENOHC_API
@@ -4188,7 +4188,7 @@ ZENOHC_API size_t z_string_len(const struct z_loaned_string_t *this_);
  */
 ZENOHC_API const struct z_loaned_string_t *z_string_loan(const struct z_owned_string_t *this_);
 /**
- * Drops subscriber and resets it to its gravestone state. Also attempts to undeclare it.
+ * Drops subscriber and resets it to its gravestone state.
  */
 ZENOHC_API void z_subscriber_drop(struct z_moved_subscriber_t *this_);
 /**
@@ -4871,7 +4871,7 @@ ZENOHC_API bool ze_internal_querying_subscriber_check(const ze_owned_querying_su
 ZENOHC_API void ze_internal_querying_subscriber_null(ze_owned_querying_subscriber_t *this_);
 #endif
 /**
- * Drops publication cache. Also attempts to undeclare it.
+ * Drops publication cache and resets it to its gravestone state.
  */
 #if defined(UNSTABLE)
 ZENOHC_API void ze_publication_cache_drop(ze_moved_publication_cache_t *this_);
@@ -4883,7 +4883,7 @@ ZENOHC_API void ze_publication_cache_drop(ze_moved_publication_cache_t *this_);
 ZENOHC_API void ze_publication_cache_options_default(struct ze_publication_cache_options_t *this_);
 #endif
 /**
- * Drops querying subscriber. Also attempts to undeclare it.
+ * Drops querying subscriber.
  */
 #if defined(UNSTABLE)
 ZENOHC_API void ze_querying_subscriber_drop(ze_moved_querying_subscriber_t *this_);
@@ -4926,5 +4926,5 @@ ZENOHC_API z_result_t ze_undeclare_publication_cache(ze_moved_publication_cache_
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(UNSTABLE)
-ZENOHC_API z_result_t ze_undeclare_querying_subscriber(ze_moved_querying_subscriber_t *_this);
+ZENOHC_API z_result_t ze_undeclare_querying_subscriber(ze_moved_querying_subscriber_t *this_);
 #endif

--- a/src/publication_cache.rs
+++ b/src/publication_cache.rs
@@ -149,9 +149,9 @@ pub extern "C" fn ze_undeclare_publication_cache(
     result::Z_OK
 }
 
-/// Drops publication cache. Also attempts to undeclare it.
+/// Drops publication cache and resets it to its gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn ze_publication_cache_drop(this_: &mut ze_moved_publication_cache_t) {
-    ze_undeclare_publication_cache(this_);
+pub extern "C" fn ze_publication_cache_drop(this: &mut ze_moved_publication_cache_t) {
+    std::mem::drop(this.take_rust_type())
 }

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -430,9 +430,9 @@ pub extern "C" fn z_undeclare_publisher(this_: &mut z_moved_publisher_t) -> resu
     result::Z_OK
 }
 
-/// Frees memory and resets publisher to its gravestone state. Also attempts undeclare publisher.
+/// Frees memory and resets publisher to its gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_publisher_drop(this_: &mut z_moved_publisher_t) {
-    z_undeclare_publisher(this_);
+pub extern "C" fn z_publisher_drop(this: &mut z_moved_publisher_t) {
+    std::mem::drop(this.take_rust_type())
 }

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -264,11 +264,11 @@ pub extern "C" fn z_undeclare_queryable(this_: &mut z_moved_queryable_t) -> resu
     result::Z_OK
 }
 
-/// Frees memory and resets it to its gravesztone state. Will also attempt to undeclare queryable.
+/// Frees memory and resets queryable to its gravestone state.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub extern "C" fn z_queryable_drop(this_: &mut z_moved_queryable_t) {
-    z_undeclare_queryable(this_);
+    std::mem::drop(this_.take_rust_type())
 }
 
 /// Returns ``true`` if queryable is valid, ``false`` otherwise.

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -221,9 +221,9 @@ pub unsafe extern "C" fn ze_querying_subscriber_get(
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
 pub extern "C" fn ze_undeclare_querying_subscriber(
-    _this: &mut ze_moved_querying_subscriber_t,
+    this_: &mut ze_moved_querying_subscriber_t,
 ) -> result::z_result_t {
-    if let Some(s) = _this.take_rust_type() {
+    if let Some(s) = this_.take_rust_type() {
         if let Err(e) = s.0.undeclare().wait() {
             tracing::error!("{}", e);
             return result::Z_EGENERIC;
@@ -232,10 +232,10 @@ pub extern "C" fn ze_undeclare_querying_subscriber(
     result::Z_OK
 }
 
-/// Drops querying subscriber. Also attempts to undeclare it.
+/// Drops querying subscriber.
 #[no_mangle]
 pub extern "C" fn ze_querying_subscriber_drop(this_: &mut ze_moved_querying_subscriber_t) {
-    ze_undeclare_querying_subscriber(this_);
+    std::mem::drop(this_.take_rust_type())
 }
 
 /// Returns ``true`` if querying subscriber is valid, ``false`` otherwise.

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -179,10 +179,10 @@ pub extern "C" fn z_undeclare_subscriber(this_: &mut z_moved_subscriber_t) -> re
     result::Z_OK
 }
 
-/// Drops subscriber and resets it to its gravestone state. Also attempts to undeclare it.
+/// Drops subscriber and resets it to its gravestone state.
 #[no_mangle]
 pub extern "C" fn z_subscriber_drop(this_: &mut z_moved_subscriber_t) {
-    let _ = this_.take_rust_type();
+    std::mem::drop(this_.take_rust_type())
 }
 
 /// Returns ``true`` if subscriber is valid, ``false`` otherwise.


### PR DESCRIPTION
make z_drop on zenoh entities call actual drop instead of undeclare.
This is in particular will be required to support https://github.com/eclipse-zenoh/zenoh/pull/1334.