### PR TITLE
Align with Rust types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3483,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3571,7 +3571,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "tracing",
  "uhlc",
@@ -3583,12 +3583,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 
 [[package]]
 name = "zenoh-config"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "flume",
  "json5",
@@ -3610,7 +3610,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3621,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "aes",
  "hmac",
@@ -3634,7 +3634,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "bincode",
  "flume",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "hashbrown 0.14.5",
  "keyed-set",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "flume",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -3810,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3830,7 +3830,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "git-version",
  "libloading",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "const_format",
  "rand",
@@ -3870,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "anyhow",
 ]
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "lazy_static",
  "ron",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "crc",
@@ -3913,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "event-listener 5.3.1",
  "futures",
@@ -3926,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "futures",
  "tokio",
@@ -3939,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "const_format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,10 @@ rand = "0.8.5"
 spin = "0.9.5"
 unwrap-infallible = "0.1.5"
 const_format = "0.2.32"
-zenoh = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features = ["internal"] }
-zenoh-ext = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" , optional = true }
-zenoh-runtime = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
-zenoh-util = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main"  }
+zenoh = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/wrapper_types", default-features = false, features = ["internal"] }
+zenoh-ext = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/wrapper_types" , optional = true }
+zenoh-runtime = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/wrapper_types" }
+zenoh-util = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/wrapper_types"  }
 flume = "*"
 
 [build-dependencies]
@@ -69,7 +69,7 @@ phf = { version = "0.11.2", features = ["macros"] }
 
 [lib]
 path = "src/lib.rs"
-name = "zenohc"
+name = "zenohcd"
 crate-type = ["cdylib", "staticlib"]
 doctest = false
 

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -52,10 +52,10 @@ rand = "0.8.5"
 spin = "0.9.5"
 unwrap-infallible = "0.1.5"
 const_format = "0.2.32"
-zenoh = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features = ["internal"] }
-zenoh-ext = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" , optional = true }
-zenoh-runtime = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
-zenoh-util = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main"  }
+zenoh = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/wrapper_types", default-features = false, features = ["internal"] }
+zenoh-ext = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/wrapper_types" , optional = true }
+zenoh-runtime = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/wrapper_types" }
+zenoh-util = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/wrapper_types"  }
 flume = "*"
 
 [build-dependencies]

--- a/build-resources/opaque-types/Cargo.lock
+++ b/build-resources/opaque-types/Cargo.lock
@@ -2880,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "zenoh-collections",
 ]
@@ -2938,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "tracing",
  "uhlc",
@@ -2950,12 +2950,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 
 [[package]]
 name = "zenoh-config"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "flume",
  "json5",
@@ -2977,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "aes",
  "hmac",
@@ -3001,7 +3001,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "bincode",
  "flume",
@@ -3017,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "hashbrown",
  "keyed-set",
@@ -3031,7 +3031,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3048,7 +3048,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "flume",
@@ -3071,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3113,7 +3113,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3140,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3159,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -3177,7 +3177,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3197,7 +3197,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3208,7 +3208,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "git-version",
  "libloading",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "const_format",
  "rand",
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "anyhow",
 ]
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "lazy_static",
  "ron",
@@ -3258,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "crc",
@@ -3280,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "event-listener",
  "futures",
@@ -3293,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "futures",
  "tokio",
@@ -3306,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -3340,7 +3340,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3ded09418aac568fb389ee1a87722b7744adef7"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/wrapper_types#bb710e4588d39175ce6809b25e420f0e3f8a9be0"
 dependencies = [
  "async-trait",
  "const_format",

--- a/build-resources/opaque-types/Cargo.toml
+++ b/build-resources/opaque-types/Cargo.toml
@@ -12,8 +12,8 @@ panic = [] # The whole purpose of this project is to generate set of compilation
 default = ["zenoh/default"]
 
 [dependencies]
-zenoh = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features = ["internal"]  }
-zenoh-ext = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", optional = true}
-zenoh-protocol = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/wrapper_types", default-features = false, features = ["internal"]  }
+zenoh-ext = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/wrapper_types", optional = true}
+zenoh-protocol = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "dev/wrapper_types" }
 const_format = "0.2.32"
 flume = "*"

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -16,32 +16,6 @@
 #define ALIGN(n)
 #define ZENOHC_API
 #endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Allocation errors
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef enum z_alloc_error_t {
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  /**
-   * Defragmentation needed.
-   */
-  Z_ALLOC_ERROR_NEED_DEFRAGMENT,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  /**
-   * The provider is out of memory.
-   */
-  Z_ALLOC_ERROR_OUT_OF_MEMORY,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  /**
-   * Other error.
-   */
-  Z_ALLOC_ERROR_OTHER,
-#endif
-} z_alloc_error_t;
-#endif
 typedef enum z_congestion_control_t {
   /**
    * Messages are not dropped in case of congestion.
@@ -102,26 +76,6 @@ typedef enum z_keyexpr_intersection_level_t {
    */
   Z_KEYEXPR_INTERSECTION_LEVEL_EQUALS = 3,
 } z_keyexpr_intersection_level_t;
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Layouting errors
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef enum z_layout_error_t {
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  /**
-   * Layout arguments are incorrect.
-   */
-  Z_LAYOUT_ERROR_INCORRECT_LAYOUT_ARGS,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  /**
-   * Layout incompatible with provider.
-   */
-  Z_LAYOUT_ERROR_PROVIDER_INCOMPATIBLE_LAYOUT,
-#endif
-} z_layout_error_t;
 #endif
 /**
  * The priority of zenoh messages.
@@ -216,52 +170,6 @@ typedef enum z_whatami_t {
   Z_WHATAMI_CLIENT = 4,
 } z_whatami_t;
 /**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Status of SHM buffer allocation operation.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef enum zc_buf_alloc_status_t {
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  /**
-   * Allocation ok
-   */
-  ZC_BUF_ALLOC_STATUS_OK = 0,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  /**
-   * Allocation error
-   */
-  ZC_BUF_ALLOC_STATUS_ALLOC_ERROR = 1,
-#endif
-} zc_buf_alloc_status_t;
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Status of SHM buffer layouting + allocation operation.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef enum zc_buf_layout_alloc_status_t {
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  /**
-   * Allocation ok
-   */
-  ZC_BUF_LAYOUT_ALLOC_STATUS_OK = 0,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  /**
-   * Allocation error
-   */
-  ZC_BUF_LAYOUT_ALLOC_STATUS_ALLOC_ERROR = 1,
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-  /**
-   * Layouting error
-   */
-  ZC_BUF_LAYOUT_ALLOC_STATUS_LAYOUT_ERROR = 2,
-#endif
-} zc_buf_layout_alloc_status_t;
-#endif
-/**
  * The locality of samples to be received by subscribers or targeted by publishers.
  */
 typedef enum zc_locality_t {
@@ -329,53 +237,10 @@ typedef enum zc_reply_keyexpr_t {
   ZC_REPLY_KEYEXPR_MATCHING_QUERY = 1,
 } zc_reply_keyexpr_t;
 #endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief A result of SHM buffer allocation operation.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_buf_alloc_result_t {
-  enum zc_buf_alloc_status_t status;
-  z_owned_shm_mut_t buf;
-  enum z_alloc_error_t error;
-} z_buf_alloc_result_t;
-#endif
+typedef struct z_moved_alloc_layout_t {
+  struct z_owned_alloc_layout_t _this;
+} z_moved_alloc_layout_t;
 typedef int8_t z_result_t;
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief An AllocAlignment.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_alloc_alignment_t {
-  uint8_t pow;
-} z_alloc_alignment_t;
-#endif
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_threadsafe_context_data_t {
-  void *ptr;
-} zc_threadsafe_context_data_t;
-#endif
-/**
- * A tread-safe droppable context.
- * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
- * information to each callback.
- *
- * This is a thread-safe context - the associated callbacks may be executed concurrently with the same
- * zc_context_t instance. In other words, all the callbacks associated with this context data MUST be
- * thread-safe.
- *
- * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted.The
- * delete_fn is guaranteed to be executed only once at some point of time after the last associated
- * callback call returns.
- * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
- * be executed.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_threadsafe_context_t {
-  struct zc_threadsafe_context_data_t context;
-  void (*delete_fn)(void*);
-} zc_threadsafe_context_t;
-#endif
 typedef struct z_moved_bytes_t {
   struct z_owned_bytes_t _this;
 } z_moved_bytes_t;
@@ -391,41 +256,15 @@ typedef struct z_moved_string_t {
 typedef struct ALIGN(8) z_bytes_slice_iterator_t {
   uint8_t _0[24];
 } z_bytes_slice_iterator_t;
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Unique segment identifier.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef uint32_t z_segment_id_t;
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Chunk id within it's segment.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef uint32_t z_chunk_id_t;
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief A ChunkDescriptor.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_chunk_descriptor_t {
-  z_segment_id_t segment;
-  z_chunk_id_t chunk;
-  size_t len;
-} z_chunk_descriptor_t;
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief An AllocatedChunk.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_allocated_chunk_t {
-  struct z_chunk_descriptor_t descriptpr;
-  void *data;
-} z_allocated_chunk_t;
-#endif
+typedef struct z_moved_shm_t {
+  struct z_owned_shm_t _this;
+} z_moved_shm_t;
+typedef struct z_moved_shm_mut_t {
+  struct z_owned_shm_mut_t _this;
+} z_moved_shm_mut_t;
+typedef struct z_moved_chunk_alloc_result_t {
+  struct z_owned_chunk_alloc_result_t _this;
+} z_moved_chunk_alloc_result_t;
 /**
  * Monotonic clock
  */
@@ -583,7 +422,7 @@ typedef struct z_owned_closure_zid_t {
   /**
    * A callback function.
    */
-  void (*call)(const z_id_t *z_id, void *context);
+  void (*call)(const struct z_id_t *z_id, void *context);
   /**
    * An optional function that will be called upon closure drop.
    */
@@ -715,6 +554,9 @@ typedef struct z_moved_fifo_handler_sample_t {
 typedef struct z_query_consolidation_t {
   enum z_consolidation_mode_t mode;
 } z_query_consolidation_t;
+typedef struct z_moved_source_info_t {
+  struct z_owned_source_info_t _this;
+} z_moved_source_info_t;
 /**
  * Options passed to the `z_get()` function.
  */
@@ -769,7 +611,7 @@ typedef struct z_get_options_t {
    *
    * The source info for the query.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * An optional attachment to attach to the query.
@@ -786,6 +628,9 @@ typedef struct z_moved_hello_t {
 typedef struct z_moved_keyexpr_t {
   struct z_owned_keyexpr_t _this;
 } z_moved_keyexpr_t;
+typedef struct z_moved_memory_layout_t {
+  struct z_owned_memory_layout_t _this;
+} z_moved_memory_layout_t;
 typedef struct z_moved_mutex_t {
   struct z_owned_mutex_t _this;
 } z_moved_mutex_t;
@@ -826,7 +671,7 @@ typedef struct z_publisher_put_options_t {
    *
    * The source info for the publication.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to attach to the publication.
@@ -879,7 +724,7 @@ typedef struct z_put_options_t {
    *
    * The source info for the message.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this message.
@@ -920,7 +765,7 @@ typedef struct z_query_reply_options_t {
    *
    * The source info for the reply.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
@@ -954,7 +799,7 @@ typedef struct z_query_reply_del_options_t {
    *
    * The source info for the reply.
    */
-  z_moved_source_info_t *source_info;
+  struct z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
@@ -1005,46 +850,15 @@ typedef struct z_scout_options_t {
    */
   enum z_what_t what;
 } z_scout_options_t;
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Callbacks for ShmSegment.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_shm_segment_callbacks_t {
-  uint8_t *(*map_fn)(z_chunk_id_t chunk_id, void *context);
-} zc_shm_segment_callbacks_t;
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief An ShmSegment.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_shm_segment_t {
-  struct zc_threadsafe_context_t context;
-  struct zc_shm_segment_callbacks_t callbacks;
-} z_shm_segment_t;
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Callback for ShmClient.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_shm_client_callbacks_t {
-  bool (*attach_fn)(struct z_shm_segment_t *out_segment, z_segment_id_t segment_id, void *context);
-} zc_shm_client_callbacks_t;
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief A result of SHM buffer layouting + allocation operation.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct z_buf_layout_alloc_result_t {
-  enum zc_buf_layout_alloc_status_t status;
-  z_owned_shm_mut_t buf;
-  enum z_alloc_error_t alloc_error;
-  enum z_layout_error_t layout_error;
-} z_buf_layout_alloc_result_t;
-#endif
+typedef struct z_moved_shm_client_t {
+  struct z_owned_shm_client_t _this;
+} z_moved_shm_client_t;
+typedef struct z_moved_shm_client_storage_t {
+  struct z_owned_shm_client_storage_t _this;
+} z_moved_shm_client_storage_t;
+typedef struct z_moved_shm_provider_t {
+  struct z_owned_shm_provider_t _this;
+} z_moved_shm_provider_t;
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Unique protocol identifier.
@@ -1053,47 +867,6 @@ typedef struct z_buf_layout_alloc_result_t {
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 typedef uint32_t z_protocol_id_t;
-#endif
-/**
- * A non-tread-safe droppable context.
- * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
- * information to each callback.
- *
- * This is a non-thread-safe context - zenoh-c guarantees that associated callbacks that share the same
- * zc_context_t instance will never be executed concurrently. In other words, all the callbacks associated
- * with this context data are not required to be thread-safe.
- *
- * NOTE: Remember that the same callback interfaces associated with different zc_context_t instances can
- * still be executed concurrently. The exact behavior depends on user's application, but we strongly
- * discourage our users from pinning to some specific behavior unless they _really_ understand what they
- * are doing.
- *
- * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted. The
- * delete_fn is guaranteed to be executed only once at some point of time after the last associated
- * callback call returns.
- * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
- * be executed.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_context_t {
-  void *context;
-  void (*delete_fn)(void*);
-} zc_context_t;
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Callbacks for ShmProviderBackend.
- */
-#if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-typedef struct zc_shm_provider_backend_callbacks_t {
-  void (*alloc_fn)(z_owned_chunk_alloc_result_t *out_result,
-                   const z_loaned_memory_layout_t *layout,
-                   void *context);
-  void (*free_fn)(const struct z_chunk_descriptor_t *chunk, void *context);
-  size_t (*defragment_fn)(void *context);
-  size_t (*available_fn)(void *context);
-  void (*layout_for_fn)(z_owned_memory_layout_t *layout, void *context);
-} zc_shm_provider_backend_callbacks_t;
 #endif
 typedef struct z_moved_string_array_t {
   struct z_owned_string_array_t _this;
@@ -1143,15 +916,6 @@ typedef struct zc_owned_closure_log_t {
 typedef struct zc_moved_closure_log_t {
   struct zc_owned_closure_log_t _this;
 } zc_moved_closure_log_t;
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Loaned closure.
- */
-#if defined(UNSTABLE)
-typedef struct zc_loaned_closure_matching_status_t {
-  size_t _0[3];
-} zc_loaned_closure_matching_status_t;
-#endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief A struct that indicates if there exist Subscribers matching the Publisher's key expression.
@@ -1227,6 +991,15 @@ typedef struct zc_liveliness_get_options_t {
   uint32_t timeout_ms;
 } zc_liveliness_get_options_t;
 #endif
+typedef struct zc_moved_liveliness_token_t {
+  struct zc_owned_liveliness_token_t _this;
+} zc_moved_liveliness_token_t;
+typedef struct zc_moved_matching_listener_t {
+  struct zc_owned_matching_listener_t _this;
+} zc_moved_matching_listener_t;
+typedef struct zc_moved_shm_client_list_t {
+  struct zc_owned_shm_client_list_t _this;
+} zc_moved_shm_client_list_t;
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Options passed to the `ze_declare_publication_cache()` function.
@@ -1295,6 +1068,19 @@ typedef struct ze_querying_subscriber_options_t {
   uint64_t query_timeout_ms;
 } ze_querying_subscriber_options_t;
 #endif
+typedef struct ze_moved_publication_cache_t {
+  struct ze_owned_publication_cache_t _this;
+} ze_moved_publication_cache_t;
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief A loaned Zenoh publication cache.
+ */
+typedef struct ALIGN(8) ze_loaned_publication_cache_t {
+  uint8_t _0[96];
+} ze_loaned_publication_cache_t;
+typedef struct ze_moved_querying_subscriber_t {
+  struct ze_owned_querying_subscriber_t _this;
+} ze_moved_querying_subscriber_t;
 ZENOHC_API extern const unsigned int Z_ROUTER;
 ZENOHC_API extern const unsigned int Z_PEER;
 ZENOHC_API extern const unsigned int Z_CLIENT;
@@ -1314,39 +1100,40 @@ ZENOHC_API extern const unsigned int Z_SHM_POSIX_PROTOCOL_ID;
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc(struct z_buf_alloc_result_t *out_result,
-                          const z_loaned_alloc_layout_t *layout);
+                          const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc(struct z_buf_alloc_result_t *out_result,
-                             const z_loaned_alloc_layout_t *layout);
+                             const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag(struct z_buf_alloc_result_t *out_result,
-                                    const z_loaned_alloc_layout_t *layout);
+                                    const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_blocking(struct z_buf_alloc_result_t *out_result,
-                                             const z_loaned_alloc_layout_t *layout);
+                                             const struct z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_dealloc(struct z_buf_alloc_result_t *out_result,
-                                            const z_loaned_alloc_layout_t *layout);
+                                            const struct z_loaned_alloc_layout_t *layout);
 #endif
 /**
  * Deletes Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_alloc_layout_drop(z_moved_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_drop(struct z_moved_alloc_layout_t *this_);
 #endif
 /**
  * Borrows Alloc Layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API const z_loaned_alloc_layout_t *z_alloc_layout_loan(const z_owned_alloc_layout_t *this_);
+ZENOHC_API
+const struct z_loaned_alloc_layout_t *z_alloc_layout_loan(const struct z_owned_alloc_layout_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1354,15 +1141,15 @@ ZENOHC_API const z_loaned_alloc_layout_t *z_alloc_layout_loan(const z_owned_allo
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_alloc_layout_new(z_owned_alloc_layout_t *this_,
-                              const z_loaned_shm_provider_t *provider,
+z_result_t z_alloc_layout_new(struct z_owned_alloc_layout_t *this_,
+                              const struct z_loaned_shm_provider_t *provider,
                               size_t size,
                               struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_alloc_layout_threadsafe_alloc_gc_defrag_async(struct z_buf_alloc_result_t *out_result,
-                                                           const z_loaned_alloc_layout_t *layout,
+                                                           const struct z_loaned_alloc_layout_t *layout,
                                                            struct zc_threadsafe_context_t result_context,
                                                            void (*result_callback)(void*,
                                                                                    struct z_buf_alloc_result_t*));
@@ -1423,7 +1210,7 @@ z_result_t z_bytes_deserialize_into_int8(const struct z_loaned_bytes_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *this_,
-                                               const z_loaned_shm_t **dst);
+                                               const struct z_loaned_shm_t **dst);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1435,7 +1222,7 @@ z_result_t z_bytes_deserialize_into_loaned_shm(const struct z_loaned_bytes_t *th
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this_,
-                                                   z_loaned_shm_t **dst);
+                                                   struct z_loaned_shm_t **dst);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1447,7 +1234,7 @@ z_result_t z_bytes_deserialize_into_mut_loaned_shm(struct z_loaned_bytes_t *this
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_deserialize_into_owned_shm(const struct z_loaned_bytes_t *this_,
-                                              z_owned_shm_t *dst);
+                                              struct z_owned_shm_t *dst);
 #endif
 /**
  * Deserializes into a pair of `z_owned_bytes_t` objects.
@@ -1715,7 +1502,7 @@ ZENOHC_API void z_bytes_serialize_from_int8(struct z_owned_bytes_t *this_, int8_
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_,
-                                      z_moved_shm_t *shm);
+                                      struct z_moved_shm_t *shm);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1724,7 +1511,7 @@ z_result_t z_bytes_serialize_from_shm(struct z_owned_bytes_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_bytes_serialize_from_shm_mut(struct z_owned_bytes_t *this_,
-                                          z_moved_shm_mut_t *shm);
+                                          struct z_moved_shm_mut_t *shm);
 #endif
 /**
  * Serializes a slice by copying.
@@ -1803,7 +1590,7 @@ z_result_t z_bytes_writer_write_all(struct z_bytes_writer_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_chunk_alloc_result_drop(z_moved_chunk_alloc_result_t *this_);
+void z_chunk_alloc_result_drop(struct z_moved_chunk_alloc_result_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1811,7 +1598,7 @@ void z_chunk_alloc_result_drop(z_moved_chunk_alloc_result_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const z_owned_chunk_alloc_result_t *this_);
+const struct z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1819,7 +1606,7 @@ const z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const z_owned_chu
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
+void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
                                     enum z_alloc_error_t alloc_error);
 #endif
 /**
@@ -1828,7 +1615,7 @@ void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_chunk_alloc_result_new_ok(z_owned_chunk_alloc_result_t *this_,
+z_result_t z_chunk_alloc_result_new_ok(struct z_owned_chunk_alloc_result_t *this_,
                                        struct z_allocated_chunk_t allocated_chunk);
 #endif
 /**
@@ -1927,7 +1714,7 @@ const struct z_loaned_closure_sample_t *z_closure_sample_loan(const struct z_own
 #if defined(UNSTABLE)
 ZENOHC_API
 void z_closure_zid_call(const struct z_loaned_closure_zid_t *closure,
-                        const z_id_t *z_id);
+                        const struct z_id_t *z_id);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2574,7 +2361,7 @@ ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint8(void);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-uint32_t z_entity_global_id_eid(const z_entity_global_id_t *this_);
+uint32_t z_entity_global_id_eid(const struct z_entity_global_id_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2582,7 +2369,7 @@ uint32_t z_entity_global_id_eid(const z_entity_global_id_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_id_t z_entity_global_id_zid(const z_entity_global_id_t *this_);
+struct z_id_t z_entity_global_id_zid(const struct z_entity_global_id_t *this_);
 #endif
 /**
  * Constructs send and recieve ends of the fifo channel
@@ -2734,7 +2521,7 @@ ZENOHC_API enum z_whatami_t z_hello_whatami(const struct z_loaned_hello_t *this_
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
+struct z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2742,7 +2529,7 @@ z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void z_id_to_string(const z_id_t *zid,
+void z_id_to_string(const struct z_id_t *zid,
                     struct z_owned_string_t *dst);
 #endif
 /**
@@ -2783,19 +2570,19 @@ z_result_t z_info_routers_zid(const struct z_loaned_session_t *session,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_id_t z_info_zid(const struct z_loaned_session_t *session);
+struct z_id_t z_info_zid(const struct z_loaned_session_t *session);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API bool z_internal_alloc_layout_check(const z_owned_alloc_layout_t *this_);
+ZENOHC_API bool z_internal_alloc_layout_check(const struct z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Constructs Alloc Layout in its gravestone value.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API void z_internal_alloc_layout_null(z_owned_alloc_layout_t *this_);
+ZENOHC_API void z_internal_alloc_layout_null(struct z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Returns ``true`` if `this_` is in a valid state, ``false`` if it is in a gravestone state.
@@ -2811,7 +2598,7 @@ ZENOHC_API void z_internal_bytes_null(struct z_owned_bytes_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-bool z_internal_chunk_alloc_result_check(const z_owned_chunk_alloc_result_t *this_);
+bool z_internal_chunk_alloc_result_check(const struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2819,7 +2606,7 @@ bool z_internal_chunk_alloc_result_check(const z_owned_chunk_alloc_result_t *thi
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_internal_chunk_alloc_result_null(z_owned_chunk_alloc_result_t *this_);
+void z_internal_chunk_alloc_result_null(struct z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
@@ -2942,7 +2729,7 @@ ZENOHC_API void z_internal_keyexpr_null(struct z_owned_keyexpr_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-bool z_internal_memory_layout_check(const z_owned_memory_layout_t *this_);
+bool z_internal_memory_layout_check(const struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2950,7 +2737,7 @@ bool z_internal_memory_layout_check(const z_owned_memory_layout_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_internal_memory_layout_null(z_owned_memory_layout_t *this_);
+void z_internal_memory_layout_null(struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * Returns ``true`` if mutex is valid, ``false`` otherwise.
@@ -3049,7 +2836,7 @@ ZENOHC_API void z_internal_session_null(struct z_owned_session_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-bool z_internal_shm_check(const z_owned_shm_t *this_);
+bool z_internal_shm_check(const struct z_owned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3057,7 +2844,7 @@ bool z_internal_shm_check(const z_owned_shm_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-bool z_internal_shm_client_check(const z_owned_shm_client_t *this_);
+bool z_internal_shm_client_check(const struct z_owned_shm_client_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3065,7 +2852,7 @@ bool z_internal_shm_client_check(const z_owned_shm_client_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_internal_shm_client_null(z_owned_shm_client_t *this_);
+void z_internal_shm_client_null(struct z_owned_shm_client_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3073,7 +2860,7 @@ void z_internal_shm_client_null(z_owned_shm_client_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-bool z_internal_shm_client_storage_check(const z_owned_shm_client_storage_t *this_);
+bool z_internal_shm_client_storage_check(const struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3081,7 +2868,7 @@ bool z_internal_shm_client_storage_check(const z_owned_shm_client_storage_t *thi
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_internal_shm_client_storage_null(z_owned_shm_client_storage_t *this_);
+void z_internal_shm_client_storage_null(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3089,7 +2876,7 @@ void z_internal_shm_client_storage_null(z_owned_shm_client_storage_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-bool z_internal_shm_mut_check(const z_owned_shm_mut_t *this_);
+bool z_internal_shm_mut_check(const struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3097,7 +2884,7 @@ bool z_internal_shm_mut_check(const z_owned_shm_mut_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_internal_shm_mut_null(z_owned_shm_mut_t *this_);
+void z_internal_shm_mut_null(struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3105,7 +2892,7 @@ void z_internal_shm_mut_null(z_owned_shm_mut_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_internal_shm_null(z_owned_shm_t *this_);
+void z_internal_shm_null(struct z_owned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3113,7 +2900,7 @@ void z_internal_shm_null(z_owned_shm_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-bool z_internal_shm_provider_check(const z_owned_shm_provider_t *this_);
+bool z_internal_shm_provider_check(const struct z_owned_shm_provider_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3121,7 +2908,7 @@ bool z_internal_shm_provider_check(const z_owned_shm_provider_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_internal_shm_provider_null(z_owned_shm_provider_t *this_);
+void z_internal_shm_provider_null(struct z_owned_shm_provider_t *this_);
 #endif
 /**
  * @return ``true`` if slice is not empty, ``false`` otherwise.
@@ -3137,7 +2924,7 @@ ZENOHC_API void z_internal_slice_null(struct z_owned_slice_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-bool z_internal_source_info_check(const z_owned_source_info_t *this_);
+bool z_internal_source_info_check(const struct z_owned_source_info_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3145,7 +2932,7 @@ bool z_internal_source_info_check(const z_owned_source_info_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void z_internal_source_info_null(z_owned_source_info_t *this_);
+void z_internal_source_info_null(struct z_owned_source_info_t *this_);
 #endif
 /**
  * @return ``true`` if the string array is valid, ``false`` if it is in a gravestone state.
@@ -3322,7 +3109,7 @@ enum z_keyexpr_intersection_level_t z_keyexpr_relation_to(const struct z_loaned_
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_memory_layout_drop(z_moved_memory_layout_t *this_);
+void z_memory_layout_drop(struct z_moved_memory_layout_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3330,7 +3117,7 @@ void z_memory_layout_drop(z_moved_memory_layout_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_memory_layout_get_data(const z_loaned_memory_layout_t *this_,
+void z_memory_layout_get_data(const struct z_loaned_memory_layout_t *this_,
                               size_t *out_size,
                               struct z_alloc_alignment_t *out_alignment);
 #endif
@@ -3340,7 +3127,7 @@ void z_memory_layout_get_data(const z_loaned_memory_layout_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_memory_layout_t *z_memory_layout_loan(const z_owned_memory_layout_t *this_);
+const struct z_loaned_memory_layout_t *z_memory_layout_loan(const struct z_owned_memory_layout_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3348,7 +3135,7 @@ const z_loaned_memory_layout_t *z_memory_layout_loan(const z_owned_memory_layout
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_memory_layout_new(z_owned_memory_layout_t *this_,
+z_result_t z_memory_layout_new(struct z_owned_memory_layout_t *this_,
                                size_t size,
                                struct z_alloc_alignment_t alignment);
 #endif
@@ -3404,7 +3191,7 @@ ZENOHC_API void z_open_options_default(struct z_open_options_t *this_);
 ZENOHC_API
 z_result_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
                                           struct z_moved_config_t *config,
-                                          const z_loaned_shm_client_storage_t *shm_clients);
+                                          const struct z_loaned_shm_client_storage_t *shm_clients);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3412,7 +3199,7 @@ z_result_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_posix_shm_client_new(z_owned_shm_client_t *this_);
+void z_posix_shm_client_new(struct z_owned_shm_client_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3420,8 +3207,8 @@ void z_posix_shm_client_new(z_owned_shm_client_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_posix_shm_provider_new(z_owned_shm_provider_t *this_,
-                                    const z_loaned_memory_layout_t *layout);
+z_result_t z_posix_shm_provider_new(struct z_owned_shm_provider_t *this_,
+                                    const struct z_loaned_memory_layout_t *layout);
 #endif
 /**
  * Returns the default value of #z_priority_t.
@@ -3449,7 +3236,7 @@ ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
+struct z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
 #endif
 /**
  * Returns the key expression of the publisher.
@@ -3672,7 +3459,7 @@ void z_queryable_drop(struct z_moved_queryable_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_entity_global_id_t z_queryable_id(const struct z_loaned_queryable_t *queryable);
+struct z_entity_global_id_t z_queryable_id(const struct z_loaned_queryable_t *queryable);
 #endif
 ZENOHC_API
 const struct z_loaned_queryable_t *z_queryable_loan(const struct z_owned_queryable_t *this_);
@@ -3705,7 +3492,7 @@ ZENOHC_API uint8_t z_random_u8(void);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_ref_shm_client_storage_global(z_owned_shm_client_storage_t *this_);
+void z_ref_shm_client_storage_global(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3777,7 +3564,7 @@ ZENOHC_API const struct z_loaned_sample_t *z_reply_ok(const struct z_loaned_repl
 #if defined(UNSTABLE)
 ZENOHC_API
 bool z_reply_replier_id(const struct z_loaned_reply_t *this_,
-                        z_id_t *out_id);
+                        struct z_id_t *out_id);
 #endif
 /**
  * Constructs send and recieve ends of the ring channel
@@ -3940,7 +3727,7 @@ enum z_reliability_t z_sample_reliability(const struct z_loaned_sample_t *this_)
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
+const struct z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
 #endif
 /**
  * Returns the sample timestamp.
@@ -3979,7 +3766,7 @@ ZENOHC_API const struct z_loaned_session_t *z_session_loan(const struct z_owned_
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_drop(z_moved_shm_client_t *this_);
+void z_shm_client_drop(struct z_moved_shm_client_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3987,7 +3774,7 @@ void z_shm_client_drop(z_moved_shm_client_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_new(z_owned_shm_client_t *this_,
+void z_shm_client_new(struct z_owned_shm_client_t *this_,
                       struct zc_threadsafe_context_t context,
                       struct zc_shm_client_callbacks_t callbacks);
 #endif
@@ -3997,8 +3784,8 @@ void z_shm_client_new(z_owned_shm_client_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_storage_clone(z_owned_shm_client_storage_t *this_,
-                                const z_loaned_shm_client_storage_t *from);
+void z_shm_client_storage_clone(struct z_owned_shm_client_storage_t *this_,
+                                const struct z_loaned_shm_client_storage_t *from);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4006,7 +3793,7 @@ void z_shm_client_storage_clone(z_owned_shm_client_storage_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_storage_drop(z_moved_shm_client_storage_t *this_);
+void z_shm_client_storage_drop(struct z_moved_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4014,15 +3801,15 @@ void z_shm_client_storage_drop(z_moved_shm_client_storage_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const z_owned_shm_client_storage_t *this_);
+const struct z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_shm_client_storage_new(z_owned_shm_client_storage_t *this_,
-                                    const zc_loaned_shm_client_list_t *clients,
+z_result_t z_shm_client_storage_new(struct z_owned_shm_client_storage_t *this_,
+                                    const struct zc_loaned_shm_client_list_t *clients,
                                     bool add_default_client_set);
 #endif
 /**
@@ -4030,7 +3817,7 @@ z_result_t z_shm_client_storage_new(z_owned_shm_client_storage_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_client_storage_new_default(z_owned_shm_client_storage_t *this_);
+void z_shm_client_storage_new_default(struct z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4038,8 +3825,8 @@ void z_shm_client_storage_new_default(z_owned_shm_client_storage_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_clone(z_owned_shm_t *out,
-                 const z_loaned_shm_t *this_);
+void z_shm_clone(struct z_owned_shm_t *out,
+                 const struct z_loaned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4047,7 +3834,7 @@ void z_shm_clone(z_owned_shm_t *out,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const unsigned char *z_shm_data(const z_loaned_shm_t *this_);
+const unsigned char *z_shm_data(const struct z_loaned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4055,7 +3842,7 @@ const unsigned char *z_shm_data(const z_loaned_shm_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_drop(z_moved_shm_t *this_);
+void z_shm_drop(struct z_moved_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4063,8 +3850,8 @@ void z_shm_drop(z_moved_shm_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_from_mut(z_owned_shm_t *this_,
-                    z_moved_shm_mut_t *that);
+void z_shm_from_mut(struct z_owned_shm_t *this_,
+                    struct z_moved_shm_mut_t *that);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4072,7 +3859,7 @@ void z_shm_from_mut(z_owned_shm_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-size_t z_shm_len(const z_loaned_shm_t *this_);
+size_t z_shm_len(const struct z_loaned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4080,13 +3867,13 @@ size_t z_shm_len(const z_loaned_shm_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_shm_t *z_shm_loan(const z_owned_shm_t *this_);
+const struct z_loaned_shm_t *z_shm_loan(const struct z_owned_shm_t *this_);
 #endif
 /**
  * @brief Mutably borrows ZShm slice.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
-ZENOHC_API z_loaned_shm_t *z_shm_loan_mut(z_owned_shm_t *this_);
+ZENOHC_API struct z_loaned_shm_t *z_shm_loan_mut(struct z_owned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4094,7 +3881,7 @@ ZENOHC_API z_loaned_shm_t *z_shm_loan_mut(z_owned_shm_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const unsigned char *z_shm_mut_data(const z_loaned_shm_mut_t *this_);
+const unsigned char *z_shm_mut_data(const struct z_loaned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4102,7 +3889,7 @@ const unsigned char *z_shm_mut_data(const z_loaned_shm_mut_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-unsigned char *z_shm_mut_data_mut(z_loaned_shm_mut_t *this_);
+unsigned char *z_shm_mut_data_mut(struct z_loaned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4110,7 +3897,7 @@ unsigned char *z_shm_mut_data_mut(z_loaned_shm_mut_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_mut_drop(z_moved_shm_mut_t *this_);
+void z_shm_mut_drop(struct z_moved_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4118,7 +3905,7 @@ void z_shm_mut_drop(z_moved_shm_mut_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-size_t z_shm_mut_len(const z_loaned_shm_mut_t *this_);
+size_t z_shm_mut_len(const struct z_loaned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4126,7 +3913,7 @@ size_t z_shm_mut_len(const z_loaned_shm_mut_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_shm_mut_t *z_shm_mut_loan(const z_owned_shm_mut_t *this_);
+const struct z_loaned_shm_mut_t *z_shm_mut_loan(const struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4134,7 +3921,7 @@ const z_loaned_shm_mut_t *z_shm_mut_loan(const z_owned_shm_mut_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_loaned_shm_mut_t *z_shm_mut_loan_mut(z_owned_shm_mut_t *this_);
+struct z_loaned_shm_mut_t *z_shm_mut_loan_mut(struct z_owned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4148,9 +3935,9 @@ z_loaned_shm_mut_t *z_shm_mut_loan_mut(z_owned_shm_mut_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_shm_mut_try_from_immut(z_owned_shm_mut_t *this_,
-                                    z_moved_shm_t *that,
-                                    z_owned_shm_t *immut);
+z_result_t z_shm_mut_try_from_immut(struct z_owned_shm_mut_t *this_,
+                                    struct z_moved_shm_t *that,
+                                    struct z_owned_shm_t *immut);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4158,7 +3945,7 @@ z_result_t z_shm_mut_try_from_immut(z_owned_shm_mut_t *this_,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc(struct z_buf_layout_alloc_result_t *out_result,
-                          const z_loaned_shm_provider_t *provider,
+                          const struct z_loaned_shm_provider_t *provider,
                           size_t size,
                           struct z_alloc_alignment_t alignment);
 #endif
@@ -4168,7 +3955,7 @@ void z_shm_provider_alloc(struct z_buf_layout_alloc_result_t *out_result,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc(struct z_buf_layout_alloc_result_t *out_result,
-                             const z_loaned_shm_provider_t *provider,
+                             const struct z_loaned_shm_provider_t *provider,
                              size_t size,
                              struct z_alloc_alignment_t alignment);
 #endif
@@ -4178,7 +3965,7 @@ void z_shm_provider_alloc_gc(struct z_buf_layout_alloc_result_t *out_result,
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag(struct z_buf_layout_alloc_result_t *out_result,
-                                    const z_loaned_shm_provider_t *provider,
+                                    const struct z_loaned_shm_provider_t *provider,
                                     size_t size,
                                     struct z_alloc_alignment_t alignment);
 #endif
@@ -4188,7 +3975,7 @@ void z_shm_provider_alloc_gc_defrag(struct z_buf_layout_alloc_result_t *out_resu
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result_t *out_result,
-                                                const z_loaned_shm_provider_t *provider,
+                                                const struct z_loaned_shm_provider_t *provider,
                                                 size_t size,
                                                 struct z_alloc_alignment_t alignment,
                                                 struct zc_threadsafe_context_t result_context,
@@ -4201,7 +3988,7 @@ z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_blocking(struct z_buf_layout_alloc_result_t *out_result,
-                                             const z_loaned_shm_provider_t *provider,
+                                             const struct z_loaned_shm_provider_t *provider,
                                              size_t size,
                                              struct z_alloc_alignment_t alignment);
 #endif
@@ -4211,7 +3998,7 @@ void z_shm_provider_alloc_gc_defrag_blocking(struct z_buf_layout_alloc_result_t 
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_dealloc(struct z_buf_layout_alloc_result_t *out_result,
-                                            const z_loaned_shm_provider_t *provider,
+                                            const struct z_loaned_shm_provider_t *provider,
                                             size_t size,
                                             struct z_alloc_alignment_t alignment);
 #endif
@@ -4220,14 +4007,14 @@ void z_shm_provider_alloc_gc_defrag_dealloc(struct z_buf_layout_alloc_result_t *
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-size_t z_shm_provider_available(const z_loaned_shm_provider_t *provider);
+size_t z_shm_provider_available(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-size_t z_shm_provider_defragment(const z_loaned_shm_provider_t *provider);
+size_t z_shm_provider_defragment(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4235,14 +4022,14 @@ size_t z_shm_provider_defragment(const z_loaned_shm_provider_t *provider);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_drop(z_moved_shm_provider_t *this_);
+void z_shm_provider_drop(struct z_moved_shm_provider_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-size_t z_shm_provider_garbage_collect(const z_loaned_shm_provider_t *provider);
+size_t z_shm_provider_garbage_collect(const struct z_loaned_shm_provider_t *provider);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4250,15 +4037,15 @@ size_t z_shm_provider_garbage_collect(const z_loaned_shm_provider_t *provider);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const z_loaned_shm_provider_t *z_shm_provider_loan(const z_owned_shm_provider_t *this_);
+const struct z_loaned_shm_provider_t *z_shm_provider_loan(const struct z_owned_shm_provider_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t z_shm_provider_map(z_owned_shm_mut_t *out_result,
-                              const z_loaned_shm_provider_t *provider,
+z_result_t z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
+                              const struct z_loaned_shm_provider_t *provider,
                               struct z_allocated_chunk_t allocated_chunk,
                               size_t len);
 #endif
@@ -4268,7 +4055,7 @@ z_result_t z_shm_provider_map(z_owned_shm_mut_t *out_result,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_new(z_owned_shm_provider_t *this_,
+void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
                         z_protocol_id_t id,
                         struct zc_context_t context,
                         struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -4279,7 +4066,7 @@ void z_shm_provider_new(z_owned_shm_provider_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
+void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
                                    z_protocol_id_t id,
                                    struct zc_threadsafe_context_t context,
                                    struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -4290,7 +4077,7 @@ void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_loaned_shm_mut_t *z_shm_try_mut(z_owned_shm_t *this_);
+struct z_loaned_shm_mut_t *z_shm_try_mut(struct z_owned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4298,7 +4085,7 @@ z_loaned_shm_mut_t *z_shm_try_mut(z_owned_shm_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_loaned_shm_mut_t *z_shm_try_reloan_mut(z_loaned_shm_t *this_);
+struct z_loaned_shm_mut_t *z_shm_try_reloan_mut(struct z_loaned_shm_t *this_);
 #endif
 /**
  * Puts current thread to sleep for specified amount of milliseconds.
@@ -4371,7 +4158,7 @@ ZENOHC_API const struct z_loaned_slice_t *z_slice_loan(const struct z_owned_slic
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void z_source_info_drop(z_moved_source_info_t *this_);
+void z_source_info_drop(struct z_moved_source_info_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4379,7 +4166,7 @@ void z_source_info_drop(z_moved_source_info_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_entity_global_id_t z_source_info_id(const z_loaned_source_info_t *this_);
+struct z_entity_global_id_t z_source_info_id(const struct z_loaned_source_info_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4387,7 +4174,7 @@ z_entity_global_id_t z_source_info_id(const z_loaned_source_info_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const z_loaned_source_info_t *z_source_info_loan(const z_owned_source_info_t *this_);
+const struct z_loaned_source_info_t *z_source_info_loan(const struct z_owned_source_info_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4395,9 +4182,9 @@ const z_loaned_source_info_t *z_source_info_loan(const z_owned_source_info_t *th
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t z_source_info_new(z_owned_source_info_t *this_,
-                             const z_entity_global_id_t *source_id,
-                             uint64_t source_sn);
+z_result_t z_source_info_new(struct z_owned_source_info_t *this_,
+                             const struct z_entity_global_id_t *source_id,
+                             SourceSn source_sn);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4405,7 +4192,7 @@ z_result_t z_source_info_new(z_owned_source_info_t *this_,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-uint64_t z_source_info_sn(const z_loaned_source_info_t *this_);
+SourceSn z_source_info_sn(const struct z_loaned_source_info_t *this_);
 #endif
 /**
  * Constructs an owned copy of a string array.
@@ -4599,7 +4386,7 @@ const char *z_time_now_as_str(const char *buf,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
+struct z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
 #endif
 /**
  * Create uhlc timestamp from session id.
@@ -4940,7 +4727,7 @@ void zc_internal_closure_matching_status_null(struct zc_owned_closure_matching_s
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-bool zc_internal_liveliness_token_check(const zc_owned_liveliness_token_t *this_);
+bool zc_internal_liveliness_token_check(const struct zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4948,7 +4735,7 @@ bool zc_internal_liveliness_token_check(const zc_owned_liveliness_token_t *this_
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void zc_internal_liveliness_token_null(zc_owned_liveliness_token_t *this_);
+void zc_internal_liveliness_token_null(struct zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4956,7 +4743,7 @@ void zc_internal_liveliness_token_null(zc_owned_liveliness_token_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-bool zc_internal_matching_listener_check(const zc_owned_matching_listener_t *this_);
+bool zc_internal_matching_listener_check(const struct zc_owned_matching_listener_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4964,7 +4751,7 @@ bool zc_internal_matching_listener_check(const zc_owned_matching_listener_t *thi
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void zc_internal_matching_listener_null(zc_owned_matching_listener_t *this_);
+void zc_internal_matching_listener_null(struct zc_owned_matching_listener_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4972,7 +4759,7 @@ void zc_internal_matching_listener_null(zc_owned_matching_listener_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-bool zc_internal_shm_client_list_check(const zc_owned_shm_client_list_t *this_);
+bool zc_internal_shm_client_list_check(const struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4980,7 +4767,7 @@ bool zc_internal_shm_client_list_check(const zc_owned_shm_client_list_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void zc_internal_shm_client_list_null(zc_owned_shm_client_list_t *this_);
+void zc_internal_shm_client_list_null(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5024,7 +4811,7 @@ z_result_t zc_liveliness_declare_subscriber(struct z_owned_subscriber_t *this_,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_liveliness_declare_token(zc_owned_liveliness_token_t *this_,
+z_result_t zc_liveliness_declare_token(struct zc_owned_liveliness_token_t *this_,
                                        const struct z_loaned_session_t *session,
                                        const struct z_loaned_keyexpr_t *key_expr,
                                        const struct zc_liveliness_declaration_options_t *_options);
@@ -5067,7 +4854,7 @@ void zc_liveliness_subscriber_options_default(struct zc_liveliness_subscriber_op
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void zc_liveliness_token_drop(zc_moved_liveliness_token_t *this_);
+void zc_liveliness_token_drop(struct zc_moved_liveliness_token_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5075,7 +4862,7 @@ void zc_liveliness_token_drop(zc_moved_liveliness_token_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const zc_owned_liveliness_token_t *this_);
+const struct zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const struct zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5083,7 +4870,7 @@ const zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const zc_owned_live
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_liveliness_undeclare_token(zc_moved_liveliness_token_t *this_);
+z_result_t zc_liveliness_undeclare_token(struct zc_moved_liveliness_token_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5116,7 +4903,7 @@ z_result_t zc_publisher_get_matching_status(const struct z_loaned_publisher_t *t
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_publisher_matching_listener_declare(zc_owned_matching_listener_t *this_,
+z_result_t zc_publisher_matching_listener_declare(struct zc_owned_matching_listener_t *this_,
                                                   const struct z_loaned_publisher_t *publisher,
                                                   struct zc_moved_closure_matching_status_t *callback);
 #endif
@@ -5126,7 +4913,7 @@ z_result_t zc_publisher_matching_listener_declare(zc_owned_matching_listener_t *
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void zc_publisher_matching_listener_drop(zc_moved_matching_listener_t *this_);
+void zc_publisher_matching_listener_drop(struct zc_moved_matching_listener_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5136,7 +4923,7 @@ void zc_publisher_matching_listener_drop(zc_moved_matching_listener_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t zc_publisher_matching_listener_undeclare(zc_moved_matching_listener_t *this_);
+z_result_t zc_publisher_matching_listener_undeclare(struct zc_moved_matching_listener_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5151,9 +4938,9 @@ enum zc_reply_keyexpr_t zc_reply_keyexpr_default(void);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-z_result_t zc_shm_client_list_add_client(zc_loaned_shm_client_list_t *this_,
+z_result_t zc_shm_client_list_add_client(struct zc_loaned_shm_client_list_t *this_,
                                          z_protocol_id_t id,
-                                         z_moved_shm_client_t *client);
+                                         struct z_moved_shm_client_t *client);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5161,7 +4948,7 @@ z_result_t zc_shm_client_list_add_client(zc_loaned_shm_client_list_t *this_,
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void zc_shm_client_list_drop(zc_moved_shm_client_list_t *this_);
+void zc_shm_client_list_drop(struct zc_moved_shm_client_list_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5169,7 +4956,7 @@ void zc_shm_client_list_drop(zc_moved_shm_client_list_t *this_);
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-const zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const zc_owned_shm_client_list_t *this_);
+const struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5177,7 +4964,7 @@ const zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const zc_owned_shm_cl
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(zc_owned_shm_client_list_t *this_);
+struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5185,7 +4972,7 @@ zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(zc_owned_shm_client_lis
  */
 #if (defined(SHARED_MEMORY) && defined(UNSTABLE))
 ZENOHC_API
-void zc_shm_client_list_new(zc_owned_shm_client_list_t *this_);
+void zc_shm_client_list_new(struct zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Stops all Zenoh tasks and drops all related static variables.
@@ -5208,7 +4995,7 @@ void zc_stop_z_runtime(void);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_declare_publication_cache(ze_owned_publication_cache_t *this_,
+z_result_t ze_declare_publication_cache(struct ze_owned_publication_cache_t *this_,
                                         const struct z_loaned_session_t *session,
                                         const struct z_loaned_keyexpr_t *key_expr,
                                         struct ze_publication_cache_options_t *options);
@@ -5227,7 +5014,7 @@ z_result_t ze_declare_publication_cache(ze_owned_publication_cache_t *this_,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_declare_querying_subscriber(ze_owned_querying_subscriber_t *this_,
+z_result_t ze_declare_querying_subscriber(struct ze_owned_querying_subscriber_t *this_,
                                           const struct z_loaned_session_t *session,
                                           const struct z_loaned_keyexpr_t *key_expr,
                                           struct z_moved_closure_sample_t *callback,
@@ -5239,7 +5026,7 @@ z_result_t ze_declare_querying_subscriber(ze_owned_querying_subscriber_t *this_,
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-bool ze_internal_publication_cache_check(const ze_owned_publication_cache_t *this_);
+bool ze_internal_publication_cache_check(const struct ze_owned_publication_cache_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5247,7 +5034,7 @@ bool ze_internal_publication_cache_check(const ze_owned_publication_cache_t *thi
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void ze_internal_publication_cache_null(ze_owned_publication_cache_t *this_);
+void ze_internal_publication_cache_null(struct ze_owned_publication_cache_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5255,13 +5042,13 @@ void ze_internal_publication_cache_null(ze_owned_publication_cache_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-bool ze_internal_querying_subscriber_check(const ze_owned_querying_subscriber_t *this_);
+bool ze_internal_querying_subscriber_check(const struct ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Constructs a querying subscriber in a gravestone state.
  */
 #if defined(UNSTABLE)
-ZENOHC_API void ze_internal_querying_subscriber_null(ze_owned_querying_subscriber_t *this_);
+ZENOHC_API void ze_internal_querying_subscriber_null(struct ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5269,7 +5056,7 @@ ZENOHC_API void ze_internal_querying_subscriber_null(ze_owned_querying_subscribe
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void ze_publication_cache_drop(ze_moved_publication_cache_t *this_);
+void ze_publication_cache_drop(struct ze_moved_publication_cache_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5277,7 +5064,7 @@ void ze_publication_cache_drop(ze_moved_publication_cache_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const struct z_loaned_keyexpr_t *ze_publication_cache_keyexpr(const ze_loaned_publication_cache_t *this_);
+const struct z_loaned_keyexpr_t *ze_publication_cache_keyexpr(const struct ze_loaned_publication_cache_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5285,7 +5072,7 @@ const struct z_loaned_keyexpr_t *ze_publication_cache_keyexpr(const ze_loaned_pu
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const ze_loaned_publication_cache_t *ze_publication_cache_loan(const ze_owned_publication_cache_t *this_);
+const struct ze_loaned_publication_cache_t *ze_publication_cache_loan(const struct ze_owned_publication_cache_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5302,7 +5089,7 @@ void ze_publication_cache_options_default(struct ze_publication_cache_options_t 
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-void ze_querying_subscriber_drop(ze_moved_querying_subscriber_t *this_);
+void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5312,7 +5099,7 @@ void ze_querying_subscriber_drop(ze_moved_querying_subscriber_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_querying_subscriber_get(const ze_loaned_querying_subscriber_t *this_,
+z_result_t ze_querying_subscriber_get(const struct ze_loaned_querying_subscriber_t *this_,
                                       const struct z_loaned_keyexpr_t *selector,
                                       struct z_get_options_t *options);
 #endif
@@ -5322,7 +5109,7 @@ z_result_t ze_querying_subscriber_get(const ze_loaned_querying_subscriber_t *thi
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-const ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const ze_owned_querying_subscriber_t *this_);
+const struct ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const struct ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5339,7 +5126,7 @@ void ze_querying_subscriber_options_default(struct ze_querying_subscriber_option
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_undeclare_publication_cache(ze_moved_publication_cache_t *this_);
+z_result_t ze_undeclare_publication_cache(struct ze_moved_publication_cache_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5349,5 +5136,5 @@ z_result_t ze_undeclare_publication_cache(ze_moved_publication_cache_t *this_);
  */
 #if defined(UNSTABLE)
 ZENOHC_API
-z_result_t ze_undeclare_querying_subscriber(ze_moved_querying_subscriber_t *this_);
+z_result_t ze_undeclare_querying_subscriber(struct ze_moved_querying_subscriber_t *this_);
 #endif

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -4,11 +4,14 @@
 
 #ifndef __cplusplus
 
+static inline z_moved_alloc_layout_t* z_alloc_layout_move(z_owned_alloc_layout_t* x) { return (z_moved_alloc_layout_t*)(x); }
 static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return (z_moved_bytes_t*)(x); }
+static inline z_moved_chunk_alloc_result_t* z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return (z_moved_chunk_alloc_result_t*)(x); }
 static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return (z_moved_closure_hello_t*)(x); }
 static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return (z_moved_closure_query_t*)(x); }
 static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return (z_moved_closure_reply_t*)(x); }
 static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return (z_moved_closure_sample_t*)(x); }
+static inline z_moved_closure_zid_t* z_closure_zid_move(z_owned_closure_zid_t* x) { return (z_moved_closure_zid_t*)(x); }
 static inline z_moved_condvar_t* z_condvar_move(z_owned_condvar_t* x) { return (z_moved_condvar_t*)(x); }
 static inline z_moved_config_t* z_config_move(z_owned_config_t* x) { return (z_moved_config_t*)(x); }
 static inline z_moved_encoding_t* z_encoding_move(z_owned_encoding_t* x) { return (z_moved_encoding_t*)(x); }
@@ -17,6 +20,7 @@ static inline z_moved_fifo_handler_reply_t* z_fifo_handler_reply_move(z_owned_fi
 static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return (z_moved_fifo_handler_sample_t*)(x); }
 static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return (z_moved_hello_t*)(x); }
 static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return (z_moved_keyexpr_t*)(x); }
+static inline z_moved_memory_layout_t* z_memory_layout_move(z_owned_memory_layout_t* x) { return (z_moved_memory_layout_t*)(x); }
 static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return (z_moved_mutex_t*)(x); }
 static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return (z_moved_publisher_t*)(x); }
 static inline z_moved_query_t* z_query_move(z_owned_query_t* x) { return (z_moved_query_t*)(x); }
@@ -28,21 +32,36 @@ static inline z_moved_ring_handler_reply_t* z_ring_handler_reply_move(z_owned_ri
 static inline z_moved_ring_handler_sample_t* z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return (z_moved_ring_handler_sample_t*)(x); }
 static inline z_moved_sample_t* z_sample_move(z_owned_sample_t* x) { return (z_moved_sample_t*)(x); }
 static inline z_moved_session_t* z_session_move(z_owned_session_t* x) { return (z_moved_session_t*)(x); }
+static inline z_moved_shm_client_t* z_shm_client_move(z_owned_shm_client_t* x) { return (z_moved_shm_client_t*)(x); }
+static inline z_moved_shm_client_storage_t* z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return (z_moved_shm_client_storage_t*)(x); }
+static inline z_moved_shm_t* z_shm_move(z_owned_shm_t* x) { return (z_moved_shm_t*)(x); }
+static inline z_moved_shm_mut_t* z_shm_mut_move(z_owned_shm_mut_t* x) { return (z_moved_shm_mut_t*)(x); }
+static inline z_moved_shm_provider_t* z_shm_provider_move(z_owned_shm_provider_t* x) { return (z_moved_shm_provider_t*)(x); }
 static inline z_moved_slice_t* z_slice_move(z_owned_slice_t* x) { return (z_moved_slice_t*)(x); }
+static inline z_moved_source_info_t* z_source_info_move(z_owned_source_info_t* x) { return (z_moved_source_info_t*)(x); }
 static inline z_moved_string_array_t* z_string_array_move(z_owned_string_array_t* x) { return (z_moved_string_array_t*)(x); }
 static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return (z_moved_string_t*)(x); }
 static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return (z_moved_subscriber_t*)(x); }
 static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return (z_moved_task_t*)(x); }
 static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return (zc_moved_closure_log_t*)(x); }
+static inline zc_moved_closure_matching_status_t* zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return (zc_moved_closure_matching_status_t*)(x); }
+static inline zc_moved_liveliness_token_t* zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return (zc_moved_liveliness_token_t*)(x); }
+static inline zc_moved_matching_listener_t* zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return (zc_moved_matching_listener_t*)(x); }
+static inline zc_moved_shm_client_list_t* zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return (zc_moved_shm_client_list_t*)(x); }
+static inline ze_moved_publication_cache_t* ze_publication_cache_move(ze_owned_publication_cache_t* x) { return (ze_moved_publication_cache_t*)(x); }
+static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return (ze_moved_querying_subscriber_t*)(x); }
 
 
 #define z_loan(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t : z_alloc_layout_loan, \
         z_owned_bytes_t : z_bytes_loan, \
+        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_loan, \
         z_owned_closure_hello_t : z_closure_hello_loan, \
         z_owned_closure_query_t : z_closure_query_loan, \
         z_owned_closure_reply_t : z_closure_reply_loan, \
         z_owned_closure_sample_t : z_closure_sample_loan, \
+        z_owned_closure_zid_t : z_closure_zid_loan, \
         z_owned_condvar_t : z_condvar_loan, \
         z_owned_config_t : z_config_loan, \
         z_owned_encoding_t : z_encoding_loan, \
@@ -51,6 +70,7 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_loan, \
         z_owned_hello_t : z_hello_loan, \
         z_owned_keyexpr_t : z_keyexpr_loan, \
+        z_owned_memory_layout_t : z_memory_layout_loan, \
         z_owned_publisher_t : z_publisher_loan, \
         z_owned_query_t : z_query_loan, \
         z_owned_queryable_t : z_queryable_loan, \
@@ -61,14 +81,24 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_ring_handler_sample_t : z_ring_handler_sample_loan, \
         z_owned_sample_t : z_sample_loan, \
         z_owned_session_t : z_session_loan, \
+        z_owned_shm_client_storage_t : z_shm_client_storage_loan, \
+        z_owned_shm_t : z_shm_loan, \
+        z_owned_shm_mut_t : z_shm_mut_loan, \
+        z_owned_shm_provider_t : z_shm_provider_loan, \
         z_owned_slice_t : z_slice_loan, \
+        z_owned_source_info_t : z_source_info_loan, \
         z_owned_string_array_t : z_string_array_loan, \
         z_owned_string_t : z_string_loan, \
         z_owned_subscriber_t : z_subscriber_loan, \
         z_view_keyexpr_t : z_view_keyexpr_loan, \
         z_view_slice_t : z_view_slice_loan, \
         z_view_string_t : z_view_string_loan, \
-        zc_owned_closure_log_t : zc_closure_log_loan \
+        zc_owned_closure_log_t : zc_closure_log_loan, \
+        zc_owned_closure_matching_status_t : zc_closure_matching_status_loan, \
+        zc_owned_liveliness_token_t : zc_liveliness_token_loan, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_loan, \
+        ze_owned_publication_cache_t : ze_publication_cache_loan, \
+        ze_owned_querying_subscriber_t : ze_querying_subscriber_loan \
     )(&this_)
 
 #define z_loan_mut(this_) \
@@ -79,16 +109,22 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_encoding_t : z_encoding_loan_mut, \
         z_owned_mutex_t : z_mutex_loan_mut, \
         z_owned_publisher_t : z_publisher_loan_mut, \
-        z_owned_string_array_t : z_string_array_loan_mut \
+        z_owned_shm_t : z_shm_loan_mut, \
+        z_owned_shm_mut_t : z_shm_mut_loan_mut, \
+        z_owned_string_array_t : z_string_array_loan_mut, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_loan_mut \
     )(&this_)
 
 #define z_drop(this_) \
     _Generic((this_), \
+        z_moved_alloc_layout_t* : z_alloc_layout_drop, \
         z_moved_bytes_t* : z_bytes_drop, \
+        z_moved_chunk_alloc_result_t* : z_chunk_alloc_result_drop, \
         z_moved_closure_hello_t* : z_closure_hello_drop, \
         z_moved_closure_query_t* : z_closure_query_drop, \
         z_moved_closure_reply_t* : z_closure_reply_drop, \
         z_moved_closure_sample_t* : z_closure_sample_drop, \
+        z_moved_closure_zid_t* : z_closure_zid_drop, \
         z_moved_condvar_t* : z_condvar_drop, \
         z_moved_config_t* : z_config_drop, \
         z_moved_encoding_t* : z_encoding_drop, \
@@ -97,6 +133,7 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_moved_fifo_handler_sample_t* : z_fifo_handler_sample_drop, \
         z_moved_hello_t* : z_hello_drop, \
         z_moved_keyexpr_t* : z_keyexpr_drop, \
+        z_moved_memory_layout_t* : z_memory_layout_drop, \
         z_moved_mutex_t* : z_mutex_drop, \
         z_moved_publisher_t* : z_publisher_drop, \
         z_moved_query_t* : z_query_drop, \
@@ -108,21 +145,36 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_moved_ring_handler_sample_t* : z_ring_handler_sample_drop, \
         z_moved_sample_t* : z_sample_drop, \
         z_moved_session_t* : z_session_drop, \
+        z_moved_shm_client_t* : z_shm_client_drop, \
+        z_moved_shm_client_storage_t* : z_shm_client_storage_drop, \
+        z_moved_shm_t* : z_shm_drop, \
+        z_moved_shm_mut_t* : z_shm_mut_drop, \
+        z_moved_shm_provider_t* : z_shm_provider_drop, \
         z_moved_slice_t* : z_slice_drop, \
+        z_moved_source_info_t* : z_source_info_drop, \
         z_moved_string_array_t* : z_string_array_drop, \
         z_moved_string_t* : z_string_drop, \
         z_moved_subscriber_t* : z_subscriber_drop, \
         z_moved_task_t* : z_task_drop, \
-        zc_moved_closure_log_t* : zc_closure_log_drop \
+        zc_moved_closure_log_t* : zc_closure_log_drop, \
+        zc_moved_closure_matching_status_t* : zc_closure_matching_status_drop, \
+        zc_moved_liveliness_token_t* : zc_liveliness_token_drop, \
+        zc_moved_matching_listener_t* : zc_publisher_matching_listener_drop, \
+        zc_moved_shm_client_list_t* : zc_shm_client_list_drop, \
+        ze_moved_publication_cache_t* : ze_publication_cache_drop, \
+        ze_moved_querying_subscriber_t* : ze_querying_subscriber_drop \
     )(this_)
 
 #define z_move(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t : z_alloc_layout_move, \
         z_owned_bytes_t : z_bytes_move, \
+        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_move, \
         z_owned_closure_hello_t : z_closure_hello_move, \
         z_owned_closure_query_t : z_closure_query_move, \
         z_owned_closure_reply_t : z_closure_reply_move, \
         z_owned_closure_sample_t : z_closure_sample_move, \
+        z_owned_closure_zid_t : z_closure_zid_move, \
         z_owned_condvar_t : z_condvar_move, \
         z_owned_config_t : z_config_move, \
         z_owned_encoding_t : z_encoding_move, \
@@ -131,6 +183,7 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_move, \
         z_owned_hello_t : z_hello_move, \
         z_owned_keyexpr_t : z_keyexpr_move, \
+        z_owned_memory_layout_t : z_memory_layout_move, \
         z_owned_mutex_t : z_mutex_move, \
         z_owned_publisher_t : z_publisher_move, \
         z_owned_query_t : z_query_move, \
@@ -142,21 +195,36 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_ring_handler_sample_t : z_ring_handler_sample_move, \
         z_owned_sample_t : z_sample_move, \
         z_owned_session_t : z_session_move, \
+        z_owned_shm_client_t : z_shm_client_move, \
+        z_owned_shm_client_storage_t : z_shm_client_storage_move, \
+        z_owned_shm_t : z_shm_move, \
+        z_owned_shm_mut_t : z_shm_mut_move, \
+        z_owned_shm_provider_t : z_shm_provider_move, \
         z_owned_slice_t : z_slice_move, \
+        z_owned_source_info_t : z_source_info_move, \
         z_owned_string_array_t : z_string_array_move, \
         z_owned_string_t : z_string_move, \
         z_owned_subscriber_t : z_subscriber_move, \
         z_owned_task_t : z_task_move, \
-        zc_owned_closure_log_t : zc_closure_log_move \
+        zc_owned_closure_log_t : zc_closure_log_move, \
+        zc_owned_closure_matching_status_t : zc_closure_matching_status_move, \
+        zc_owned_liveliness_token_t : zc_liveliness_token_move, \
+        zc_owned_matching_listener_t : zc_publisher_matching_listener_move, \
+        zc_owned_shm_client_list_t : zc_shm_client_list_move, \
+        ze_owned_publication_cache_t : ze_publication_cache_move, \
+        ze_owned_querying_subscriber_t : ze_querying_subscriber_move \
     )(&this_)
 
 #define z_internal_null(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t* : z_internal_alloc_layout_null, \
         z_owned_bytes_t* : z_internal_bytes_null, \
+        z_owned_chunk_alloc_result_t* : z_internal_chunk_alloc_result_null, \
         z_owned_closure_hello_t* : z_internal_closure_hello_null, \
         z_owned_closure_query_t* : z_internal_closure_query_null, \
         z_owned_closure_reply_t* : z_internal_closure_reply_null, \
         z_owned_closure_sample_t* : z_internal_closure_sample_null, \
+        z_owned_closure_zid_t* : z_internal_closure_zid_null, \
         z_owned_condvar_t* : z_internal_condvar_null, \
         z_owned_config_t* : z_internal_config_null, \
         z_owned_encoding_t* : z_internal_encoding_null, \
@@ -165,6 +233,7 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_fifo_handler_sample_t* : z_internal_fifo_handler_sample_null, \
         z_owned_hello_t* : z_internal_hello_null, \
         z_owned_keyexpr_t* : z_internal_keyexpr_null, \
+        z_owned_memory_layout_t* : z_internal_memory_layout_null, \
         z_owned_mutex_t* : z_internal_mutex_null, \
         z_owned_publisher_t* : z_internal_publisher_null, \
         z_owned_query_t* : z_internal_query_null, \
@@ -176,19 +245,34 @@ static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t
         z_owned_ring_handler_sample_t* : z_internal_ring_handler_sample_null, \
         z_owned_sample_t* : z_internal_sample_null, \
         z_owned_session_t* : z_internal_session_null, \
+        z_owned_shm_client_t* : z_internal_shm_client_null, \
+        z_owned_shm_client_storage_t* : z_internal_shm_client_storage_null, \
+        z_owned_shm_mut_t* : z_internal_shm_mut_null, \
+        z_owned_shm_t* : z_internal_shm_null, \
+        z_owned_shm_provider_t* : z_internal_shm_provider_null, \
         z_owned_slice_t* : z_internal_slice_null, \
+        z_owned_source_info_t* : z_internal_source_info_null, \
         z_owned_string_array_t* : z_internal_string_array_null, \
         z_owned_string_t* : z_internal_string_null, \
         z_owned_subscriber_t* : z_internal_subscriber_null, \
         z_owned_task_t* : z_internal_task_null, \
-        zc_owned_closure_log_t* : zc_internal_closure_log_null \
+        zc_owned_closure_log_t* : zc_internal_closure_log_null, \
+        zc_owned_closure_matching_status_t* : zc_internal_closure_matching_status_null, \
+        zc_owned_liveliness_token_t* : zc_internal_liveliness_token_null, \
+        zc_owned_matching_listener_t* : zc_internal_matching_listener_null, \
+        zc_owned_shm_client_list_t* : zc_internal_shm_client_list_null, \
+        ze_owned_publication_cache_t* : ze_internal_publication_cache_null, \
+        ze_owned_querying_subscriber_t* : ze_internal_querying_subscriber_null \
     )(this_)
 
+static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) { *this_ = x->_this; z_internal_alloc_layout_null(&x->_this); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *this_ = x->_this; z_internal_bytes_null(&x->_this); }
+static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) { *this_ = x->_this; z_internal_chunk_alloc_result_null(&x->_this); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_internal_closure_hello_null(&x->_this); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_internal_closure_query_null(&x->_this); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_internal_closure_reply_null(&x->_this); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_internal_closure_sample_null(&x->_this); }
+static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) { *closure_ = x->_this; z_internal_closure_zid_null(&x->_this); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) { *this_ = x->_this; z_internal_condvar_null(&x->_this); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t* x) { *this_ = x->_this; z_internal_config_null(&x->_this); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t* x) { *this_ = x->_this; z_internal_encoding_null(&x->_this); }
@@ -197,6 +281,7 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t* x) { *this_ = x->_this; z_internal_fifo_handler_sample_null(&x->_this); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_internal_hello_null(&x->_this); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_internal_keyexpr_null(&x->_this); }
+static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) { *this_ = x->_this; z_internal_memory_layout_null(&x->_this); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_internal_mutex_null(&x->_this); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_internal_publisher_null(&x->_this); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t* x) { *this_ = x->_this; z_internal_query_null(&x->_this); }
@@ -208,21 +293,36 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t* x) { *this_ = x->_this; z_internal_ring_handler_sample_null(&x->_this); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t* x) { *this_ = x->_this; z_internal_sample_null(&x->_this); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t* x) { *this_ = x->_this; z_internal_session_null(&x->_this); }
+static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) { *this_ = x->_this; z_internal_shm_client_null(&x->_this); }
+static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) { *this_ = x->_this; z_internal_shm_client_storage_null(&x->_this); }
+static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t* x) { *this_ = x->_this; z_internal_shm_null(&x->_this); }
+static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) { *this_ = x->_this; z_internal_shm_mut_null(&x->_this); }
+static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) { *this_ = x->_this; z_internal_shm_provider_null(&x->_this); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t* x) { *this_ = x->_this; z_internal_slice_null(&x->_this); }
+static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) { *this_ = x->_this; z_internal_source_info_null(&x->_this); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) { *this_ = x->_this; z_internal_string_array_null(&x->_this); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) { *this_ = x->_this; z_internal_string_null(&x->_this); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_internal_subscriber_null(&x->_this); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_internal_task_null(&x->_this); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_internal_closure_log_null(&x->_this); }
+static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) { *closure_ = x->_this; zc_internal_closure_matching_status_null(&x->_this); }
+static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) { *this_ = x->_this; zc_internal_liveliness_token_null(&x->_this); }
+static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) { *this_ = x->_this; zc_internal_matching_listener_null(&x->_this); }
+static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) { *this_ = x->_this; zc_internal_shm_client_list_null(&x->_this); }
+static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) { *this_ = x->_this; ze_internal_publication_cache_null(&x->_this); }
+static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) { *this_ = x->_this; ze_internal_querying_subscriber_null(&x->_this); }
 
 
 #define z_take(this_, x) \
     _Generic((this_), \
+        z_owned_alloc_layout_t* : z_alloc_layout_take, \
         z_owned_bytes_t* : z_bytes_take, \
+        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_take, \
         z_owned_closure_hello_t* : z_closure_hello_take, \
         z_owned_closure_query_t* : z_closure_query_take, \
         z_owned_closure_reply_t* : z_closure_reply_take, \
         z_owned_closure_sample_t* : z_closure_sample_take, \
+        z_owned_closure_zid_t* : z_closure_zid_take, \
         z_owned_condvar_t* : z_condvar_take, \
         z_owned_config_t* : z_config_take, \
         z_owned_encoding_t* : z_encoding_take, \
@@ -231,6 +331,7 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_take, \
         z_owned_hello_t* : z_hello_take, \
         z_owned_keyexpr_t* : z_keyexpr_take, \
+        z_owned_memory_layout_t* : z_memory_layout_take, \
         z_owned_mutex_t* : z_mutex_take, \
         z_owned_publisher_t* : z_publisher_take, \
         z_owned_query_t* : z_query_take, \
@@ -242,21 +343,36 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_take, \
         z_owned_sample_t* : z_sample_take, \
         z_owned_session_t* : z_session_take, \
+        z_owned_shm_client_t* : z_shm_client_take, \
+        z_owned_shm_client_storage_t* : z_shm_client_storage_take, \
+        z_owned_shm_t* : z_shm_take, \
+        z_owned_shm_mut_t* : z_shm_mut_take, \
+        z_owned_shm_provider_t* : z_shm_provider_take, \
         z_owned_slice_t* : z_slice_take, \
+        z_owned_source_info_t* : z_source_info_take, \
         z_owned_string_array_t* : z_string_array_take, \
         z_owned_string_t* : z_string_take, \
         z_owned_subscriber_t* : z_subscriber_take, \
         z_owned_task_t* : z_task_take, \
-        zc_owned_closure_log_t* : zc_closure_log_take \
+        zc_owned_closure_log_t* : zc_closure_log_take, \
+        zc_owned_closure_matching_status_t* : zc_closure_matching_status_take, \
+        zc_owned_liveliness_token_t* : zc_liveliness_token_take, \
+        zc_owned_matching_listener_t* : zc_publisher_matching_listener_take, \
+        zc_owned_shm_client_list_t* : zc_shm_client_list_take, \
+        ze_owned_publication_cache_t* : ze_publication_cache_take, \
+        ze_owned_querying_subscriber_t* : ze_querying_subscriber_take \
     )(this_, x)
 
 #define z_internal_check(this_) \
     _Generic((this_), \
+        z_owned_alloc_layout_t : z_internal_alloc_layout_check, \
         z_owned_bytes_t : z_internal_bytes_check, \
+        z_owned_chunk_alloc_result_t : z_internal_chunk_alloc_result_check, \
         z_owned_closure_hello_t : z_internal_closure_hello_check, \
         z_owned_closure_query_t : z_internal_closure_query_check, \
         z_owned_closure_reply_t : z_internal_closure_reply_check, \
         z_owned_closure_sample_t : z_internal_closure_sample_check, \
+        z_owned_closure_zid_t : z_internal_closure_zid_check, \
         z_owned_condvar_t : z_internal_condvar_check, \
         z_owned_config_t : z_internal_config_check, \
         z_owned_encoding_t : z_internal_encoding_check, \
@@ -265,6 +381,7 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         z_owned_fifo_handler_sample_t : z_internal_fifo_handler_sample_check, \
         z_owned_hello_t : z_internal_hello_check, \
         z_owned_keyexpr_t : z_internal_keyexpr_check, \
+        z_owned_memory_layout_t : z_internal_memory_layout_check, \
         z_owned_mutex_t : z_internal_mutex_check, \
         z_owned_publisher_t : z_internal_publisher_check, \
         z_owned_query_t : z_internal_query_check, \
@@ -276,12 +393,24 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         z_owned_ring_handler_sample_t : z_internal_ring_handler_sample_check, \
         z_owned_sample_t : z_internal_sample_check, \
         z_owned_session_t : z_internal_session_check, \
+        z_owned_shm_t : z_internal_shm_check, \
+        z_owned_shm_client_t : z_internal_shm_client_check, \
+        z_owned_shm_client_storage_t : z_internal_shm_client_storage_check, \
+        z_owned_shm_mut_t : z_internal_shm_mut_check, \
+        z_owned_shm_provider_t : z_internal_shm_provider_check, \
         z_owned_slice_t : z_internal_slice_check, \
+        z_owned_source_info_t : z_internal_source_info_check, \
         z_owned_string_array_t : z_internal_string_array_check, \
         z_owned_string_t : z_internal_string_check, \
         z_owned_subscriber_t : z_internal_subscriber_check, \
         z_owned_task_t : z_internal_task_check, \
-        zc_owned_closure_log_t : zc_internal_closure_log_check \
+        zc_owned_closure_log_t : zc_internal_closure_log_check, \
+        zc_owned_closure_matching_status_t : zc_internal_closure_matching_status_check, \
+        zc_owned_liveliness_token_t : zc_internal_liveliness_token_check, \
+        zc_owned_matching_listener_t : zc_internal_matching_listener_check, \
+        zc_owned_shm_client_list_t : zc_internal_shm_client_list_check, \
+        ze_owned_publication_cache_t : ze_internal_publication_cache_check, \
+        ze_owned_querying_subscriber_t : ze_internal_querying_subscriber_check \
     )(&this_)
 
 #define z_call(closure, hello) \
@@ -289,7 +418,9 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         const z_loaned_closure_hello_t* : z_closure_hello_call, \
         const z_loaned_closure_query_t* : z_closure_query_call, \
         const z_loaned_closure_reply_t* : z_closure_reply_call, \
-        const z_loaned_closure_sample_t* : z_closure_sample_call \
+        const z_loaned_closure_sample_t* : z_closure_sample_call, \
+        const z_loaned_closure_zid_t* : z_closure_zid_call, \
+        const zc_loaned_closure_matching_status_t* : zc_closure_matching_status_call \
     )(closure, hello)
 
 #define z_closure(x, callback, dropper, ctx) \
@@ -326,6 +457,8 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
         z_owned_reply_t* : z_reply_clone, \
         z_owned_reply_err_t* : z_reply_err_clone, \
         z_owned_sample_t* : z_sample_clone, \
+        z_owned_shm_client_storage_t* : z_shm_client_storage_clone, \
+        z_owned_shm_t* : z_shm_clone, \
         z_owned_slice_t* : z_slice_clone, \
         z_owned_string_array_t* : z_string_array_clone, \
         z_owned_string_t* : z_string_clone \
@@ -333,11 +466,14 @@ static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_move
 #else  // #ifndef __cplusplus
 
 
+static inline z_moved_alloc_layout_t* z_alloc_layout_move(z_owned_alloc_layout_t* x) { return reinterpret_cast<z_moved_alloc_layout_t*>(x); }
 static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return reinterpret_cast<z_moved_bytes_t*>(x); }
+static inline z_moved_chunk_alloc_result_t* z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return reinterpret_cast<z_moved_chunk_alloc_result_t*>(x); }
 static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return reinterpret_cast<z_moved_closure_hello_t*>(x); }
 static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return reinterpret_cast<z_moved_closure_query_t*>(x); }
 static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return reinterpret_cast<z_moved_closure_reply_t*>(x); }
 static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return reinterpret_cast<z_moved_closure_sample_t*>(x); }
+static inline z_moved_closure_zid_t* z_closure_zid_move(z_owned_closure_zid_t* x) { return reinterpret_cast<z_moved_closure_zid_t*>(x); }
 static inline z_moved_condvar_t* z_condvar_move(z_owned_condvar_t* x) { return reinterpret_cast<z_moved_condvar_t*>(x); }
 static inline z_moved_config_t* z_config_move(z_owned_config_t* x) { return reinterpret_cast<z_moved_config_t*>(x); }
 static inline z_moved_encoding_t* z_encoding_move(z_owned_encoding_t* x) { return reinterpret_cast<z_moved_encoding_t*>(x); }
@@ -346,6 +482,7 @@ static inline z_moved_fifo_handler_reply_t* z_fifo_handler_reply_move(z_owned_fi
 static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return reinterpret_cast<z_moved_fifo_handler_sample_t*>(x); }
 static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return reinterpret_cast<z_moved_hello_t*>(x); }
 static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return reinterpret_cast<z_moved_keyexpr_t*>(x); }
+static inline z_moved_memory_layout_t* z_memory_layout_move(z_owned_memory_layout_t* x) { return reinterpret_cast<z_moved_memory_layout_t*>(x); }
 static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return reinterpret_cast<z_moved_mutex_t*>(x); }
 static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return reinterpret_cast<z_moved_publisher_t*>(x); }
 static inline z_moved_query_t* z_query_move(z_owned_query_t* x) { return reinterpret_cast<z_moved_query_t*>(x); }
@@ -357,20 +494,35 @@ static inline z_moved_ring_handler_reply_t* z_ring_handler_reply_move(z_owned_ri
 static inline z_moved_ring_handler_sample_t* z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return reinterpret_cast<z_moved_ring_handler_sample_t*>(x); }
 static inline z_moved_sample_t* z_sample_move(z_owned_sample_t* x) { return reinterpret_cast<z_moved_sample_t*>(x); }
 static inline z_moved_session_t* z_session_move(z_owned_session_t* x) { return reinterpret_cast<z_moved_session_t*>(x); }
+static inline z_moved_shm_client_t* z_shm_client_move(z_owned_shm_client_t* x) { return reinterpret_cast<z_moved_shm_client_t*>(x); }
+static inline z_moved_shm_client_storage_t* z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return reinterpret_cast<z_moved_shm_client_storage_t*>(x); }
+static inline z_moved_shm_t* z_shm_move(z_owned_shm_t* x) { return reinterpret_cast<z_moved_shm_t*>(x); }
+static inline z_moved_shm_mut_t* z_shm_mut_move(z_owned_shm_mut_t* x) { return reinterpret_cast<z_moved_shm_mut_t*>(x); }
+static inline z_moved_shm_provider_t* z_shm_provider_move(z_owned_shm_provider_t* x) { return reinterpret_cast<z_moved_shm_provider_t*>(x); }
 static inline z_moved_slice_t* z_slice_move(z_owned_slice_t* x) { return reinterpret_cast<z_moved_slice_t*>(x); }
+static inline z_moved_source_info_t* z_source_info_move(z_owned_source_info_t* x) { return reinterpret_cast<z_moved_source_info_t*>(x); }
 static inline z_moved_string_array_t* z_string_array_move(z_owned_string_array_t* x) { return reinterpret_cast<z_moved_string_array_t*>(x); }
 static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return reinterpret_cast<z_moved_string_t*>(x); }
 static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return reinterpret_cast<z_moved_subscriber_t*>(x); }
 static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return reinterpret_cast<z_moved_task_t*>(x); }
 static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return reinterpret_cast<zc_moved_closure_log_t*>(x); }
+static inline zc_moved_closure_matching_status_t* zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return reinterpret_cast<zc_moved_closure_matching_status_t*>(x); }
+static inline zc_moved_liveliness_token_t* zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return reinterpret_cast<zc_moved_liveliness_token_t*>(x); }
+static inline zc_moved_matching_listener_t* zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return reinterpret_cast<zc_moved_matching_listener_t*>(x); }
+static inline zc_moved_shm_client_list_t* zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return reinterpret_cast<zc_moved_shm_client_list_t*>(x); }
+static inline ze_moved_publication_cache_t* ze_publication_cache_move(ze_owned_publication_cache_t* x) { return reinterpret_cast<ze_moved_publication_cache_t*>(x); }
+static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return reinterpret_cast<ze_moved_querying_subscriber_t*>(x); }
 
 
 
+inline const z_loaned_alloc_layout_t* z_loan(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_loan(&this_); };
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& this_) { return z_bytes_loan(&this_); };
+inline const z_loaned_chunk_alloc_result_t* z_loan(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_loan(&this_); };
 inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t& closure) { return z_closure_hello_loan(&closure); };
 inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t& closure) { return z_closure_query_loan(&closure); };
 inline const z_loaned_closure_reply_t* z_loan(const z_owned_closure_reply_t& closure) { return z_closure_reply_loan(&closure); };
 inline const z_loaned_closure_sample_t* z_loan(const z_owned_closure_sample_t& closure) { return z_closure_sample_loan(&closure); };
+inline const z_loaned_closure_zid_t* z_loan(const z_owned_closure_zid_t& closure) { return z_closure_zid_loan(&closure); };
 inline const z_loaned_condvar_t* z_loan(const z_owned_condvar_t& this_) { return z_condvar_loan(&this_); };
 inline const z_loaned_config_t* z_loan(const z_owned_config_t& this_) { return z_config_loan(&this_); };
 inline const z_loaned_encoding_t* z_loan(const z_owned_encoding_t& this_) { return z_encoding_loan(&this_); };
@@ -379,6 +531,7 @@ inline const z_loaned_fifo_handler_reply_t* z_loan(const z_owned_fifo_handler_re
 inline const z_loaned_fifo_handler_sample_t* z_loan(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_loan(&this_); };
 inline const z_loaned_hello_t* z_loan(const z_owned_hello_t& this_) { return z_hello_loan(&this_); };
 inline const z_loaned_keyexpr_t* z_loan(const z_owned_keyexpr_t& this_) { return z_keyexpr_loan(&this_); };
+inline const z_loaned_memory_layout_t* z_loan(const z_owned_memory_layout_t& this_) { return z_memory_layout_loan(&this_); };
 inline const z_loaned_publisher_t* z_loan(const z_owned_publisher_t& this_) { return z_publisher_loan(&this_); };
 inline const z_loaned_query_t* z_loan(const z_owned_query_t& this_) { return z_query_loan(&this_); };
 inline const z_loaned_queryable_t* z_loan(const z_owned_queryable_t& this_) { return z_queryable_loan(&this_); };
@@ -389,7 +542,12 @@ inline const z_loaned_ring_handler_reply_t* z_loan(const z_owned_ring_handler_re
 inline const z_loaned_ring_handler_sample_t* z_loan(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_loan(&this_); };
 inline const z_loaned_sample_t* z_loan(const z_owned_sample_t& this_) { return z_sample_loan(&this_); };
 inline const z_loaned_session_t* z_loan(const z_owned_session_t& this_) { return z_session_loan(&this_); };
+inline const z_loaned_shm_client_storage_t* z_loan(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_loan(&this_); };
+inline const z_loaned_shm_t* z_loan(const z_owned_shm_t& this_) { return z_shm_loan(&this_); };
+inline const z_loaned_shm_mut_t* z_loan(const z_owned_shm_mut_t& this_) { return z_shm_mut_loan(&this_); };
+inline const z_loaned_shm_provider_t* z_loan(const z_owned_shm_provider_t& this_) { return z_shm_provider_loan(&this_); };
 inline const z_loaned_slice_t* z_loan(const z_owned_slice_t& this_) { return z_slice_loan(&this_); };
+inline const z_loaned_source_info_t* z_loan(const z_owned_source_info_t& this_) { return z_source_info_loan(&this_); };
 inline const z_loaned_string_array_t* z_loan(const z_owned_string_array_t& this_) { return z_string_array_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_owned_string_t& this_) { return z_string_loan(&this_); };
 inline const z_loaned_subscriber_t* z_loan(const z_owned_subscriber_t& this_) { return z_subscriber_loan(&this_); };
@@ -397,6 +555,11 @@ inline const z_loaned_keyexpr_t* z_loan(const z_view_keyexpr_t& this_) { return 
 inline const z_loaned_slice_t* z_loan(const z_view_slice_t& this_) { return z_view_slice_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_view_string_t& this_) { return z_view_string_loan(&this_); };
 inline const zc_loaned_closure_log_t* z_loan(const zc_owned_closure_log_t& closure) { return zc_closure_log_loan(&closure); };
+inline const zc_loaned_closure_matching_status_t* z_loan(const zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_loan(&closure); };
+inline const zc_loaned_liveliness_token_t* z_loan(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_loan(&this_); };
+inline const zc_loaned_shm_client_list_t* z_loan(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan(&this_); };
+inline const ze_loaned_publication_cache_t* z_loan(const ze_owned_publication_cache_t& this_) { return ze_publication_cache_loan(&this_); };
+inline const ze_loaned_querying_subscriber_t* z_loan(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_loan(&this_); };
 
 
 inline z_loaned_bytes_t* z_loan_mut(z_owned_bytes_t& this_) { return z_bytes_loan_mut(&this_); };
@@ -405,14 +568,20 @@ inline z_loaned_config_t* z_loan_mut(z_owned_config_t& this_) { return z_config_
 inline z_loaned_encoding_t* z_loan_mut(z_owned_encoding_t& this_) { return z_encoding_loan_mut(&this_); };
 inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t& this_) { return z_mutex_loan_mut(&this_); };
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& this_) { return z_publisher_loan_mut(&this_); };
+inline z_loaned_shm_t* z_loan_mut(z_owned_shm_t& this_) { return z_shm_loan_mut(&this_); };
+inline z_loaned_shm_mut_t* z_loan_mut(z_owned_shm_mut_t& this_) { return z_shm_mut_loan_mut(&this_); };
 inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { return z_string_array_loan_mut(&this_); };
+inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan_mut(&this_); };
 
 
+inline void z_drop(z_moved_alloc_layout_t* this_) { z_alloc_layout_drop(this_); };
 inline void z_drop(z_moved_bytes_t* this_) { z_bytes_drop(this_); };
+inline void z_drop(z_moved_chunk_alloc_result_t* this_) { z_chunk_alloc_result_drop(this_); };
 inline void z_drop(z_moved_closure_hello_t* this_) { z_closure_hello_drop(this_); };
 inline void z_drop(z_moved_closure_query_t* closure_) { z_closure_query_drop(closure_); };
 inline void z_drop(z_moved_closure_reply_t* closure_) { z_closure_reply_drop(closure_); };
 inline void z_drop(z_moved_closure_sample_t* closure_) { z_closure_sample_drop(closure_); };
+inline void z_drop(z_moved_closure_zid_t* closure_) { z_closure_zid_drop(closure_); };
 inline void z_drop(z_moved_condvar_t* this_) { z_condvar_drop(this_); };
 inline void z_drop(z_moved_config_t* this_) { z_config_drop(this_); };
 inline void z_drop(z_moved_encoding_t* this_) { z_encoding_drop(this_); };
@@ -421,6 +590,7 @@ inline void z_drop(z_moved_fifo_handler_reply_t* this_) { z_fifo_handler_reply_d
 inline void z_drop(z_moved_fifo_handler_sample_t* this_) { z_fifo_handler_sample_drop(this_); };
 inline void z_drop(z_moved_hello_t* this_) { z_hello_drop(this_); };
 inline void z_drop(z_moved_keyexpr_t* this_) { z_keyexpr_drop(this_); };
+inline void z_drop(z_moved_memory_layout_t* this_) { z_memory_layout_drop(this_); };
 inline void z_drop(z_moved_mutex_t* this_) { z_mutex_drop(this_); };
 inline void z_drop(z_moved_publisher_t* this_) { z_publisher_drop(this_); };
 inline void z_drop(z_moved_query_t* this_) { z_query_drop(this_); };
@@ -432,19 +602,34 @@ inline void z_drop(z_moved_ring_handler_reply_t* this_) { z_ring_handler_reply_d
 inline void z_drop(z_moved_ring_handler_sample_t* this_) { z_ring_handler_sample_drop(this_); };
 inline void z_drop(z_moved_sample_t* this_) { z_sample_drop(this_); };
 inline void z_drop(z_moved_session_t* this_) { z_session_drop(this_); };
+inline void z_drop(z_moved_shm_client_t* this_) { z_shm_client_drop(this_); };
+inline void z_drop(z_moved_shm_client_storage_t* this_) { z_shm_client_storage_drop(this_); };
+inline void z_drop(z_moved_shm_t* this_) { z_shm_drop(this_); };
+inline void z_drop(z_moved_shm_mut_t* this_) { z_shm_mut_drop(this_); };
+inline void z_drop(z_moved_shm_provider_t* this_) { z_shm_provider_drop(this_); };
 inline void z_drop(z_moved_slice_t* this_) { z_slice_drop(this_); };
+inline void z_drop(z_moved_source_info_t* this_) { z_source_info_drop(this_); };
 inline void z_drop(z_moved_string_array_t* this_) { z_string_array_drop(this_); };
 inline void z_drop(z_moved_string_t* this_) { z_string_drop(this_); };
 inline void z_drop(z_moved_subscriber_t* this_) { z_subscriber_drop(this_); };
 inline void z_drop(z_moved_task_t* this_) { z_task_drop(this_); };
 inline void z_drop(zc_moved_closure_log_t* closure_) { zc_closure_log_drop(closure_); };
+inline void z_drop(zc_moved_closure_matching_status_t* closure_) { zc_closure_matching_status_drop(closure_); };
+inline void z_drop(zc_moved_liveliness_token_t* this_) { zc_liveliness_token_drop(this_); };
+inline void z_drop(zc_moved_matching_listener_t* this_) { zc_publisher_matching_listener_drop(this_); };
+inline void z_drop(zc_moved_shm_client_list_t* this_) { zc_shm_client_list_drop(this_); };
+inline void z_drop(ze_moved_publication_cache_t* this_) { ze_publication_cache_drop(this_); };
+inline void z_drop(ze_moved_querying_subscriber_t* this_) { ze_querying_subscriber_drop(this_); };
 
 
+inline z_moved_alloc_layout_t* z_move(z_owned_alloc_layout_t& this_) { return z_alloc_layout_move(&this_); };
 inline z_moved_bytes_t* z_move(z_owned_bytes_t& this_) { return z_bytes_move(&this_); };
+inline z_moved_chunk_alloc_result_t* z_move(z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_move(&this_); };
 inline z_moved_closure_hello_t* z_move(z_owned_closure_hello_t& this_) { return z_closure_hello_move(&this_); };
 inline z_moved_closure_query_t* z_move(z_owned_closure_query_t& closure_) { return z_closure_query_move(&closure_); };
 inline z_moved_closure_reply_t* z_move(z_owned_closure_reply_t& closure_) { return z_closure_reply_move(&closure_); };
 inline z_moved_closure_sample_t* z_move(z_owned_closure_sample_t& closure_) { return z_closure_sample_move(&closure_); };
+inline z_moved_closure_zid_t* z_move(z_owned_closure_zid_t& closure_) { return z_closure_zid_move(&closure_); };
 inline z_moved_condvar_t* z_move(z_owned_condvar_t& this_) { return z_condvar_move(&this_); };
 inline z_moved_config_t* z_move(z_owned_config_t& this_) { return z_config_move(&this_); };
 inline z_moved_encoding_t* z_move(z_owned_encoding_t& this_) { return z_encoding_move(&this_); };
@@ -453,6 +638,7 @@ inline z_moved_fifo_handler_reply_t* z_move(z_owned_fifo_handler_reply_t& this_)
 inline z_moved_fifo_handler_sample_t* z_move(z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_move(&this_); };
 inline z_moved_hello_t* z_move(z_owned_hello_t& this_) { return z_hello_move(&this_); };
 inline z_moved_keyexpr_t* z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
+inline z_moved_memory_layout_t* z_move(z_owned_memory_layout_t& this_) { return z_memory_layout_move(&this_); };
 inline z_moved_mutex_t* z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
 inline z_moved_publisher_t* z_move(z_owned_publisher_t& this_) { return z_publisher_move(&this_); };
 inline z_moved_query_t* z_move(z_owned_query_t& this_) { return z_query_move(&this_); };
@@ -464,19 +650,34 @@ inline z_moved_ring_handler_reply_t* z_move(z_owned_ring_handler_reply_t& this_)
 inline z_moved_ring_handler_sample_t* z_move(z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_move(&this_); };
 inline z_moved_sample_t* z_move(z_owned_sample_t& this_) { return z_sample_move(&this_); };
 inline z_moved_session_t* z_move(z_owned_session_t& this_) { return z_session_move(&this_); };
+inline z_moved_shm_client_t* z_move(z_owned_shm_client_t& this_) { return z_shm_client_move(&this_); };
+inline z_moved_shm_client_storage_t* z_move(z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_move(&this_); };
+inline z_moved_shm_t* z_move(z_owned_shm_t& this_) { return z_shm_move(&this_); };
+inline z_moved_shm_mut_t* z_move(z_owned_shm_mut_t& this_) { return z_shm_mut_move(&this_); };
+inline z_moved_shm_provider_t* z_move(z_owned_shm_provider_t& this_) { return z_shm_provider_move(&this_); };
 inline z_moved_slice_t* z_move(z_owned_slice_t& this_) { return z_slice_move(&this_); };
+inline z_moved_source_info_t* z_move(z_owned_source_info_t& this_) { return z_source_info_move(&this_); };
 inline z_moved_string_array_t* z_move(z_owned_string_array_t& this_) { return z_string_array_move(&this_); };
 inline z_moved_string_t* z_move(z_owned_string_t& this_) { return z_string_move(&this_); };
 inline z_moved_subscriber_t* z_move(z_owned_subscriber_t& this_) { return z_subscriber_move(&this_); };
 inline z_moved_task_t* z_move(z_owned_task_t& this_) { return z_task_move(&this_); };
 inline zc_moved_closure_log_t* z_move(zc_owned_closure_log_t& closure_) { return zc_closure_log_move(&closure_); };
+inline zc_moved_closure_matching_status_t* z_move(zc_owned_closure_matching_status_t& closure_) { return zc_closure_matching_status_move(&closure_); };
+inline zc_moved_liveliness_token_t* z_move(zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_move(&this_); };
+inline zc_moved_matching_listener_t* z_move(zc_owned_matching_listener_t& this_) { return zc_publisher_matching_listener_move(&this_); };
+inline zc_moved_shm_client_list_t* z_move(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_move(&this_); };
+inline ze_moved_publication_cache_t* z_move(ze_owned_publication_cache_t& this_) { return ze_publication_cache_move(&this_); };
+inline ze_moved_querying_subscriber_t* z_move(ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_move(&this_); };
 
 
+inline void z_internal_null(z_owned_alloc_layout_t* this_) { z_internal_alloc_layout_null(this_); };
 inline void z_internal_null(z_owned_bytes_t* this_) { z_internal_bytes_null(this_); };
+inline void z_internal_null(z_owned_chunk_alloc_result_t* this_) { z_internal_chunk_alloc_result_null(this_); };
 inline void z_internal_null(z_owned_closure_hello_t* this_) { z_internal_closure_hello_null(this_); };
 inline void z_internal_null(z_owned_closure_query_t* this_) { z_internal_closure_query_null(this_); };
 inline void z_internal_null(z_owned_closure_reply_t* this_) { z_internal_closure_reply_null(this_); };
 inline void z_internal_null(z_owned_closure_sample_t* this_) { z_internal_closure_sample_null(this_); };
+inline void z_internal_null(z_owned_closure_zid_t* this_) { z_internal_closure_zid_null(this_); };
 inline void z_internal_null(z_owned_condvar_t* this_) { z_internal_condvar_null(this_); };
 inline void z_internal_null(z_owned_config_t* this_) { z_internal_config_null(this_); };
 inline void z_internal_null(z_owned_encoding_t* this_) { z_internal_encoding_null(this_); };
@@ -485,6 +686,7 @@ inline void z_internal_null(z_owned_fifo_handler_reply_t* this_) { z_internal_fi
 inline void z_internal_null(z_owned_fifo_handler_sample_t* this_) { z_internal_fifo_handler_sample_null(this_); };
 inline void z_internal_null(z_owned_hello_t* this_) { z_internal_hello_null(this_); };
 inline void z_internal_null(z_owned_keyexpr_t* this_) { z_internal_keyexpr_null(this_); };
+inline void z_internal_null(z_owned_memory_layout_t* this_) { z_internal_memory_layout_null(this_); };
 inline void z_internal_null(z_owned_mutex_t* this_) { z_internal_mutex_null(this_); };
 inline void z_internal_null(z_owned_publisher_t* this_) { z_internal_publisher_null(this_); };
 inline void z_internal_null(z_owned_query_t* this_) { z_internal_query_null(this_); };
@@ -496,18 +698,33 @@ inline void z_internal_null(z_owned_ring_handler_reply_t* this_) { z_internal_ri
 inline void z_internal_null(z_owned_ring_handler_sample_t* this_) { z_internal_ring_handler_sample_null(this_); };
 inline void z_internal_null(z_owned_sample_t* this_) { z_internal_sample_null(this_); };
 inline void z_internal_null(z_owned_session_t* this_) { z_internal_session_null(this_); };
+inline void z_internal_null(z_owned_shm_client_t* this_) { z_internal_shm_client_null(this_); };
+inline void z_internal_null(z_owned_shm_client_storage_t* this_) { z_internal_shm_client_storage_null(this_); };
+inline void z_internal_null(z_owned_shm_mut_t* this_) { z_internal_shm_mut_null(this_); };
+inline void z_internal_null(z_owned_shm_t* this_) { z_internal_shm_null(this_); };
+inline void z_internal_null(z_owned_shm_provider_t* this_) { z_internal_shm_provider_null(this_); };
 inline void z_internal_null(z_owned_slice_t* this_) { z_internal_slice_null(this_); };
+inline void z_internal_null(z_owned_source_info_t* this_) { z_internal_source_info_null(this_); };
 inline void z_internal_null(z_owned_string_array_t* this_) { z_internal_string_array_null(this_); };
 inline void z_internal_null(z_owned_string_t* this_) { z_internal_string_null(this_); };
 inline void z_internal_null(z_owned_subscriber_t* this_) { z_internal_subscriber_null(this_); };
 inline void z_internal_null(z_owned_task_t* this_) { z_internal_task_null(this_); };
 inline void z_internal_null(zc_owned_closure_log_t* this_) { zc_internal_closure_log_null(this_); };
+inline void z_internal_null(zc_owned_closure_matching_status_t* this_) { zc_internal_closure_matching_status_null(this_); };
+inline void z_internal_null(zc_owned_liveliness_token_t* this_) { zc_internal_liveliness_token_null(this_); };
+inline void z_internal_null(zc_owned_matching_listener_t* this_) { zc_internal_matching_listener_null(this_); };
+inline void z_internal_null(zc_owned_shm_client_list_t* this_) { zc_internal_shm_client_list_null(this_); };
+inline void z_internal_null(ze_owned_publication_cache_t* this_) { ze_internal_publication_cache_null(this_); };
+inline void z_internal_null(ze_owned_querying_subscriber_t* this_) { ze_internal_querying_subscriber_null(this_); };
 
+static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) { *this_ = x->_this; z_internal_alloc_layout_null(&x->_this); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *this_ = x->_this; z_internal_bytes_null(&x->_this); }
+static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) { *this_ = x->_this; z_internal_chunk_alloc_result_null(&x->_this); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_internal_closure_hello_null(&x->_this); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_internal_closure_query_null(&x->_this); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_internal_closure_reply_null(&x->_this); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_internal_closure_sample_null(&x->_this); }
+static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) { *closure_ = x->_this; z_internal_closure_zid_null(&x->_this); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) { *this_ = x->_this; z_internal_condvar_null(&x->_this); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t* x) { *this_ = x->_this; z_internal_config_null(&x->_this); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t* x) { *this_ = x->_this; z_internal_encoding_null(&x->_this); }
@@ -516,6 +733,7 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t* x) { *this_ = x->_this; z_internal_fifo_handler_sample_null(&x->_this); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_internal_hello_null(&x->_this); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_internal_keyexpr_null(&x->_this); }
+static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) { *this_ = x->_this; z_internal_memory_layout_null(&x->_this); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_internal_mutex_null(&x->_this); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_internal_publisher_null(&x->_this); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t* x) { *this_ = x->_this; z_internal_query_null(&x->_this); }
@@ -527,17 +745,35 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t* x) { *this_ = x->_this; z_internal_ring_handler_sample_null(&x->_this); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t* x) { *this_ = x->_this; z_internal_sample_null(&x->_this); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t* x) { *this_ = x->_this; z_internal_session_null(&x->_this); }
+static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) { *this_ = x->_this; z_internal_shm_client_null(&x->_this); }
+static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) { *this_ = x->_this; z_internal_shm_client_storage_null(&x->_this); }
+static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t* x) { *this_ = x->_this; z_internal_shm_null(&x->_this); }
+static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) { *this_ = x->_this; z_internal_shm_mut_null(&x->_this); }
+static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) { *this_ = x->_this; z_internal_shm_provider_null(&x->_this); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t* x) { *this_ = x->_this; z_internal_slice_null(&x->_this); }
+static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) { *this_ = x->_this; z_internal_source_info_null(&x->_this); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) { *this_ = x->_this; z_internal_string_array_null(&x->_this); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) { *this_ = x->_this; z_internal_string_null(&x->_this); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_internal_subscriber_null(&x->_this); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_internal_task_null(&x->_this); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_internal_closure_log_null(&x->_this); }
+static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) { *closure_ = x->_this; zc_internal_closure_matching_status_null(&x->_this); }
+static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) { *this_ = x->_this; zc_internal_liveliness_token_null(&x->_this); }
+static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) { *this_ = x->_this; zc_internal_matching_listener_null(&x->_this); }
+static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) { *this_ = x->_this; zc_internal_shm_client_list_null(&x->_this); }
+static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) { *this_ = x->_this; ze_internal_publication_cache_null(&x->_this); }
+static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) { *this_ = x->_this; ze_internal_querying_subscriber_null(&x->_this); }
 
 
 
+inline void z_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) {
+    z_alloc_layout_take(this_, x);
+};
 inline void z_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) {
     z_bytes_take(this_, x);
+};
+inline void z_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) {
+    z_chunk_alloc_result_take(this_, x);
 };
 inline void z_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) {
     z_closure_hello_take(this_, x);
@@ -550,6 +786,9 @@ inline void z_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x
 };
 inline void z_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) {
     z_closure_sample_take(closure_, x);
+};
+inline void z_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) {
+    z_closure_zid_take(closure_, x);
 };
 inline void z_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) {
     z_condvar_take(this_, x);
@@ -574,6 +813,9 @@ inline void z_take(z_owned_hello_t* this_, z_moved_hello_t* x) {
 };
 inline void z_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) {
     z_keyexpr_take(this_, x);
+};
+inline void z_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) {
+    z_memory_layout_take(this_, x);
 };
 inline void z_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) {
     z_mutex_take(this_, x);
@@ -608,8 +850,26 @@ inline void z_take(z_owned_sample_t* this_, z_moved_sample_t* x) {
 inline void z_take(z_owned_session_t* this_, z_moved_session_t* x) {
     z_session_take(this_, x);
 };
+inline void z_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) {
+    z_shm_client_take(this_, x);
+};
+inline void z_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) {
+    z_shm_client_storage_take(this_, x);
+};
+inline void z_take(z_owned_shm_t* this_, z_moved_shm_t* x) {
+    z_shm_take(this_, x);
+};
+inline void z_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) {
+    z_shm_mut_take(this_, x);
+};
+inline void z_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) {
+    z_shm_provider_take(this_, x);
+};
 inline void z_take(z_owned_slice_t* this_, z_moved_slice_t* x) {
     z_slice_take(this_, x);
+};
+inline void z_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) {
+    z_source_info_take(this_, x);
 };
 inline void z_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) {
     z_string_array_take(this_, x);
@@ -626,13 +886,34 @@ inline void z_take(z_owned_task_t* this_, z_moved_task_t* x) {
 inline void z_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) {
     zc_closure_log_take(closure_, x);
 };
+inline void z_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) {
+    zc_closure_matching_status_take(closure_, x);
+};
+inline void z_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) {
+    zc_liveliness_token_take(this_, x);
+};
+inline void z_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) {
+    zc_publisher_matching_listener_take(this_, x);
+};
+inline void z_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) {
+    zc_shm_client_list_take(this_, x);
+};
+inline void z_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) {
+    ze_publication_cache_take(this_, x);
+};
+inline void z_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) {
+    ze_querying_subscriber_take(this_, x);
+};
 
 
+inline bool z_internal_check(const z_owned_alloc_layout_t& this_) { return z_internal_alloc_layout_check(&this_); };
 inline bool z_internal_check(const z_owned_bytes_t& this_) { return z_internal_bytes_check(&this_); };
+inline bool z_internal_check(const z_owned_chunk_alloc_result_t& this_) { return z_internal_chunk_alloc_result_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_hello_t& this_) { return z_internal_closure_hello_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_query_t& this_) { return z_internal_closure_query_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_reply_t& this_) { return z_internal_closure_reply_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_sample_t& this_) { return z_internal_closure_sample_check(&this_); };
+inline bool z_internal_check(const z_owned_closure_zid_t& this_) { return z_internal_closure_zid_check(&this_); };
 inline bool z_internal_check(const z_owned_condvar_t& this_) { return z_internal_condvar_check(&this_); };
 inline bool z_internal_check(const z_owned_config_t& this_) { return z_internal_config_check(&this_); };
 inline bool z_internal_check(const z_owned_encoding_t& this_) { return z_internal_encoding_check(&this_); };
@@ -641,6 +922,7 @@ inline bool z_internal_check(const z_owned_fifo_handler_reply_t& this_) { return
 inline bool z_internal_check(const z_owned_fifo_handler_sample_t& this_) { return z_internal_fifo_handler_sample_check(&this_); };
 inline bool z_internal_check(const z_owned_hello_t& this_) { return z_internal_hello_check(&this_); };
 inline bool z_internal_check(const z_owned_keyexpr_t& this_) { return z_internal_keyexpr_check(&this_); };
+inline bool z_internal_check(const z_owned_memory_layout_t& this_) { return z_internal_memory_layout_check(&this_); };
 inline bool z_internal_check(const z_owned_mutex_t& this_) { return z_internal_mutex_check(&this_); };
 inline bool z_internal_check(const z_owned_publisher_t& this_) { return z_internal_publisher_check(&this_); };
 inline bool z_internal_check(const z_owned_query_t& query) { return z_internal_query_check(&query); };
@@ -652,12 +934,24 @@ inline bool z_internal_check(const z_owned_ring_handler_reply_t& this_) { return
 inline bool z_internal_check(const z_owned_ring_handler_sample_t& this_) { return z_internal_ring_handler_sample_check(&this_); };
 inline bool z_internal_check(const z_owned_sample_t& this_) { return z_internal_sample_check(&this_); };
 inline bool z_internal_check(const z_owned_session_t& this_) { return z_internal_session_check(&this_); };
+inline bool z_internal_check(const z_owned_shm_t& this_) { return z_internal_shm_check(&this_); };
+inline bool z_internal_check(const z_owned_shm_client_t& this_) { return z_internal_shm_client_check(&this_); };
+inline bool z_internal_check(const z_owned_shm_client_storage_t& this_) { return z_internal_shm_client_storage_check(&this_); };
+inline bool z_internal_check(const z_owned_shm_mut_t& this_) { return z_internal_shm_mut_check(&this_); };
+inline bool z_internal_check(const z_owned_shm_provider_t& this_) { return z_internal_shm_provider_check(&this_); };
 inline bool z_internal_check(const z_owned_slice_t& this_) { return z_internal_slice_check(&this_); };
+inline bool z_internal_check(const z_owned_source_info_t& this_) { return z_internal_source_info_check(&this_); };
 inline bool z_internal_check(const z_owned_string_array_t& this_) { return z_internal_string_array_check(&this_); };
 inline bool z_internal_check(const z_owned_string_t& this_) { return z_internal_string_check(&this_); };
 inline bool z_internal_check(const z_owned_subscriber_t& this_) { return z_internal_subscriber_check(&this_); };
 inline bool z_internal_check(const z_owned_task_t& this_) { return z_internal_task_check(&this_); };
 inline bool z_internal_check(const zc_owned_closure_log_t& this_) { return zc_internal_closure_log_check(&this_); };
+inline bool z_internal_check(const zc_owned_closure_matching_status_t& this_) { return zc_internal_closure_matching_status_check(&this_); };
+inline bool z_internal_check(const zc_owned_liveliness_token_t& this_) { return zc_internal_liveliness_token_check(&this_); };
+inline bool z_internal_check(const zc_owned_matching_listener_t& this_) { return zc_internal_matching_listener_check(&this_); };
+inline bool z_internal_check(const zc_owned_shm_client_list_t& this_) { return zc_internal_shm_client_list_check(&this_); };
+inline bool z_internal_check(const ze_owned_publication_cache_t& this_) { return ze_internal_publication_cache_check(&this_); };
+inline bool z_internal_check(const ze_owned_querying_subscriber_t& this_) { return ze_internal_querying_subscriber_check(&this_); };
 
 
 inline void z_call(const z_loaned_closure_hello_t* closure, z_loaned_hello_t* hello) {
@@ -671,6 +965,12 @@ inline void z_call(const z_loaned_closure_reply_t* closure, z_loaned_reply_t* re
 };
 inline void z_call(const z_loaned_closure_sample_t* closure, z_loaned_sample_t* sample) {
     z_closure_sample_call(closure, sample);
+};
+inline void z_call(const z_loaned_closure_zid_t* closure, const z_id_t* z_id) {
+    z_closure_zid_call(closure, z_id);
+};
+inline void z_call(const zc_loaned_closure_matching_status_t* closure, const zc_matching_status_t* mathing_status) {
+    zc_closure_matching_status_call(closure, mathing_status);
 };
 
 extern "C" using z_closure_drop_callback_t = void(void*);
@@ -709,6 +1009,26 @@ extern "C" using z_closure_sample_callback_t = void(z_loaned_sample_t*, void*);
 inline void z_closure(
     z_owned_closure_sample_t* closure,
     z_closure_sample_callback_t* call,
+    z_closure_drop_callback_t* drop,
+    void *context) {
+    closure->context = context;
+    closure->drop = drop;
+    closure->call = call;
+};
+extern "C" using z_closure_zid_callback_t = void(const z_id_t*, void*);
+inline void z_closure(
+    z_owned_closure_zid_t* closure,
+    z_closure_zid_callback_t* call,
+    z_closure_drop_callback_t* drop,
+    void *context) {
+    closure->context = context;
+    closure->drop = drop;
+    closure->call = call;
+};
+extern "C" using zc_closure_matching_status_callback_t = void(const zc_matching_status_t*, void*);
+inline void z_closure(
+    zc_owned_closure_matching_status_t* closure,
+    zc_closure_matching_status_callback_t* call,
     z_closure_drop_callback_t* drop,
     void *context) {
     closure->context = context;
@@ -784,6 +1104,12 @@ inline void z_clone(z_owned_reply_err_t* dst, z_loaned_reply_err_t* this_) {
 inline void z_clone(z_owned_sample_t* dst, z_loaned_sample_t* this_) {
     z_sample_clone(dst, this_);
 };
+inline void z_clone(z_owned_shm_client_storage_t* this_, z_loaned_shm_client_storage_t* from) {
+    z_shm_client_storage_clone(this_, from);
+};
+inline void z_clone(z_owned_shm_t* out, z_loaned_shm_t* this_) {
+    z_shm_clone(out, this_);
+};
 inline void z_clone(z_owned_slice_t* dst, z_loaned_slice_t* this_) {
     z_slice_clone(dst, this_);
 };
@@ -796,8 +1122,12 @@ inline void z_clone(z_owned_string_t* dst, z_loaned_string_t* this_) {
 
 template<class T> struct z_loaned_to_owned_type_t {};
 template<class T> struct z_owned_to_loaned_type_t {};
+template<> struct z_loaned_to_owned_type_t<z_loaned_alloc_layout_t> { typedef z_owned_alloc_layout_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_alloc_layout_t> { typedef z_loaned_alloc_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_t> { typedef z_owned_bytes_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_t> { typedef z_loaned_bytes_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_chunk_alloc_result_t> { typedef z_owned_chunk_alloc_result_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_chunk_alloc_result_t> { typedef z_loaned_chunk_alloc_result_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_hello_t> { typedef z_owned_closure_hello_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_hello_t> { typedef z_loaned_closure_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_query_t> { typedef z_owned_closure_query_t type; };
@@ -806,6 +1136,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_closure_reply_t> { typedef z
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_reply_t> { typedef z_loaned_closure_reply_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_sample_t> { typedef z_owned_closure_sample_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_sample_t> { typedef z_loaned_closure_sample_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_closure_zid_t> { typedef z_owned_closure_zid_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_closure_zid_t> { typedef z_loaned_closure_zid_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_condvar_t> { typedef z_owned_condvar_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_condvar_t> { typedef z_loaned_condvar_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_config_t> { typedef z_owned_config_t type; };
@@ -822,6 +1154,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_hello_t> { typedef z_owned_h
 template<> struct z_owned_to_loaned_type_t<z_owned_hello_t> { typedef z_loaned_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_keyexpr_t> { typedef z_owned_keyexpr_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_keyexpr_t> { typedef z_loaned_keyexpr_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_memory_layout_t> { typedef z_owned_memory_layout_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_memory_layout_t> { typedef z_loaned_memory_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_publisher_t> { typedef z_owned_publisher_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_publisher_t> { typedef z_loaned_publisher_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_query_t> { typedef z_owned_query_t type; };
@@ -842,8 +1176,18 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_sample_t> { typedef z_owned_
 template<> struct z_owned_to_loaned_type_t<z_owned_sample_t> { typedef z_loaned_sample_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_session_t> { typedef z_owned_session_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_session_t> { typedef z_loaned_session_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_client_storage_t> { typedef z_owned_shm_client_storage_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_client_storage_t> { typedef z_loaned_shm_client_storage_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_t> { typedef z_owned_shm_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_t> { typedef z_loaned_shm_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_mut_t> { typedef z_owned_shm_mut_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_mut_t> { typedef z_loaned_shm_mut_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_shm_provider_t> { typedef z_owned_shm_provider_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_shm_provider_t> { typedef z_loaned_shm_provider_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_slice_t> { typedef z_owned_slice_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_slice_t> { typedef z_loaned_slice_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_source_info_t> { typedef z_owned_source_info_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_source_info_t> { typedef z_loaned_source_info_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_array_t> { typedef z_owned_string_array_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_string_array_t> { typedef z_loaned_string_array_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_t> { typedef z_owned_string_t type; };
@@ -852,6 +1196,16 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_subscriber_t> { typedef z_ow
 template<> struct z_owned_to_loaned_type_t<z_owned_subscriber_t> { typedef z_loaned_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_log_t> { typedef zc_owned_closure_log_t type; };
 template<> struct z_owned_to_loaned_type_t<zc_owned_closure_log_t> { typedef zc_loaned_closure_log_t type; };
+template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_matching_status_t> { typedef zc_owned_closure_matching_status_t type; };
+template<> struct z_owned_to_loaned_type_t<zc_owned_closure_matching_status_t> { typedef zc_loaned_closure_matching_status_t type; };
+template<> struct z_loaned_to_owned_type_t<zc_loaned_liveliness_token_t> { typedef zc_owned_liveliness_token_t type; };
+template<> struct z_owned_to_loaned_type_t<zc_owned_liveliness_token_t> { typedef zc_loaned_liveliness_token_t type; };
+template<> struct z_loaned_to_owned_type_t<zc_loaned_shm_client_list_t> { typedef zc_owned_shm_client_list_t type; };
+template<> struct z_owned_to_loaned_type_t<zc_owned_shm_client_list_t> { typedef zc_loaned_shm_client_list_t type; };
+template<> struct z_loaned_to_owned_type_t<ze_loaned_publication_cache_t> { typedef ze_owned_publication_cache_t type; };
+template<> struct z_owned_to_loaned_type_t<ze_owned_publication_cache_t> { typedef ze_loaned_publication_cache_t type; };
+template<> struct z_loaned_to_owned_type_t<ze_loaned_querying_subscriber_t> { typedef ze_owned_querying_subscriber_t type; };
+template<> struct z_owned_to_loaned_type_t<ze_owned_querying_subscriber_t> { typedef ze_loaned_querying_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_mutex_t> { typedef z_owned_mutex_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_mutex_t> { typedef z_loaned_mutex_t type; };
 #endif  // #ifndef __cplusplus

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -19,7 +19,7 @@ use libc::c_ulong;
 use zenoh::{
     pubsub::Reliability,
     query::ReplyKeyExpr,
-    sample::{Locality, SourceInfo},
+    sample::{Locality, SourceInfo, SourceSn},
     session::EntityGlobalId,
 };
 use zenoh::{
@@ -556,7 +556,7 @@ decl_c_type!(
 pub extern "C" fn z_source_info_new(
     this: &mut MaybeUninit<z_owned_source_info_t>,
     source_id: &z_entity_global_id_t,
-    source_sn: u64,
+    source_sn: SourceSn,
 ) -> result::z_result_t {
     let this = this.as_rust_type_mut_uninit();
     let source_info = SourceInfo {
@@ -583,7 +583,7 @@ pub extern "C" fn z_source_info_id(this_: &z_loaned_source_info_t) -> z_entity_g
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Returns the source_sn of the source info.
 #[no_mangle]
-pub extern "C" fn z_source_info_sn(this_: &z_loaned_source_info_t) -> u64 {
+pub extern "C" fn z_source_info_sn(this_: &z_loaned_source_info_t) -> SourceSn {
     this_.as_rust_type_ref().source_sn.unwrap_or(0)
 }
 


### PR DESCRIPTION
To point to zenoh `main` after https://github.com/eclipse-zenoh/zenoh/pull/1425 is merged 