### PR TITLE
made closure param mutable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ phf = { version = "0.11.2", features = ["macros"] }
 
 [lib]
 path = "src/lib.rs"
-name = "zenohcd"
+name = "zenohc"
 crate-type = ["cdylib", "staticlib"]
 doctest = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ phf = { version = "0.11.2", features = ["macros"] }
 
 [lib]
 path = "src/lib.rs"
-name = "zenohc"
+name = "zenohcd"
 crate-type = ["cdylib", "staticlib"]
 doctest = false
 

--- a/examples/z_ping.c
+++ b/examples/z_ping.c
@@ -21,7 +21,7 @@
 z_owned_condvar_t cond;
 z_owned_mutex_t mutex;
 
-void callback(const z_loaned_sample_t* sample, void* context) { z_condvar_signal(z_loan(cond)); }
+void callback(z_loaned_sample_t* sample, void* context) { z_condvar_signal(z_loan(cond)); }
 void drop(void* context) { z_drop(z_move(cond)); }
 
 struct args_t {

--- a/examples/z_ping_shm.c
+++ b/examples/z_ping_shm.c
@@ -20,7 +20,7 @@
 z_owned_condvar_t cond;
 z_owned_mutex_t mutex;
 
-void callback(const z_loaned_sample_t* sample, void* context) { z_condvar_signal(z_loan(cond)); }
+void callback(z_loaned_sample_t* sample, void* context) { z_condvar_signal(z_loan(cond)); }
 void drop(void* context) { z_drop(z_move(cond)); }
 
 struct args_t {

--- a/examples/z_pong.c
+++ b/examples/z_pong.c
@@ -6,7 +6,7 @@
 
 void parse_args(int argc, char** argv, z_owned_config_t* config);
 
-void callback(const z_loaned_sample_t* sample, void* context) {
+void callback(z_loaned_sample_t* sample, void* context) {
     const z_loaned_publisher_t* pub = z_loan(*(z_owned_publisher_t*)context);
     z_owned_bytes_t payload;
     z_bytes_clone(&payload, z_sample_payload(sample));

--- a/examples/z_query_sub.c
+++ b/examples/z_query_sub.c
@@ -25,7 +25,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
 const char* kind_to_str(z_sample_kind_t kind);
 
-void data_handler(const z_loaned_sample_t* sample, void* arg) {
+void data_handler(z_loaned_sample_t* sample, void* arg) {
     z_view_string_t key_string;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
     z_owned_string_t payload_string;

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -30,7 +30,7 @@ char *value;
 
 struct args_t parse_args(int argc, char **argv, z_owned_config_t *config);
 
-void query_handler(const z_loaned_query_t *query, void *context) {
+void query_handler(z_loaned_query_t *query, void *context) {
     z_view_string_t key_string;
     z_keyexpr_as_view_string(z_query_keyexpr(query), &key_string);
 

--- a/examples/z_queryable_shm.c
+++ b/examples/z_queryable_shm.c
@@ -20,7 +20,7 @@ const char *keyexpr = "demo/example/zenoh-c-queryable";
 const char *value = "Queryable from C SHM!";
 z_view_keyexpr_t ke;
 
-void query_handler(const z_loaned_query_t *query, void *context) {
+void query_handler(z_loaned_query_t *query, void *context) {
     z_loaned_shm_provider_t *provider = (z_loaned_shm_provider_t *)context;
 
     z_view_string_t key_string;

--- a/examples/z_scout.c
+++ b/examples/z_scout.c
@@ -72,7 +72,7 @@ void fprinthello(FILE *stream, const z_loaned_hello_t *hello) {
     fprintf(stream, " }");
 }
 
-void callback(const z_loaned_hello_t *hello, void *context) {
+void callback(z_loaned_hello_t *hello, void *context) {
     fprinthello(stdout, hello);
     fprintf(stdout, "\n");
     (*(int *)context)++;

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -25,7 +25,7 @@ struct args_t parse_args(int argc, char **argv, z_owned_config_t *config);
 
 const char *kind_to_str(z_sample_kind_t kind);
 
-void data_handler(const z_loaned_sample_t *sample, void *arg) {
+void data_handler(z_loaned_sample_t *sample, void *arg) {
     z_view_string_t key_string;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
 

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -25,7 +25,7 @@ struct args_t {
 struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 const char* kind_to_str(z_sample_kind_t kind);
 
-void data_handler(const z_loaned_sample_t* sample, void* arg) {
+void data_handler(z_loaned_sample_t* sample, void* arg) {
     z_view_string_t key_string;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
 

--- a/examples/z_sub_liveliness.c
+++ b/examples/z_sub_liveliness.c
@@ -23,7 +23,7 @@ struct args_t {
 };
 struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
-void data_handler(const z_loaned_sample_t* sample, void* arg) {
+void data_handler(z_loaned_sample_t* sample, void* arg) {
     z_view_string_t key_string;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
     switch (z_sample_kind(sample)) {

--- a/examples/z_sub_shm.c
+++ b/examples/z_sub_shm.c
@@ -17,7 +17,7 @@
 
 const char *kind_to_str(z_sample_kind_t kind);
 
-void data_handler(const z_loaned_sample_t *sample, void *arg) {
+void data_handler(z_loaned_sample_t *sample, void *arg) {
     z_view_string_t key_string;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);
 

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -36,7 +36,7 @@ z_stats_t *z_stats_make() {
     return stats;
 }
 
-void on_sample(const z_loaned_sample_t *sample, void *context) {
+void on_sample(z_loaned_sample_t *sample, void *context) {
     z_stats_t *stats = (z_stats_t *)context;
     if (stats->count == 0) {
         stats->start = z_clock_now();

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -461,7 +461,7 @@ typedef struct z_owned_closure_hello_t {
   /**
    * A closure body.
    */
-  void (*call)(const struct z_loaned_hello_t *hello, void *context);
+  void (*call)(struct z_loaned_hello_t *hello, void *context);
   /**
    * An optional drop function that will be called when the closure is dropped.
    */
@@ -491,7 +491,7 @@ typedef struct z_owned_closure_query_t {
   /**
    * A closure body.
    */
-  void (*call)(const struct z_loaned_query_t *reply, void *context);
+  void (*call)(struct z_loaned_query_t *reply, void *context);
   /**
    * An optional drop function that will be called when the closure is dropped.
    */
@@ -521,7 +521,7 @@ typedef struct z_owned_closure_reply_t {
   /**
    * A closure body.
    */
-  void (*call)(const struct z_loaned_reply_t *reply, void *context);
+  void (*call)(struct z_loaned_reply_t *reply, void *context);
   /**
    * An optional drop function that will be called when the closure is dropped.
    */
@@ -551,7 +551,7 @@ typedef struct z_owned_closure_sample_t {
   /**
    * A closure body.
    */
-  void (*call)(const struct z_loaned_sample_t *sample, void *context);
+  void (*call)(struct z_loaned_sample_t *sample, void *context);
   /**
    * An optional drop function that will be called when the closure is dropped.
    */
@@ -583,7 +583,7 @@ typedef struct z_owned_closure_zid_t {
   /**
    * A callback function.
    */
-  void (*call)(const z_id_t *z_id, void *context);
+  void (*call)(z_id_t *z_id, void *context);
   /**
    * An optional function that will be called upon closure drop.
    */
@@ -1184,7 +1184,7 @@ typedef struct zc_owned_closure_matching_status_t {
   /**
    * A closure body.
    */
-  void (*call)(const struct zc_matching_status_t *matching_status, void *context);
+  void (*call)(struct zc_matching_status_t *matching_status, void *context);
   /**
    * An optional drop function that will be called when the closure is dropped.
    */
@@ -1865,7 +1865,7 @@ ZENOHC_API void z_close_options_default(struct z_close_options_t *this_);
  */
 ZENOHC_API
 void z_closure_hello_call(const struct z_loaned_closure_hello_t *closure,
-                          const struct z_loaned_hello_t *hello);
+                          struct z_loaned_hello_t *hello);
 /**
  * Drops the closure. Droping an uninitialized closure is a no-op.
  */
@@ -1880,7 +1880,7 @@ const struct z_loaned_closure_hello_t *z_closure_hello_loan(const struct z_owned
  */
 ZENOHC_API
 void z_closure_query_call(const struct z_loaned_closure_query_t *closure,
-                          const struct z_loaned_query_t *query);
+                          struct z_loaned_query_t *query);
 /**
  * Drops the closure, resetting it to its gravestone state.
  */
@@ -1895,7 +1895,7 @@ const struct z_loaned_closure_query_t *z_closure_query_loan(const struct z_owned
  */
 ZENOHC_API
 void z_closure_reply_call(const struct z_loaned_closure_reply_t *closure,
-                          const struct z_loaned_reply_t *reply);
+                          struct z_loaned_reply_t *reply);
 /**
  * Drops the closure, resetting it to its gravestone state. Droping an uninitialized closure is a no-op.
  */
@@ -1911,7 +1911,7 @@ const struct z_loaned_closure_reply_t *z_closure_reply_loan(const struct z_owned
  */
 ZENOHC_API
 void z_closure_sample_call(const struct z_loaned_closure_sample_t *closure,
-                           const struct z_loaned_sample_t *sample);
+                           struct z_loaned_sample_t *sample);
 /**
  * Drops the closure. Droping an uninitialized closure is a no-op.
  */

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1184,7 +1184,7 @@ typedef struct zc_owned_closure_matching_status_t {
   /**
    * A closure body.
    */
-  void (*call)(struct zc_matching_status_t *matching_status, void *context);
+  void (*call)(const struct zc_matching_status_t *matching_status, void *context);
   /**
    * An optional drop function that will be called when the closure is dropped.
    */
@@ -4800,7 +4800,7 @@ const struct zc_loaned_closure_log_t *zc_closure_log_loan(const struct zc_owned_
 #if defined(UNSTABLE)
 ZENOHC_API
 void zc_closure_matching_status_call(const struct zc_loaned_closure_matching_status_t *closure,
-                                     struct zc_matching_status_t *mathing_status);
+                                     const struct zc_matching_status_t *mathing_status);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1928,7 +1928,7 @@ const struct z_loaned_closure_sample_t *z_closure_sample_loan(const struct z_own
 #if defined(UNSTABLE)
 ZENOHC_API
 void z_closure_zid_call(const struct z_loaned_closure_zid_t *closure,
-                        const z_id_t *z_id);
+                        z_id_t *z_id);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4797,7 +4797,7 @@ const struct zc_loaned_closure_log_t *zc_closure_log_loan(const struct zc_owned_
 #if defined(UNSTABLE)
 ZENOHC_API
 void zc_closure_matching_status_call(const struct zc_loaned_closure_matching_status_t *closure,
-                                     const struct zc_matching_status_t *mathing_status);
+                                     struct zc_matching_status_t *mathing_status);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -583,7 +583,7 @@ typedef struct z_owned_closure_zid_t {
   /**
    * A callback function.
    */
-  void (*call)(z_id_t *z_id, void *context);
+  void (*call)(const z_id_t *z_id, void *context);
   /**
    * An optional function that will be called upon closure drop.
    */
@@ -1927,7 +1927,7 @@ const struct z_loaned_closure_sample_t *z_closure_sample_loan(const struct z_own
 #if defined(UNSTABLE)
 ZENOHC_API
 void z_closure_zid_call(const struct z_loaned_closure_zid_t *closure,
-                        z_id_t *z_id);
+                        const z_id_t *z_id);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -658,22 +658,22 @@ inline bool z_internal_check(const z_owned_task_t& this_) { return z_internal_ta
 inline bool z_internal_check(const zc_owned_closure_log_t& this_) { return zc_internal_closure_log_check(&this_); };
 
 
-inline void z_call(const z_loaned_closure_hello_t* closure, const z_loaned_hello_t* hello) {
+inline void z_call(const z_loaned_closure_hello_t* closure, z_loaned_hello_t* hello) {
     z_closure_hello_call(closure, hello);
 };
-inline void z_call(const z_loaned_closure_query_t* closure, const z_loaned_query_t* query) {
+inline void z_call(const z_loaned_closure_query_t* closure, z_loaned_query_t* query) {
     z_closure_query_call(closure, query);
 };
-inline void z_call(const z_loaned_closure_reply_t* closure, const z_loaned_reply_t* reply) {
+inline void z_call(const z_loaned_closure_reply_t* closure, z_loaned_reply_t* reply) {
     z_closure_reply_call(closure, reply);
 };
-inline void z_call(const z_loaned_closure_sample_t* closure, const z_loaned_sample_t* sample) {
+inline void z_call(const z_loaned_closure_sample_t* closure, z_loaned_sample_t* sample) {
     z_closure_sample_call(closure, sample);
 };
 
 extern "C" using z_closure_drop_callback_t = void(void*);
 
-extern "C" using z_closure_hello_callback_t = void(const z_loaned_hello_t*, void*);
+extern "C" using z_closure_hello_callback_t = void(z_loaned_hello_t*, void*);
 inline void z_closure(
     z_owned_closure_hello_t* closure,
     z_closure_hello_callback_t* call,
@@ -683,7 +683,7 @@ inline void z_closure(
     closure->drop = drop;
     closure->call = call;
 };
-extern "C" using z_closure_query_callback_t = void(const z_loaned_query_t*, void*);
+extern "C" using z_closure_query_callback_t = void(z_loaned_query_t*, void*);
 inline void z_closure(
     z_owned_closure_query_t* closure,
     z_closure_query_callback_t* call,
@@ -693,7 +693,7 @@ inline void z_closure(
     closure->drop = drop;
     closure->call = call;
 };
-extern "C" using z_closure_reply_callback_t = void(const z_loaned_reply_t*, void*);
+extern "C" using z_closure_reply_callback_t = void(z_loaned_reply_t*, void*);
 inline void z_closure(
     z_owned_closure_reply_t* closure,
     z_closure_reply_callback_t* call,
@@ -703,7 +703,7 @@ inline void z_closure(
     closure->drop = drop;
     closure->call = call;
 };
-extern "C" using z_closure_sample_callback_t = void(const z_loaned_sample_t*, void*);
+extern "C" using z_closure_sample_callback_t = void(z_loaned_sample_t*, void*);
 inline void z_closure(
     z_owned_closure_sample_t* closure,
     z_closure_sample_callback_t* call,

--- a/src/closures/matching_status_closure.rs
+++ b/src/closures/matching_status_closure.rs
@@ -33,7 +33,7 @@ pub struct zc_owned_closure_matching_status_t {
     /// An optional pointer to a closure state.
     context: *mut c_void,
     /// A closure body.
-    call: Option<extern "C" fn(matching_status: &mut zc_matching_status_t, context: *mut c_void)>,
+    call: Option<extern "C" fn(matching_status: &zc_matching_status_t, context: *mut c_void)>,
     /// An optional drop function that will be called when the closure is dropped.
     drop: Option<extern "C" fn(context: *mut c_void)>,
 }
@@ -106,7 +106,7 @@ pub extern "C" fn zc_internal_closure_matching_status_check(
 #[no_mangle]
 pub extern "C" fn zc_closure_matching_status_call(
     closure: &zc_loaned_closure_matching_status_t,
-    mathing_status: &mut zc_matching_status_t,
+    mathing_status: &zc_matching_status_t,
 ) {
     let closure = closure.as_owned_c_type_ref();
     match closure.call {
@@ -126,11 +126,11 @@ pub extern "C" fn zc_closure_matching_status_drop(
     let _ = closure_.take_rust_type();
 }
 
-impl<F: Fn(&mut zc_matching_status_t)> From<F> for zc_owned_closure_matching_status_t {
+impl<F: Fn(&zc_matching_status_t)> From<F> for zc_owned_closure_matching_status_t {
     fn from(f: F) -> Self {
         let this = Box::into_raw(Box::new(f)) as _;
-        extern "C" fn call<F: Fn(&mut zc_matching_status_t)>(
-            response: &mut zc_matching_status_t,
+        extern "C" fn call<F: Fn(&zc_matching_status_t)>(
+            response: &zc_matching_status_t,
             this: *mut c_void,
         ) {
             let this = unsafe { &*(this as *const F) };

--- a/src/closures/matching_status_closure.rs
+++ b/src/closures/matching_status_closure.rs
@@ -106,7 +106,7 @@ pub extern "C" fn zc_internal_closure_matching_status_check(
 #[no_mangle]
 pub extern "C" fn zc_closure_matching_status_call(
     closure: &zc_loaned_closure_matching_status_t,
-    mathing_status: &zc_matching_status_t,
+    mathing_status: &mut zc_matching_status_t,
 ) {
     let closure = closure.as_owned_c_type_ref();
     match closure.call {
@@ -126,11 +126,11 @@ pub extern "C" fn zc_closure_matching_status_drop(
     let _ = closure_.take_rust_type();
 }
 
-impl<F: Fn(&zc_matching_status_t)> From<F> for zc_owned_closure_matching_status_t {
+impl<F: Fn(&mut zc_matching_status_t)> From<F> for zc_owned_closure_matching_status_t {
     fn from(f: F) -> Self {
         let this = Box::into_raw(Box::new(f)) as _;
-        extern "C" fn call<F: Fn(&zc_matching_status_t)>(
-            response: &zc_matching_status_t,
+        extern "C" fn call<F: Fn(&mut zc_matching_status_t)>(
+            response: &mut zc_matching_status_t,
             this: *mut c_void,
         ) {
             let this = unsafe { &*(this as *const F) };

--- a/src/closures/matching_status_closure.rs
+++ b/src/closures/matching_status_closure.rs
@@ -33,7 +33,7 @@ pub struct zc_owned_closure_matching_status_t {
     /// An optional pointer to a closure state.
     context: *mut c_void,
     /// A closure body.
-    call: Option<extern "C" fn(matching_status: &zc_matching_status_t, context: *mut c_void)>,
+    call: Option<extern "C" fn(matching_status: &mut zc_matching_status_t, context: *mut c_void)>,
     /// An optional drop function that will be called when the closure is dropped.
     drop: Option<extern "C" fn(context: *mut c_void)>,
 }

--- a/src/closures/query_channel.rs
+++ b/src/closures/query_channel.rs
@@ -55,7 +55,7 @@ pub extern "C" fn z_internal_fifo_handler_query_check(
     this_.as_rust_type_ref().is_some()
 }
 
-extern "C" fn __z_handler_query_send(query: &z_loaned_query_t, context: *mut c_void) {
+extern "C" fn __z_handler_query_send(query: &mut z_loaned_query_t, context: *mut c_void) {
     unsafe {
         let f = (context as *mut std::sync::Arc<dyn Fn(Query) + Send + Sync>)
             .as_mut()

--- a/src/closures/query_closure.rs
+++ b/src/closures/query_closure.rs
@@ -116,7 +116,10 @@ pub extern "C" fn z_closure_query_drop(closure_: &mut z_moved_closure_query_t) {
 impl<F: Fn(&mut z_loaned_query_t)> From<F> for z_owned_closure_query_t {
     fn from(f: F) -> Self {
         let this = Box::into_raw(Box::new(f)) as _;
-        extern "C" fn call<F: Fn(&mut z_loaned_query_t)>(query: &mut z_loaned_query_t, this: *mut c_void) {
+        extern "C" fn call<F: Fn(&mut z_loaned_query_t)>(
+            query: &mut z_loaned_query_t,
+            this: *mut c_void,
+        ) {
             let this = unsafe { &*(this as *const F) };
             this(query)
         }

--- a/src/closures/query_closure.rs
+++ b/src/closures/query_closure.rs
@@ -33,7 +33,7 @@ pub struct z_owned_closure_query_t {
     /// An optional pointer to a context representing a closure state.
     pub context: *mut c_void,
     /// A closure body.
-    pub call: Option<extern "C" fn(reply: &z_loaned_query_t, context: *mut c_void)>,
+    pub call: Option<extern "C" fn(reply: &mut z_loaned_query_t, context: *mut c_void)>,
     /// An optional drop function that will be called when the closure is dropped.
     pub drop: Option<extern "C" fn(context: *mut c_void)>,
 }
@@ -99,7 +99,7 @@ pub extern "C" fn z_internal_closure_query_check(this_: &z_owned_closure_query_t
 #[no_mangle]
 pub extern "C" fn z_closure_query_call(
     closure: &z_loaned_closure_query_t,
-    query: &z_loaned_query_t,
+    query: &mut z_loaned_query_t,
 ) {
     let closure = closure.as_owned_c_type_ref();
     match closure.call {
@@ -113,10 +113,10 @@ pub extern "C" fn z_closure_query_drop(closure_: &mut z_moved_closure_query_t) {
     let _ = closure_.take_rust_type();
 }
 
-impl<F: Fn(&z_loaned_query_t)> From<F> for z_owned_closure_query_t {
+impl<F: Fn(&mut z_loaned_query_t)> From<F> for z_owned_closure_query_t {
     fn from(f: F) -> Self {
         let this = Box::into_raw(Box::new(f)) as _;
-        extern "C" fn call<F: Fn(&z_loaned_query_t)>(query: &z_loaned_query_t, this: *mut c_void) {
+        extern "C" fn call<F: Fn(&mut z_loaned_query_t)>(query: &mut z_loaned_query_t, this: *mut c_void) {
             let this = unsafe { &*(this as *const F) };
             this(query)
         }

--- a/src/closures/response_channel.rs
+++ b/src/closures/response_channel.rs
@@ -55,7 +55,7 @@ pub extern "C" fn z_internal_fifo_handler_reply_check(
     this_.as_rust_type_ref().is_some()
 }
 
-extern "C" fn __z_handler_reply_send(reply: &z_loaned_reply_t, context: *mut c_void) {
+extern "C" fn __z_handler_reply_send(reply: &mut z_loaned_reply_t, context: *mut c_void) {
     unsafe {
         let f = (context as *mut std::sync::Arc<dyn Fn(Reply) + Send + Sync>)
             .as_mut()

--- a/src/closures/sample_channel.rs
+++ b/src/closures/sample_channel.rs
@@ -55,7 +55,7 @@ pub extern "C" fn z_internal_fifo_handler_sample_check(
     this_.as_rust_type_ref().is_some()
 }
 
-extern "C" fn __z_handler_sample_send(sample: &z_loaned_sample_t, context: *mut c_void) {
+extern "C" fn __z_handler_sample_send(sample: &mut z_loaned_sample_t, context: *mut c_void) {
     unsafe {
         let f = (context as *mut std::sync::Arc<dyn Fn(Sample) + Send + Sync>)
             .as_mut()

--- a/src/closures/zenohid_closure.rs
+++ b/src/closures/zenohid_closure.rs
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn z_internal_closure_zid_null(
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Calls the closure. Calling an uninitialized closure is a no-op.
 #[no_mangle]
-pub extern "C" fn z_closure_zid_call(closure: &z_loaned_closure_zid_t, z_id: &z_id_t) {
+pub extern "C" fn z_closure_zid_call(closure: &z_loaned_closure_zid_t, z_id: &mut z_id_t) {
     let closure = closure.as_owned_c_type_ref();
     match closure.call {
         Some(call) => call(z_id, closure.context),
@@ -122,10 +122,10 @@ pub extern "C" fn z_closure_zid_drop(closure_: &mut z_moved_closure_zid_t) {
     let _ = closure_.take_rust_type();
 }
 
-impl<F: Fn(&z_id_t)> From<F> for z_owned_closure_zid_t {
+impl<F: Fn(&mut z_id_t)> From<F> for z_owned_closure_zid_t {
     fn from(f: F) -> Self {
         let this = Box::into_raw(Box::new(f)) as _;
-        extern "C" fn call<F: Fn(&z_id_t)>(response: &z_id_t, this: *mut c_void) {
+        extern "C" fn call<F: Fn(&mut z_id_t)>(response: &mut z_id_t, this: *mut c_void) {
             let this = unsafe { &*(this as *const F) };
             this(response)
         }

--- a/src/closures/zenohid_closure.rs
+++ b/src/closures/zenohid_closure.rs
@@ -34,7 +34,7 @@ pub struct z_owned_closure_zid_t {
     /// An optional pointer to a closure state.
     context: *mut c_void,
     /// A callback function.
-    call: Option<extern "C" fn(z_id: &z_id_t, context: *mut c_void)>,
+    call: Option<extern "C" fn(z_id: &mut z_id_t, context: *mut c_void)>,
     /// An optional function that will be called upon closure drop.
     drop: Option<extern "C" fn(context: *mut c_void)>,
 }

--- a/src/closures/zenohid_closure.rs
+++ b/src/closures/zenohid_closure.rs
@@ -34,7 +34,7 @@ pub struct z_owned_closure_zid_t {
     /// An optional pointer to a closure state.
     context: *mut c_void,
     /// A callback function.
-    call: Option<extern "C" fn(z_id: &mut z_id_t, context: *mut c_void)>,
+    call: Option<extern "C" fn(z_id: &z_id_t, context: *mut c_void)>,
     /// An optional function that will be called upon closure drop.
     drop: Option<extern "C" fn(context: *mut c_void)>,
 }
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn z_internal_closure_zid_null(
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Calls the closure. Calling an uninitialized closure is a no-op.
 #[no_mangle]
-pub extern "C" fn z_closure_zid_call(closure: &z_loaned_closure_zid_t, z_id: &mut z_id_t) {
+pub extern "C" fn z_closure_zid_call(closure: &z_loaned_closure_zid_t, z_id: &z_id_t) {
     let closure = closure.as_owned_c_type_ref();
     match closure.call {
         Some(call) => call(z_id, closure.context),
@@ -122,10 +122,10 @@ pub extern "C" fn z_closure_zid_drop(closure_: &mut z_moved_closure_zid_t) {
     let _ = closure_.take_rust_type();
 }
 
-impl<F: Fn(&mut z_id_t)> From<F> for z_owned_closure_zid_t {
+impl<F: Fn(&z_id_t)> From<F> for z_owned_closure_zid_t {
     fn from(f: F) -> Self {
         let this = Box::into_raw(Box::new(f)) as _;
-        extern "C" fn call<F: Fn(&mut z_id_t)>(response: &mut z_id_t, this: *mut c_void) {
+        extern "C" fn call<F: Fn(&z_id_t)>(response: &z_id_t, this: *mut c_void) {
             let this = unsafe { &*(this as *const F) };
             this(response)
         }

--- a/src/get.rs
+++ b/src/get.rs
@@ -266,10 +266,10 @@ pub unsafe extern "C" fn z_get(
         }
     }
     match get
-        .callback(move |response| {
+        .callback(move |mut response| {
             z_closure_reply_call(
                 z_closure_reply_loan(&callback),
-                response.as_loaned_c_type_ref(),
+                response.as_loaned_c_type_mut(),
             )
         })
         .wait()

--- a/src/info.rs
+++ b/src/info.rs
@@ -66,8 +66,8 @@ pub unsafe extern "C" fn z_info_peers_zid(
 ) -> result::z_result_t {
     let session = session.as_rust_type_ref();
     let callback = callback.take_rust_type();
-    for id in session.info().peers_zid().wait() {
-        z_closure_zid_call(z_closure_zid_loan(&callback), id.as_ctype_ref());
+    for mut id in session.info().peers_zid().wait() {
+        z_closure_zid_call(z_closure_zid_loan(&callback), id.as_ctype_mut());
     }
     result::Z_OK
 }
@@ -87,8 +87,8 @@ pub unsafe extern "C" fn z_info_routers_zid(
 ) -> result::z_result_t {
     let session = session.as_rust_type_ref();
     let callback = callback.take_rust_type();
-    for id in session.info().routers_zid().wait() {
-        z_closure_zid_call(z_closure_zid_loan(&callback), id.as_ctype_ref());
+    for mut id in session.info().routers_zid().wait() {
+        z_closure_zid_call(z_closure_zid_loan(&callback), id.as_ctype_mut());
     }
     result::Z_OK
 }

--- a/src/liveliness.rs
+++ b/src/liveliness.rs
@@ -174,8 +174,8 @@ pub extern "C" fn zc_liveliness_declare_subscriber(
         .liveliness()
         .declare_subscriber(key_expr)
         .history(options.is_some_and(|o| o.history))
-        .callback(move |sample| {
-            let sample = sample.as_loaned_c_type_ref();
+        .callback(move |mut sample| {
+            let sample = sample.as_loaned_c_type_mut();
             z_closure_sample_call(z_closure_sample_loan(&callback), sample)
         })
         .wait()
@@ -226,10 +226,10 @@ pub extern "C" fn zc_liveliness_get(
     let key_expr = key_expr.as_rust_type_ref();
     let callback = callback.take_rust_type();
     let liveliness: Liveliness<'static> = session.liveliness();
-    let mut builder = liveliness.get(key_expr).callback(move |response| {
+    let mut builder = liveliness.get(key_expr).callback(move |mut response| {
         z_closure_reply_call(
             z_closure_reply_loan(&callback),
-            response.as_loaned_c_type_ref(),
+            response.as_loaned_c_type_mut(),
         )
     });
     if let Some(options) = options {

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -362,12 +362,12 @@ pub extern "C" fn zc_publisher_matching_listener_declare(
     let listener = publisher
         .matching_listener()
         .callback_mut(move |matching_status| {
-            let mut status = zc_matching_status_t {
+            let status = zc_matching_status_t {
                 matching: matching_status.matching_subscribers(),
             };
             zc_closure_matching_status_call(
                 zc_closure_matching_status_loan(&callback),
-                &mut status,
+                &status,
             );
         })
         .wait();

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -365,7 +365,10 @@ pub extern "C" fn zc_publisher_matching_listener_declare(
             let mut status = zc_matching_status_t {
                 matching: matching_status.matching_subscribers(),
             };
-            zc_closure_matching_status_call(zc_closure_matching_status_loan(&callback), &mut status);
+            zc_closure_matching_status_call(
+                zc_closure_matching_status_loan(&callback),
+                &mut status,
+            );
         })
         .wait();
     match listener {

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -362,10 +362,10 @@ pub extern "C" fn zc_publisher_matching_listener_declare(
     let listener = publisher
         .matching_listener()
         .callback_mut(move |matching_status| {
-            let status = zc_matching_status_t {
+            let mut status = zc_matching_status_t {
                 matching: matching_status.matching_subscribers(),
             };
-            zc_closure_matching_status_call(zc_closure_matching_status_loan(&callback), &status);
+            zc_closure_matching_status_call(zc_closure_matching_status_loan(&callback), &mut status);
         })
         .wait();
     match listener {

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -365,10 +365,7 @@ pub extern "C" fn zc_publisher_matching_listener_declare(
             let status = zc_matching_status_t {
                 matching: matching_status.matching_subscribers(),
             };
-            zc_closure_matching_status_call(
-                zc_closure_matching_status_loan(&callback),
-                &status,
-            );
+            zc_closure_matching_status_call(zc_closure_matching_status_loan(&callback), &status);
         })
         .wait();
     match listener {

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -234,10 +234,10 @@ pub extern "C" fn z_declare_queryable(
         builder = builder.complete(options.complete);
     }
     let queryable = builder
-        .callback(move |query| {
+        .callback(move |mut query| {
             z_closure_query_call(
                 z_closure_query_loan(&callback),
-                query.as_loaned_c_type_ref(),
+                query.as_loaned_c_type_mut(),
             )
         })
         .wait();

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -131,8 +131,8 @@ pub unsafe extern "C" fn ze_declare_querying_subscriber(
             sub = sub.query_timeout(std::time::Duration::from_millis(options.query_timeout_ms));
         }
     }
-    let sub = sub.callback(move |sample| {
-        let sample = sample.as_loaned_c_type_ref();
+    let sub = sub.callback(move |mut sample| {
+        let sample = sample.as_loaned_c_type_mut();
         z_closure_sample_call(z_closure_sample_loan(&callback), sample);
     });
     match sub.wait() {

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -177,8 +177,8 @@ pub extern "C" fn z_scout(
 
     task::block_on(async move {
         let scout = zenoh::scout(what, config)
-            .callback(move |h| {
-                z_closure_hello_call(z_closure_hello_loan(&callback), h.as_loaned_c_type_ref())
+            .callback(move |mut h| {
+                z_closure_hello_call(z_closure_hello_loan(&callback), h.as_loaned_c_type_mut())
             })
             .await
             .unwrap();

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -83,8 +83,8 @@ pub extern "C" fn z_declare_subscriber(
     let callback = callback.take_rust_type();
     let subscriber = session
         .declare_subscriber(key_expr)
-        .callback(move |sample| {
-            let sample = sample.as_loaned_c_type_ref();
+        .callback(move |mut sample| {
+            let sample = sample.as_loaned_c_type_mut();
             z_closure_sample_call(z_closure_sample_loan(&callback), sample)
         });
     match subscriber.wait() {

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -36,14 +36,14 @@ void zid_handler(const z_id_t *id, void *arg) {
 #endif
 
 volatile unsigned int hellos = 0;
-void hello_handler(const z_loaned_hello_t *hello, void *arg) {
+void hello_handler(z_loaned_hello_t *hello, void *arg) {
     (void)(arg);
     (void)(hello);
     hellos++;
 }
 
 volatile unsigned int queries = 0;
-void query_handler(const z_loaned_query_t *query, void *arg) {
+void query_handler(z_loaned_query_t *query, void *arg) {
     queries++;
 
     const z_loaned_keyexpr_t *query_ke = z_query_keyexpr(query);
@@ -71,7 +71,7 @@ void query_handler(const z_loaned_query_t *query, void *arg) {
 }
 
 volatile unsigned int replies = 0;
-void reply_handler(const z_loaned_reply_t *reply, void *arg) {
+void reply_handler(z_loaned_reply_t *reply, void *arg) {
     replies++;
 
     if (z_reply_is_ok(reply)) {
@@ -91,7 +91,7 @@ void reply_handler(const z_loaned_reply_t *reply, void *arg) {
 }
 
 volatile unsigned int datas = 0;
-void data_handler(const z_loaned_sample_t *sample, void *arg) {
+void data_handler(z_loaned_sample_t *sample, void *arg) {
     datas++;
 
     z_view_string_t k_str;

--- a/tests/z_api_double_drop_test.c
+++ b/tests/z_api_double_drop_test.c
@@ -75,7 +75,7 @@ void test_config() {
     assert(!z_internal_check(config));
 }
 
-void data_handler(const z_loaned_sample_t *sample, void *arg) {}
+void data_handler(z_loaned_sample_t *sample, void *arg) {}
 
 void test_subscriber() {
     z_owned_config_t config;
@@ -97,7 +97,7 @@ void test_subscriber() {
     z_close(z_move(s), NULL);
 }
 
-void query_handler(const z_loaned_query_t *query, void *context) {}
+void query_handler(z_loaned_query_t *query, void *context) {}
 
 void test_queryable() {
     z_owned_config_t config;

--- a/tests/z_api_drop_options.c
+++ b/tests/z_api_drop_options.c
@@ -18,7 +18,7 @@
 #undef NDEBUG
 #include <assert.h>
 
-void cb(const struct z_loaned_reply_t *reply, void *context) {}
+void cb(struct z_loaned_reply_t *reply, void *context) {}
 void drop(void *context) {}
 
 void put() {

--- a/tests/z_api_keyexpr_drop_test.c
+++ b/tests/z_api_keyexpr_drop_test.c
@@ -43,7 +43,7 @@ void test_publisher() {
     z_close(z_move(s), NULL);
 }
 
-void data_handler(const z_loaned_sample_t *sample, void *arg) {}
+void data_handler(z_loaned_sample_t *sample, void *arg) {}
 
 void test_subscriber() {
     z_owned_config_t config;

--- a/tests/z_api_liveliness.c
+++ b/tests/z_api_liveliness.c
@@ -30,7 +30,7 @@ typedef struct context_t {
 const char* token1_expr = "zenoh/liveliness/test/1";
 const char* token2_expr = "zenoh/liveliness/test/2";
 
-void on_receive(const z_loaned_sample_t* s, void* context) {
+void on_receive(z_loaned_sample_t* s, void* context) {
     context_t* c = (context_t*)context;
     const z_loaned_keyexpr_t* k = z_sample_keyexpr(s);
     z_view_string_t ks;

--- a/tests/z_int_pub_cache_query_sub_test.c
+++ b/tests/z_int_pub_cache_query_sub_test.c
@@ -91,7 +91,7 @@ int run_publisher() {
     return 0;
 }
 
-void data_handler(const z_loaned_sample_t *sample, void *arg) {
+void data_handler(z_loaned_sample_t *sample, void *arg) {
     static int val_num = 0;
     z_view_string_t keystr;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &keystr);

--- a/tests/z_int_pub_sub_attachment_test.c
+++ b/tests/z_int_pub_sub_attachment_test.c
@@ -131,7 +131,7 @@ int run_publisher() {
     return 0;
 }
 
-void data_handler(const z_loaned_sample_t *sample, void *arg) {
+void data_handler(z_loaned_sample_t *sample, void *arg) {
     static int val_num = 0;
     z_view_string_t keystr;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &keystr);

--- a/tests/z_int_pub_sub_test.c
+++ b/tests/z_int_pub_sub_test.c
@@ -80,7 +80,7 @@ int run_publisher() {
     return 0;
 }
 
-void data_handler(const z_loaned_sample_t *sample, void *arg) {
+void data_handler(z_loaned_sample_t *sample, void *arg) {
     static int val_num = 0;
     z_view_string_t keystr;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &keystr);

--- a/tests/z_int_queryable_attachment_test.c
+++ b/tests/z_int_queryable_attachment_test.c
@@ -86,7 +86,7 @@ z_result_t check_attachment(const z_loaned_bytes_t *attachment, kv_it *it) {
     return 0;
 };
 
-void query_handler(const z_loaned_query_t *query, void *context) {
+void query_handler(z_loaned_query_t *query, void *context) {
     static int value_num = 0;
 
     z_view_string_t params;

--- a/tests/z_int_queryable_test.c
+++ b/tests/z_int_queryable_test.c
@@ -30,7 +30,7 @@ const uint64_t TEST_SN = 24;
 const uint64_t TEST_TS = 401706000;
 const uint8_t TEST_ID = 123;
 
-void query_handler(const z_loaned_query_t *query, void *context) {
+void query_handler(z_loaned_query_t *query, void *context) {
     static int value_num = 0;
 
     z_view_string_t params;

--- a/tests/z_leak_pub_sub_test.c
+++ b/tests/z_leak_pub_sub_test.c
@@ -24,7 +24,7 @@
 const char *PUB_KEY_EXPR = "test/valgrind/data";
 const char *SUB_KEY_EXPR = "test/valgrind/**";
 
-void data_handler(const z_loaned_sample_t *sample, void *context) {
+void data_handler(z_loaned_sample_t *sample, void *context) {
     (void)context;
     z_view_string_t key_string;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &key_string);

--- a/tests/z_leak_queryable_get_test.c
+++ b/tests/z_leak_queryable_get_test.c
@@ -24,7 +24,7 @@
 const char *GET_KEY_EXPR = "test/valgrind/data";
 const char *QUERYABLE_KEY_EXPR = "test/valgrind/**";
 
-void query_handler(const z_loaned_query_t *query, void *context) {
+void query_handler(z_loaned_query_t *query, void *context) {
     (void)context;
     z_view_string_t key_string;
     z_keyexpr_as_view_string(z_query_keyexpr(query), &key_string);


### PR DESCRIPTION
Fix related to https://github.com/eclipse-zenoh/zenoh/issues/1372
 
Preparation for further making `z_take` operation for `z_loaned_xxx_t*` callback parameters. This will allow user to take ownership of data passed to callback without clone operation.
This update is unsafe for C++, as in the zenoh-cpp it's already possible to perform `std::move` as soon as the callback parameter is not const. But in this update this is unsafe as on the rust side the non-owned objects are actually passed to callback. I.e. on rust side it's now `&mut Sample` represented as `z_loaned_sample_t*`. This means that it's prohibited at this moment to convert `z_loaned_sample_t*` to `z_owned_sample_t*` (which is `Option<Sample>` on rust side). But zenoh-cpp is built on assumption that it's safe to do this conversion because until this moment it was not possible to get `z_loaned_xxx_t*` reference directly to object other than `z_owned_xxx_t`.

The safety correction will be made in separate update to accelerate C++ API updating and to make verifying of safety update easier

