### PR TITLE
fix logging function names and signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Finally, we strongly advise that you refrain from using structure field that sta
 
 ## Logging
 
-By default, zenoh-c enables Zenoh's logging library upon using the `z_open` or `z_scout` functions. This behavior can be disabled by adding `-DDISABLE_LOGGER_AUTOINIT:bool=true` to the `cmake` configuration command. The logger may then be manually re-enabled with the `zc_init_logging` function.
+By default, zenoh-c enables Zenoh's logging library upon using the `z_open` or `z_scout` functions. This behavior can be disabled by adding `-DDISABLE_LOGGER_AUTOINIT:bool=true` to the `cmake` configuration command. The logger may then be manually re-enabled with the `zc_try_init_log_from_env` function.
 
 ## Cross-Compilation
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -827,8 +827,8 @@ Types
 Functions
 ---------
 
-.. doxygenfunction:: zc_init_logging
-.. doxygenfunction:: zc_init_logging_with_callback
+.. doxygenfunction:: zc_try_init_log_from_env
+.. doxygenfunction:: zc_init_log_with_callback
 
 
 Other

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -4894,22 +4894,15 @@ ZENOHC_API
 z_result_t zc_config_to_string(const struct z_loaned_config_t *config,
                                struct z_owned_string_t *out_config_string);
 /**
- * Initializes the zenoh runtime logger, using rust environment settings.
- *
- * Note that unless you built zenoh-c with the `logger-autoinit` feature disabled,
- * this will be performed automatically by `z_open` and `z_scout`.
- */
-ZENOHC_API void zc_init_logging(void);
-/**
- * Initializes the zenoh runtime logger with custom callback.
+ * Initializes the Zenoh runtime logger with custom callback.
  *
  * @param min_severity: Minimum severity level of log message to be be passed to the `callback`.
  * Messages with lower severity levels will be ignored.
  * @param callback: A closure that will be called with each log message severity level and content.
  */
 ZENOHC_API
-void zc_init_logging_with_callback(enum zc_log_severity_t min_severity,
-                                   struct zc_owned_closure_log_t *callback);
+void zc_init_log_with_callback(enum zc_log_severity_t min_severity,
+                               struct zc_moved_closure_log_t *callback);
 /**
  * Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
  */
@@ -5195,6 +5188,16 @@ void zc_shm_client_list_new(zc_owned_shm_client_list_t *this_);
  */
 ZENOHC_API
 void zc_stop_z_runtime(void);
+/**
+ * @brief Initializes the zenoh runtime logger redirecting Zenoh logs to stdout according to `RUST_LOG` env variable.
+ * For example, `RUST_LOG=debug` will set the log severity level to DEBUG.
+ * If `RUST_LOG` env varaibel is not set, then logging is not enabled.
+ *
+ * @note unless you built zenoh-c with the `logger-autoinit` feature disabled,
+ * this will be performed automatically by `z_open` and `z_scout`.
+ */
+ZENOHC_API
+void zc_try_init_log_from_env(void);
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Constructs and declares a publication cache.

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -24,7 +24,8 @@ use crate::{
     result::{self, Z_OK},
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_closure_hello_call, z_closure_hello_loan, z_moved_closure_hello_t, z_moved_config_t,
-    z_owned_string_array_t, z_view_string_t, zc_init_logging, CString, CStringView, ZVector,
+    z_owned_string_array_t, z_view_string_t, zc_try_init_log_from_env, CString, CStringView,
+    ZVector,
 };
 #[cfg(feature = "unstable")]
 use crate::{transmute::IntoCType, z_id_t};
@@ -169,7 +170,7 @@ pub extern "C" fn z_scout(
     options: Option<&z_scout_options_t>,
 ) -> result::z_result_t {
     if cfg!(feature = "logger-autoinit") {
-        zc_init_logging();
+        zc_try_init_log_from_env();
     }
     let callback = callback.take_rust_type();
     let options = options.cloned().unwrap_or_default();

--- a/src/session.rs
+++ b/src/session.rs
@@ -22,7 +22,7 @@ use crate::{
     opaque_types::{z_loaned_session_t, z_owned_session_t},
     result,
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
-    z_moved_config_t, z_moved_session_t, zc_init_logging,
+    z_moved_config_t, z_moved_session_t, zc_try_init_log_from_env,
 };
 decl_c_type!(
     owned(z_owned_session_t, option Session),
@@ -71,7 +71,7 @@ pub extern "C" fn z_open(
 ) -> result::z_result_t {
     let this = this.as_rust_type_mut_uninit();
     if cfg!(feature = "logger-autoinit") {
-        zc_init_logging();
+        zc_try_init_log_from_env();
     }
     let Some(config) = config.take_rust_type().take() else {
         tracing::error!("Config not provided");
@@ -105,7 +105,7 @@ pub extern "C" fn z_open_with_custom_shm_clients(
 ) -> result::z_result_t {
     let this = this.as_rust_type_mut_uninit();
     if cfg!(feature = "logger-autoinit") {
-        zc_init_logging();
+        zc_try_init_log_from_env();
     }
     let Some(config) = config.take_rust_type() else {
         tracing::error!("Config not provided");

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
     setbuf(stdout, NULL);
 
 #ifdef ZENOH_C
-    zc_init_logging();
+    zc_try_init_log_from_env();
 #endif
 
     z_view_keyexpr_t key_demo_example, key_demo_example_a, key_demo_example_starstar;

--- a/tests/z_api_config_test.c
+++ b/tests/z_api_config_test.c
@@ -37,6 +37,6 @@ void insert_get() {
 }
 
 int main(int argc, char **argv) {
-    zc_init_logging();
+    zc_try_init_log_from_env();
     insert_get();
 }

--- a/tests/z_api_double_drop_test.c
+++ b/tests/z_api_double_drop_test.c
@@ -120,7 +120,7 @@ void test_queryable() {
 }
 
 int main(int argc, char **argv) {
-    zc_init_logging();
+    zc_try_init_log_from_env();
     test_session();
     test_publisher();
     test_keyexpr();

--- a/tests/z_api_drop_options.c
+++ b/tests/z_api_drop_options.c
@@ -74,7 +74,7 @@ void get() {
 }
 
 int main(int argc, char **argv) {
-    zc_init_logging();
+    zc_try_init_log_from_env();
     put();
     get();
 }


### PR DESCRIPTION
rename zc_init_logging -> zc_try_init_log_from_env (according to the rust api);
rename zc_init_logging_with_callback -> zc_init_log_with_callback and fix its signature;