### PR TITLE
Change `z_sleep_*` result type to z_result_t

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -4366,15 +4366,15 @@ z_loaned_shm_mut_t *z_shm_try_reloan_mut(z_loaned_shm_t *this_);
 /**
  * Puts current thread to sleep for specified amount of milliseconds.
  */
-ZENOHC_API int8_t z_sleep_ms(size_t time);
+ZENOHC_API z_result_t z_sleep_ms(size_t time);
 /**
  * Puts current thread to sleep for specified amount of seconds.
  */
-ZENOHC_API int8_t z_sleep_s(size_t time);
+ZENOHC_API z_result_t z_sleep_s(size_t time);
 /**
  * Puts current thread to sleep for specified amount of microseconds.
  */
-ZENOHC_API int8_t z_sleep_us(size_t time);
+ZENOHC_API z_result_t z_sleep_us(size_t time);
 /**
  * Constructs an owned copy of a slice.
  */

--- a/src/platform/sleep.rs
+++ b/src/platform/sleep.rs
@@ -1,22 +1,24 @@
 use std::{thread, time};
 
+use crate::result;
+
 /// Puts current thread to sleep for specified amount of seconds.
 #[no_mangle]
-pub extern "C" fn z_sleep_s(time: usize) -> i8 {
+pub extern "C" fn z_sleep_s(time: usize) -> result::z_result_t {
     thread::sleep(time::Duration::from_secs(time as u64));
-    0
+    result::Z_OK
 }
 
 /// Puts current thread to sleep for specified amount of milliseconds.
 #[no_mangle]
-pub extern "C" fn z_sleep_ms(time: usize) -> i8 {
+pub extern "C" fn z_sleep_ms(time: usize) -> result::z_result_t {
     thread::sleep(time::Duration::from_millis(time as u64));
-    0
+    result::Z_OK
 }
 
 /// Puts current thread to sleep for specified amount of microseconds.
 #[no_mangle]
-pub extern "C" fn z_sleep_us(time: usize) -> i8 {
+pub extern "C" fn z_sleep_us(time: usize) -> result::z_result_t {
     thread::sleep(time::Duration::from_micros(time as u64));
-    0
+    result::Z_OK
 }


### PR DESCRIPTION
Sister PR: https://github.com/eclipse-zenoh/zenoh-pico/pull/681