### PR TITLE
updated autogenerared headers

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -2614,6 +2614,12 @@ ZENOHC_API enum z_whatami_t z_hello_whatami(const struct z_loaned_hello_t *this_
 ZENOHC_API z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
 #endif
 /**
+ * Formats the `z_id_t` into 16-digit hex string (LSB-first order)
+ */
+#if defined(UNSTABLE)
+ZENOHC_API void z_id_to_string(const z_id_t *zid, struct z_owned_string_t *dst);
+#endif
+/**
  * Fetches the Zenoh IDs of all connected peers.
  *
  * `callback` will be called once for each ID, is guaranteed to never be called concurrently,

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -657,43 +657,43 @@ inline void z_call(const z_loaned_closure_sample_t* closure, const z_loaned_samp
     z_closure_sample_call(closure, sample);
 };
 
-extern "C" typedef void (*z_closure_drop_callback_t)(void*);
+extern "C" using z_closure_drop_callback_t = void(void*);
 
-extern "C" typedef void (*z_closure_hello_callback_t)(const z_loaned_hello_t*, void*);
+extern "C" using z_closure_hello_callback_t = void(const z_loaned_hello_t*, void*);
 inline void z_closure(
     z_owned_closure_hello_t* closure,
-    z_closure_hello_callback_t call,
-    z_closure_drop_callback_t drop,
+    z_closure_hello_callback_t* call,
+    z_closure_drop_callback_t* drop,
     void *context) {
     closure->context = context;
     closure->drop = drop;
     closure->call = call;
 };
-extern "C" typedef void (*z_closure_query_callback_t)(const z_loaned_query_t*, void*);
+extern "C" using z_closure_query_callback_t = void(const z_loaned_query_t*, void*);
 inline void z_closure(
     z_owned_closure_query_t* closure,
-    z_closure_query_callback_t call,
-    z_closure_drop_callback_t drop,
+    z_closure_query_callback_t* call,
+    z_closure_drop_callback_t* drop,
     void *context) {
     closure->context = context;
     closure->drop = drop;
     closure->call = call;
 };
-extern "C" typedef void (*z_closure_reply_callback_t)(const z_loaned_reply_t*, void*);
+extern "C" using z_closure_reply_callback_t = void(const z_loaned_reply_t*, void*);
 inline void z_closure(
     z_owned_closure_reply_t* closure,
-    z_closure_reply_callback_t call,
-    z_closure_drop_callback_t drop,
+    z_closure_reply_callback_t* call,
+    z_closure_drop_callback_t* drop,
     void *context) {
     closure->context = context;
     closure->drop = drop;
     closure->call = call;
 };
-extern "C" typedef void (*z_closure_sample_callback_t)(const z_loaned_sample_t*, void*);
+extern "C" using z_closure_sample_callback_t = void(const z_loaned_sample_t*, void*);
 inline void z_closure(
     z_owned_closure_sample_t* closure,
-    z_closure_sample_callback_t call,
-    z_closure_drop_callback_t drop,
+    z_closure_sample_callback_t* call,
+    z_closure_drop_callback_t* drop,
     void *context) {
     closure->context = context;
     closure->drop = drop;


### PR DESCRIPTION
followup update: the headers were not updated in 
https://github.com/eclipse-zenoh/zenoh-c/pull/603 and https://github.com/eclipse-zenoh/zenoh-c/commit/d6eecefd664f21fb28dd86afe9f48ee5b56458a7