### PR TITLE
wrap loaned objects inside callbacks into option to pretend they are owned

### DIFF
--- a/src/closures/query_channel.rs
+++ b/src/closures/query_channel.rs
@@ -60,7 +60,8 @@ extern "C" fn __z_handler_query_send(query: &mut z_loaned_query_t, context: *mut
         let f = (context as *mut std::sync::Arc<dyn Fn(Query) + Send + Sync>)
             .as_mut()
             .unwrap_unchecked();
-        (f)(query.as_rust_type_ref().clone());
+        let owned_ref: &mut Option<Query> = std::mem::transmute(query);
+        (f)(std::mem::take(owned_ref).unwrap_unchecked());
     }
 }
 

--- a/src/closures/response_channel.rs
+++ b/src/closures/response_channel.rs
@@ -60,7 +60,8 @@ extern "C" fn __z_handler_reply_send(reply: &mut z_loaned_reply_t, context: *mut
         let f = (context as *mut std::sync::Arc<dyn Fn(Reply) + Send + Sync>)
             .as_mut()
             .unwrap_unchecked();
-        (f)(reply.as_rust_type_ref().clone());
+        let owned_ref: &mut Option<Reply> = std::mem::transmute(reply);
+        (f)(std::mem::take(owned_ref).unwrap_unchecked());
     }
 }
 

--- a/src/closures/sample_channel.rs
+++ b/src/closures/sample_channel.rs
@@ -60,7 +60,8 @@ extern "C" fn __z_handler_sample_send(sample: &mut z_loaned_sample_t, context: *
         let f = (context as *mut std::sync::Arc<dyn Fn(Sample) + Send + Sync>)
             .as_mut()
             .unwrap_unchecked();
-        (f)(sample.as_rust_type_ref().clone());
+        let owned_ref: &mut Option<Sample> = std::mem::transmute(sample);
+        (f)(std::mem::take(owned_ref).unwrap_unchecked());
     }
 }
 

--- a/src/get.rs
+++ b/src/get.rs
@@ -266,10 +266,14 @@ pub unsafe extern "C" fn z_get(
         }
     }
     match get
-        .callback(move |mut response| {
+        .callback(move |response| {
+            let mut owned_response = Some(response);
             z_closure_reply_call(
                 z_closure_reply_loan(&callback),
-                response.as_loaned_c_type_mut(),
+                owned_response
+                    .as_mut()
+                    .unwrap_unchecked()
+                    .as_loaned_c_type_mut(),
             )
         })
         .wait()

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -233,11 +233,14 @@ pub extern "C" fn z_declare_queryable(
         builder = builder.complete(options.complete);
     }
     let queryable = builder
-        .callback(move |mut query| {
-            z_closure_query_call(
-                z_closure_query_loan(&callback),
-                query.as_loaned_c_type_mut(),
-            )
+        .callback(move |query| {
+            let mut owned_query = Some(query);
+            z_closure_query_call(z_closure_query_loan(&callback), unsafe {
+                owned_query
+                    .as_mut()
+                    .unwrap_unchecked()
+                    .as_loaned_c_type_mut()
+            })
         })
         .wait();
     match queryable {

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -131,9 +131,15 @@ pub unsafe extern "C" fn ze_declare_querying_subscriber(
             sub = sub.query_timeout(std::time::Duration::from_millis(options.query_timeout_ms));
         }
     }
-    let sub = sub.callback(move |mut sample| {
-        let sample = sample.as_loaned_c_type_mut();
-        z_closure_sample_call(z_closure_sample_loan(&callback), sample);
+    let sub = sub.callback(move |sample| {
+        let mut owned_sample = Some(sample);
+        z_closure_sample_call(
+            z_closure_sample_loan(&callback),
+            owned_sample
+                .as_mut()
+                .unwrap_unchecked()
+                .as_loaned_c_type_mut(),
+        );
     });
     match sub.wait() {
         Ok(sub) => {

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -184,8 +184,11 @@ pub extern "C" fn z_scout(
 
     task::block_on(async move {
         let scout = zenoh::scout(what, config)
-            .callback(move |mut h| {
-                z_closure_hello_call(z_closure_hello_loan(&callback), h.as_loaned_c_type_mut())
+            .callback(move |h| {
+                let mut owned_h = Some(h);
+                z_closure_hello_call(z_closure_hello_loan(&callback), unsafe {
+                    owned_h.as_mut().unwrap_unchecked().as_loaned_c_type_mut()
+                })
             })
             .await
             .unwrap();


### PR DESCRIPTION
wrap loaned objects inside callbacks into option to pretend they are owned