### PR TITLE
added missing "moved" parameter to `zc_init_logging_with_callback`

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -4701,7 +4701,7 @@ z_result_t zc_init_log_from_env_or(const char *fallback);
  */
 ZENOHC_API
 void zc_init_logging_with_callback(enum zc_log_severity_t min_severity,
-                                   struct zc_owned_closure_log_t *callback);
+                                   struct zc_moved_closure_log_t *callback);
 /**
  * Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
  */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 use std::{cmp::min, slice};
 
 use libc::c_void;
+use transmute::TakeRustType;
 
 use crate::transmute::LoanedCTypeRef;
 #[macro_use]
@@ -116,10 +117,9 @@ pub unsafe extern "C" fn zc_init_log_from_env_or(
 #[no_mangle]
 pub extern "C" fn zc_init_logging_with_callback(
     min_severity: zc_log_severity_t,
-    callback: &mut zc_owned_closure_log_t,
+    callback: &mut zc_moved_closure_log_t,
 ) {
-    let mut closure = zc_owned_closure_log_t::empty();
-    std::mem::swap(callback, &mut closure);
+    let closure = callback.take_rust_type();
     zenoh_util::log::init_log_with_callback(
         move |meta| min_severity <= (*meta.level()).into(),
         move |record| {


### PR DESCRIPTION
fix for https://github.com/eclipse-zenoh/zenoh-c/issues/647