### PR TITLE
add missing zenoh-rust functionality

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -770,6 +770,7 @@ Types
 -----
 
 .. doxygenstruct:: ze_owned_publication_cache_t
+.. doxygenstruct:: ze_loaned_publication_cache_t
 .. doxygenstruct:: ze_publication_cache_options_t
     :members:
 .. doxygenenum:: zc_locality_t
@@ -781,6 +782,8 @@ Functions
 .. doxygenfunction:: ze_undeclare_publication_cache
 
 .. doxygenfunction:: ze_publication_cache_drop
+.. doxygenfunction:: ze_publication_cache_loan
+.. doxygenfunction:: ze_publication_cache_keyexpr
 
 .. doxygenfunction:: ze_publication_cache_options_default
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -615,6 +615,7 @@ Functions
 ---------
 .. doxygenfunction:: z_declare_queryable
 .. doxygenfunction:: z_undeclare_queryable
+.. doxygenfunction:: z_queryable_id
 
 .. doxygenfunction:: z_queryable_options_default
 .. doxygenfunction:: z_query_reply_options_default

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -3469,6 +3469,12 @@ ZENOHC_API enum z_query_target_t z_query_target_default(void);
  * Frees memory and resets it to its gravesztone state. Will also attempt to undeclare queryable.
  */
 ZENOHC_API void z_queryable_drop(struct z_moved_queryable_t *this_);
+/**
+ * Returns the ID of the queryable.
+ */
+#if defined(UNSTABLE)
+ZENOHC_API z_entity_global_id_t z_queryable_id(const struct z_loaned_queryable_t *queryable);
+#endif
 ZENOHC_API
 const struct z_loaned_queryable_t *z_queryable_loan(const struct z_owned_queryable_t *this_);
 /**
@@ -4875,6 +4881,20 @@ ZENOHC_API void ze_internal_querying_subscriber_null(ze_owned_querying_subscribe
  */
 #if defined(UNSTABLE)
 ZENOHC_API void ze_publication_cache_drop(ze_moved_publication_cache_t *this_);
+#endif
+/**
+ * Returns the key expression of the publication cache.
+ */
+#if defined(UNSTABLE)
+ZENOHC_API
+const struct z_loaned_keyexpr_t *ze_publication_cache_keyexpr(const ze_loaned_publication_cache_t *this_);
+#endif
+/**
+ * Borrows querying subscriber.
+ */
+#if defined(UNSTABLE)
+ZENOHC_API
+const ze_loaned_publication_cache_t *ze_publication_cache_loan(const ze_owned_publication_cache_t *this_);
 #endif
 /**
  * Constructs the default value for `ze_publication_cache_options_t`.

--- a/src/publication_cache.rs
+++ b/src/publication_cache.rs
@@ -19,7 +19,7 @@ use zenoh_ext::SessionExt;
 
 use crate::{
     result,
-    transmute::{RustTypeRef, RustTypeRefUninit, TakeRustType},
+    transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_keyexpr_t, z_loaned_session_t,
 };
 #[cfg(feature = "unstable")]
@@ -154,4 +154,25 @@ pub extern "C" fn ze_undeclare_publication_cache(
 #[allow(clippy::missing_safety_doc)]
 pub extern "C" fn ze_publication_cache_drop(this_: &mut ze_moved_publication_cache_t) {
     ze_undeclare_publication_cache(this_);
+}
+
+/// Returns the key expression of the publication cache.
+#[no_mangle]
+pub extern "C" fn ze_publication_cache_keyexpr(
+    this_: &ze_loaned_publication_cache_t,
+) -> &z_loaned_keyexpr_t {
+    this_.as_rust_type_ref().key_expr().as_loaned_c_type_ref()
+}
+
+/// Borrows querying subscriber.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn ze_publication_cache_loan(
+    this_: &ze_owned_publication_cache_t,
+) -> &ze_loaned_publication_cache_t {
+    this_
+        .as_rust_type_ref()
+        .as_ref()
+        .unwrap_unchecked()
+        .as_loaned_c_type_ref()
 }

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -24,7 +24,7 @@ use zenoh::{
 
 pub use crate::opaque_types::{z_loaned_queryable_t, z_owned_queryable_t};
 #[cfg(feature = "unstable")]
-use crate::z_moved_source_info_t;
+use crate::transmute::IntoCType;
 use crate::{
     result,
     transmute::{IntoRustType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
@@ -33,6 +33,8 @@ use crate::{
     z_moved_closure_query_t, z_moved_encoding_t, z_moved_queryable_t, z_priority_t, z_timestamp_t,
     z_view_string_from_substr, z_view_string_t,
 };
+#[cfg(feature = "unstable")]
+use crate::{z_entity_global_id_t, z_moved_source_info_t};
 decl_c_type!(
     owned(z_owned_queryable_t, option Queryable<'static, ()>),
     loaned(z_loaned_queryable_t),
@@ -275,6 +277,13 @@ pub extern "C" fn z_queryable_drop(this_: &mut z_moved_queryable_t) {
 #[no_mangle]
 pub extern "C" fn z_internal_queryable_check(this_: &z_owned_queryable_t) -> bool {
     this_.as_rust_type_ref().is_some()
+}
+
+#[cfg(feature = "unstable")]
+/// Returns the ID of the queryable.
+#[no_mangle]
+pub extern "C" fn z_queryable_id(queryable: &z_loaned_queryable_t) -> z_entity_global_id_t {
+    queryable.as_rust_type_ref().id().into_c_type()
 }
 
 /// Sends a reply to a query.


### PR DESCRIPTION
add ze_publication_cache_keyexpr();
add z_queryable_id();
add allowed origin to z_queryable_options_t;
Closes #392 
Closes #373 