### PR TITLE
Fix uninit Handler and Closure in `z_pull`

### DIFF
--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -48,8 +48,9 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
-    z_owned_ring_handler_sample_t handler;
     z_owned_closure_sample_t closure;
+    z_owned_ring_handler_sample_t handler;
+    z_ring_channel_sample_new(&closure, &handler, 256);
 
     printf("Declaring Subscriber on '%s'...\n", args.keyexpr);
     z_view_keyexpr_t ke;


### PR DESCRIPTION
Trying to use `z_pull` results in:

```
Opening session...
Declaring Subscriber on 'demo/example/**'...
Press <enter> to pull data...
fish: Job 1, '../target/debug/examples/z_pull' terminated by signal SIGSEGV (Address boundary error)
```

We might want to define channel capacity constants akin to (unless they're already there and I failed to find them):

https://github.com/eclipse-zenoh/zenoh/blob/main/zenoh/src/api/session.rs#L106-L111