### PR TITLE
Background declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3790,7 +3790,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "tracing",
  "uhlc",
@@ -3840,12 +3840,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 
 [[package]]
 name = "zenoh-config"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "json5",
  "num_cpus",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "aes",
  "hmac",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "bincode",
  "flume",
@@ -3907,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "hashbrown 0.14.5",
  "keyed-set",
@@ -3921,7 +3921,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "flume",
@@ -3964,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-serial"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "tokio",
@@ -4007,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixpipe"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-vsock"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "libc",
@@ -4128,7 +4128,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4148,7 +4148,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "git-version",
  "libloading",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "const_format",
  "rand",
@@ -4189,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "anyhow",
 ]
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "event-listener 5.3.1",
  "futures",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "futures",
  "tokio",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -4293,7 +4293,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "const_format",

--- a/build-resources/opaque-types/Cargo.lock
+++ b/build-resources/opaque-types/Cargo.lock
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3182,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "tracing",
  "uhlc",
@@ -3202,12 +3202,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 
 [[package]]
 name = "zenoh-config"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "json5",
  "num_cpus",
@@ -3228,7 +3228,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "aes",
  "hmac",
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "bincode",
  "flume",
@@ -3269,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "hashbrown",
  "keyed-set",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "flume",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-serial"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3369,7 +3369,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3432,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixpipe"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -3454,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -3472,7 +3472,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-vsock"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "libc",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3521,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "git-version",
  "libloading",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "const_format",
  "rand",
@@ -3551,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "anyhow",
 ]
@@ -3559,7 +3559,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "lazy_static",
  "ron",
@@ -3572,7 +3572,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -3595,7 +3595,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "event-listener",
  "futures",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "futures",
  "tokio",
@@ -3621,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -3655,7 +3655,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e9f3b376315d680e8b172b5de65a051e702b9699"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d3768b87d23599f791af2de0c0d8fbe41f079431"
 dependencies = [
  "async-trait",
  "const_format",

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -566,7 +566,6 @@ Functions
 .. doxygenfunction:: z_declare_publisher
 .. doxygenfunction:: z_publisher_put
 .. doxygenfunction:: z_publisher_delete
-.. doxygenfunction:: z_undeclare_publisher
 .. doxygenfunction:: z_publisher_keyexpr
 .. doxygenfunction:: z_publisher_id
 
@@ -588,7 +587,9 @@ Functions
 
 .. doxygenfunction:: zc_publisher_get_matching_status
 .. doxygenfunction:: zc_publisher_matching_listener_declare
-.. doxygenfunction:: zc_publisher_matching_listener_undeclare
+.. doxygenfunction:: zc_publisher_matching_listener_declare_background
+
+.. doxygenfunction:: zc_publisher_matching_listener_drop
 
 Subscription
 ============
@@ -613,7 +614,7 @@ Functions
 ---------
 
 .. doxygenfunction:: z_declare_subscriber
-.. doxygenfunction:: z_undeclare_subscriber
+.. doxygenfunction:: z_declare_background_subscriber
 .. doxygenfunction:: z_subscriber_keyexpr
 
 .. doxygenfunction:: z_subscriber_drop
@@ -669,7 +670,7 @@ Types
 Functions
 ---------
 .. doxygenfunction:: z_declare_queryable
-.. doxygenfunction:: z_undeclare_queryable
+.. doxygenfunction:: z_declare_background_queryable
 .. doxygenfunction:: z_queryable_id
 
 .. doxygenfunction:: z_queryable_options_default
@@ -816,6 +817,7 @@ Types
 Functions
 ---------
 .. doxygenfunction:: zc_liveliness_declare_subscriber
+.. doxygenfunction:: zc_liveliness_declare_background_subscriber
 .. doxygenfunction:: zc_liveliness_get
 
 .. doxygenfunction:: zc_liveliness_declare_token
@@ -843,7 +845,6 @@ Functions
 ---------
 
 .. doxygenfunction:: ze_declare_publication_cache
-.. doxygenfunction:: ze_undeclare_publication_cache
 
 .. doxygenfunction:: ze_publication_cache_drop
 .. doxygenfunction:: ze_publication_cache_loan
@@ -867,7 +868,7 @@ Functions
 ---------
 
 .. doxygenfunction:: ze_declare_querying_subscriber
-.. doxygenfunction:: ze_undeclare_querying_subscriber
+.. doxygenfunction:: ze_declare_background_querying_subscriber
 .. doxygenfunction:: ze_querying_subscriber_get
 
 .. doxygenfunction:: ze_querying_subscriber_drop

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -92,7 +92,7 @@ Subscribe
           c = fgetc(stdin);
       }
 
-      z_undeclare_subscriber(z_move(sub));
+      z_drop(z_move(sub));
       z_drop(z_move(s));
       return 0;
   }
@@ -205,7 +205,7 @@ Queryable
           c = fgetc(stdin);
       }
 
-      z_undeclare_queryable(z_move(qable));
+      z_drop(z_move(qable));
       z_drop(z_move(s));
       return 0;
   }

--- a/examples/z_ping.c
+++ b/examples/z_ping.c
@@ -90,8 +90,8 @@ int main(int argc, char** argv) {
     z_mutex_unlock(z_loan_mut(mutex));
     z_free(results);
     z_free(data);
-    z_undeclare_subscriber(z_move(sub));
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(sub));
+    z_drop(z_move(pub));
     z_drop(z_move(mutex));
     z_drop(z_move(session));
 }

--- a/examples/z_ping_shm.c
+++ b/examples/z_ping_shm.c
@@ -133,8 +133,8 @@ int main(int argc, char** argv) {
     }
     z_mutex_unlock(z_loan_mut(mutex));
     z_free(results);
-    z_undeclare_subscriber(z_move(sub));
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(sub));
+    z_drop(z_move(pub));
     z_drop(z_move(mutex));
     z_drop(z_move(session));
 

--- a/examples/z_pong.c
+++ b/examples/z_pong.c
@@ -14,7 +14,7 @@ void callback(z_loaned_sample_t* sample, void* context) {
 }
 void drop(void* context) {
     z_owned_publisher_t* pub = (z_owned_publisher_t*)context;
-    z_undeclare_publisher(z_move(*pub));
+    z_drop(z_move(*pub));
     // A note on lifetimes:
     //  here, `sub` takes ownership of `pub` and will drop it before returning from its own `drop`,
     //  which makes passing a pointer to the stack safe as long as `sub` is dropped in a scope where `pub` is still
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
     while (1) {
         z_sleep_s(1);
     }
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(session));
 }
 

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -89,11 +89,11 @@ int main(int argc, char** argv) {
     }
 #if defined(Z_FEATURE_UNSTABLE_API)
     if (args.add_matching_listener) {
-        zc_publisher_matching_listener_undeclare(z_move(listener));
+        z_drop(z_move(listener));
     }
 #endif
 
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/z_pub_attachment.c
+++ b/examples/z_pub_attachment.c
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
 
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
 
     z_drop(z_move(s));
 

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -111,11 +111,11 @@ int main(int argc, char** argv) {
 
 #if defined(Z_FEATURE_UNSTABLE_API)
     if (args.add_matching_listener) {
-        zc_publisher_matching_listener_undeclare(z_move(listener));
+        z_drop(z_move(listener));
     }
 #endif
 
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
 
     z_drop(z_move(provider));

--- a/examples/z_pub_shm_thr.c
+++ b/examples/z_pub_shm_thr.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
     }
 
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
 
     z_drop(z_move(shm));

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -62,7 +62,7 @@ int main(int argc, char** argv) {
         z_publisher_put(z_loan(pub), z_move(to_send), NULL);
     }
 
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
 }
 

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
             }
         }
     }
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/z_queryable.c
+++ b/examples/z_queryable.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
         z_sleep_s(1);
     }
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/z_queryable_shm.c
+++ b/examples/z_queryable_shm.c
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
     z_drop(z_move(s));
     z_drop(z_move(layout));
     z_drop(z_move(provider));

--- a/examples/z_queryable_with_channels.c
+++ b/examples/z_queryable_with_channels.c
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
         z_drop(z_move(oquery));
     }
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
     z_drop(z_move(handler));
     z_drop(z_move(s));
     return 0;

--- a/examples/z_sub.c
+++ b/examples/z_sub.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
         z_sleep_s(1);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/z_sub_attachment.c
+++ b/examples/z_sub_attachment.c
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
         z_sleep_s(1);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/z_sub_liveliness.c
+++ b/examples/z_sub_liveliness.c
@@ -70,7 +70,7 @@ int main(int argc, char** argv) {
         z_sleep_s(1);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/z_sub_shm.c
+++ b/examples/z_sub_shm.c
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         z_sleep_s(1);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_undeclare_keyexpr(z_move(declared_ke), z_loan(s));
     z_drop(z_move(s));
     return 0;

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -16,6 +16,32 @@
 #define ALIGN(n)
 #define ZENOHC_API
 #endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Allocation errors
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef enum z_alloc_error_t {
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+  /**
+   * Defragmentation needed.
+   */
+  Z_ALLOC_ERROR_NEED_DEFRAGMENT,
+#endif
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+  /**
+   * The provider is out of memory.
+   */
+  Z_ALLOC_ERROR_OUT_OF_MEMORY,
+#endif
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+  /**
+   * Other error.
+   */
+  Z_ALLOC_ERROR_OTHER,
+#endif
+} z_alloc_error_t;
+#endif
 typedef enum z_congestion_control_t {
   /**
    * Messages are not dropped in case of congestion.
@@ -76,6 +102,26 @@ typedef enum z_keyexpr_intersection_level_t {
    */
   Z_KEYEXPR_INTERSECTION_LEVEL_EQUALS = 3,
 } z_keyexpr_intersection_level_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Layouting errors
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef enum z_layout_error_t {
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+  /**
+   * Layout arguments are incorrect.
+   */
+  Z_LAYOUT_ERROR_INCORRECT_LAYOUT_ARGS,
+#endif
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+  /**
+   * Layout incompatible with provider.
+   */
+  Z_LAYOUT_ERROR_PROVIDER_INCOMPATIBLE_LAYOUT,
+#endif
+} z_layout_error_t;
 #endif
 /**
  * The priority of zenoh messages.
@@ -170,6 +216,52 @@ typedef enum z_whatami_t {
   Z_WHATAMI_CLIENT = 4,
 } z_whatami_t;
 /**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Status of SHM buffer allocation operation.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef enum zc_buf_alloc_status_t {
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+  /**
+   * Allocation ok
+   */
+  ZC_BUF_ALLOC_STATUS_OK = 0,
+#endif
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+  /**
+   * Allocation error
+   */
+  ZC_BUF_ALLOC_STATUS_ALLOC_ERROR = 1,
+#endif
+} zc_buf_alloc_status_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Status of SHM buffer layouting + allocation operation.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef enum zc_buf_layout_alloc_status_t {
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+  /**
+   * Allocation ok
+   */
+  ZC_BUF_LAYOUT_ALLOC_STATUS_OK = 0,
+#endif
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+  /**
+   * Allocation error
+   */
+  ZC_BUF_LAYOUT_ALLOC_STATUS_ALLOC_ERROR = 1,
+#endif
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+  /**
+   * Layouting error
+   */
+  ZC_BUF_LAYOUT_ALLOC_STATUS_LAYOUT_ERROR = 2,
+#endif
+} zc_buf_layout_alloc_status_t;
+#endif
+/**
  * The locality of samples to be received by subscribers or targeted by publishers.
  */
 typedef enum zc_locality_t {
@@ -237,19 +329,56 @@ typedef enum zc_reply_keyexpr_t {
   ZC_REPLY_KEYEXPR_MATCHING_QUERY = 1,
 } zc_reply_keyexpr_t;
 #endif
-typedef struct z_moved_alloc_layout_t {
-  struct z_owned_alloc_layout_t _this;
-} z_moved_alloc_layout_t;
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief A result of SHM buffer allocation operation.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct z_buf_alloc_result_t {
+  enum zc_buf_alloc_status_t status;
+  z_owned_shm_mut_t buf;
+  enum z_alloc_error_t error;
+} z_buf_alloc_result_t;
+#endif
 typedef int8_t z_result_t;
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief An AllocAlignment.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct z_alloc_alignment_t {
+  uint8_t pow;
+} z_alloc_alignment_t;
+#endif
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct zc_threadsafe_context_data_t {
+  void *ptr;
+} zc_threadsafe_context_data_t;
+#endif
+/**
+ * A tread-safe droppable context.
+ * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
+ * information to each callback.
+ *
+ * This is a thread-safe context - the associated callbacks may be executed concurrently with the same
+ * zc_context_t instance. In other words, all the callbacks associated with this context data MUST be
+ * thread-safe.
+ *
+ * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted.The
+ * delete_fn is guaranteed to be executed only once at some point of time after the last associated
+ * callback call returns.
+ * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
+ * be executed.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct zc_threadsafe_context_t {
+  struct zc_threadsafe_context_data_t context;
+  void (*delete_fn)(void*);
+} zc_threadsafe_context_t;
+#endif
 typedef struct z_moved_bytes_t {
   struct z_owned_bytes_t _this;
 } z_moved_bytes_t;
-typedef struct z_moved_shm_t {
-  struct z_owned_shm_t _this;
-} z_moved_shm_t;
-typedef struct z_moved_shm_mut_t {
-  struct z_owned_shm_mut_t _this;
-} z_moved_shm_mut_t;
 typedef struct z_moved_slice_t {
   struct z_owned_slice_t _this;
 } z_moved_slice_t;
@@ -265,9 +394,41 @@ typedef struct ALIGN(8) z_bytes_slice_iterator_t {
 typedef struct z_moved_bytes_writer_t {
   struct z_owned_bytes_writer_t _this;
 } z_moved_bytes_writer_t;
-typedef struct z_moved_chunk_alloc_result_t {
-  struct z_owned_chunk_alloc_result_t _this;
-} z_moved_chunk_alloc_result_t;
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Unique segment identifier.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef uint32_t z_segment_id_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Chunk id within it's segment.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef uint32_t z_chunk_id_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief A ChunkDescriptor.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct z_chunk_descriptor_t {
+  z_segment_id_t segment;
+  z_chunk_id_t chunk;
+  size_t len;
+} z_chunk_descriptor_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief An AllocatedChunk.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct z_allocated_chunk_t {
+  struct z_chunk_descriptor_t descriptpr;
+  void *data;
+} z_allocated_chunk_t;
+#endif
 /**
  * Monotonic clock
  */
@@ -422,7 +583,7 @@ typedef struct z_owned_closure_zid_t {
   /**
    * A callback function.
    */
-  void (*call)(const struct z_id_t *z_id, void *context);
+  void (*call)(const z_id_t *z_id, void *context);
   /**
    * An optional function that will be called upon closure drop.
    */
@@ -444,6 +605,24 @@ typedef struct z_moved_condvar_t {
 typedef struct z_moved_config_t {
   struct z_owned_config_t _this;
 } z_moved_config_t;
+/**
+ * Options passed to the `z_declare_queryable()` function.
+ */
+typedef struct z_queryable_options_t {
+  /**
+   * The completeness of the Queryable.
+   */
+  bool complete;
+} z_queryable_options_t;
+/**
+ * Options passed to the `z_declare_subscriber()` function.
+ */
+typedef struct z_subscriber_options_t {
+  /**
+   * Dummy field to avoid having fieldless struct
+   */
+  uint8_t _0;
+} z_subscriber_options_t;
 typedef struct z_moved_encoding_t {
   struct z_owned_encoding_t _this;
 } z_moved_encoding_t;
@@ -484,24 +663,6 @@ typedef struct z_publisher_options_t {
   enum zc_locality_t allowed_destination;
 #endif
 } z_publisher_options_t;
-/**
- * Options passed to the `z_declare_queryable()` function.
- */
-typedef struct z_queryable_options_t {
-  /**
-   * The completeness of the Queryable.
-   */
-  bool complete;
-} z_queryable_options_t;
-/**
- * Options passed to the `z_declare_subscriber()` function.
- */
-typedef struct z_subscriber_options_t {
-  /**
-   * Dummy field to avoid having fieldless struct
-   */
-  uint8_t _0;
-} z_subscriber_options_t;
 /**
  * Options passed to the `z_delete()` function.
  */
@@ -554,9 +715,6 @@ typedef struct z_moved_fifo_handler_sample_t {
 typedef struct z_query_consolidation_t {
   enum z_consolidation_mode_t mode;
 } z_query_consolidation_t;
-typedef struct z_moved_source_info_t {
-  struct z_owned_source_info_t _this;
-} z_moved_source_info_t;
 /**
  * Options passed to the `z_get()` function.
  */
@@ -611,7 +769,7 @@ typedef struct z_get_options_t {
    *
    * The source info for the query.
    */
-  struct z_moved_source_info_t *source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * An optional attachment to attach to the query.
@@ -628,9 +786,6 @@ typedef struct z_moved_hello_t {
 typedef struct z_moved_keyexpr_t {
   struct z_owned_keyexpr_t _this;
 } z_moved_keyexpr_t;
-typedef struct z_moved_memory_layout_t {
-  struct z_owned_memory_layout_t _this;
-} z_moved_memory_layout_t;
 typedef struct z_moved_mutex_t {
   struct z_owned_mutex_t _this;
 } z_moved_mutex_t;
@@ -671,7 +826,7 @@ typedef struct z_publisher_put_options_t {
    *
    * The source info for the publication.
    */
-  struct z_moved_source_info_t *source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to attach to the publication.
@@ -724,7 +879,7 @@ typedef struct z_put_options_t {
    *
    * The source info for the message.
    */
-  struct z_moved_source_info_t *source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this message.
@@ -765,7 +920,7 @@ typedef struct z_query_reply_options_t {
    *
    * The source info for the reply.
    */
-  struct z_moved_source_info_t *source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
@@ -799,7 +954,7 @@ typedef struct z_query_reply_del_options_t {
    *
    * The source info for the reply.
    */
-  struct z_moved_source_info_t *source_info;
+  z_moved_source_info_t *source_info;
 #endif
   /**
    * The attachment to this reply.
@@ -853,15 +1008,46 @@ typedef struct z_scout_options_t {
 typedef struct z_moved_session_t {
   struct z_owned_session_t _this;
 } z_moved_session_t;
-typedef struct z_moved_shm_client_t {
-  struct z_owned_shm_client_t _this;
-} z_moved_shm_client_t;
-typedef struct z_moved_shm_client_storage_t {
-  struct z_owned_shm_client_storage_t _this;
-} z_moved_shm_client_storage_t;
-typedef struct z_moved_shm_provider_t {
-  struct z_owned_shm_provider_t _this;
-} z_moved_shm_provider_t;
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Callbacks for ShmSegment.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct zc_shm_segment_callbacks_t {
+  uint8_t *(*map_fn)(z_chunk_id_t chunk_id, void *context);
+} zc_shm_segment_callbacks_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief An ShmSegment.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct z_shm_segment_t {
+  struct zc_threadsafe_context_t context;
+  struct zc_shm_segment_callbacks_t callbacks;
+} z_shm_segment_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Callback for ShmClient.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct zc_shm_client_callbacks_t {
+  bool (*attach_fn)(struct z_shm_segment_t *out_segment, z_segment_id_t segment_id, void *context);
+} zc_shm_client_callbacks_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief A result of SHM buffer layouting + allocation operation.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct z_buf_layout_alloc_result_t {
+  enum zc_buf_layout_alloc_status_t status;
+  z_owned_shm_mut_t buf;
+  enum z_alloc_error_t alloc_error;
+  enum z_layout_error_t layout_error;
+} z_buf_layout_alloc_result_t;
+#endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Unique protocol identifier.
@@ -870,6 +1056,47 @@ typedef struct z_moved_shm_provider_t {
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 typedef uint32_t z_protocol_id_t;
+#endif
+/**
+ * A non-tread-safe droppable context.
+ * Contexts are idiomatically used in C together with callback interfaces to deliver associated state
+ * information to each callback.
+ *
+ * This is a non-thread-safe context - zenoh-c guarantees that associated callbacks that share the same
+ * zc_context_t instance will never be executed concurrently. In other words, all the callbacks associated
+ * with this context data are not required to be thread-safe.
+ *
+ * NOTE: Remember that the same callback interfaces associated with different zc_context_t instances can
+ * still be executed concurrently. The exact behavior depends on user's application, but we strongly
+ * discourage our users from pinning to some specific behavior unless they _really_ understand what they
+ * are doing.
+ *
+ * Once moved to zenoh-c ownership, this context is guaranteed to execute delete_fn when deleted. The
+ * delete_fn is guaranteed to be executed only once at some point of time after the last associated
+ * callback call returns.
+ * NOTE: if user doesn't pass the instance of this context to zenoh-c, the delete_fn callback won't
+ * be executed.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct zc_context_t {
+  void *context;
+  void (*delete_fn)(void*);
+} zc_context_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Callbacks for ShmProviderBackend.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+typedef struct zc_shm_provider_backend_callbacks_t {
+  void (*alloc_fn)(z_owned_chunk_alloc_result_t *out_result,
+                   const z_loaned_memory_layout_t *layout,
+                   void *context);
+  void (*free_fn)(const struct z_chunk_descriptor_t *chunk, void *context);
+  size_t (*defragment_fn)(void *context);
+  size_t (*available_fn)(void *context);
+  void (*layout_for_fn)(z_owned_memory_layout_t *layout, void *context);
+} zc_shm_provider_backend_callbacks_t;
 #endif
 typedef struct z_moved_string_array_t {
   struct z_owned_string_array_t _this;
@@ -960,6 +1187,15 @@ typedef struct zc_owned_closure_matching_status_t {
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Loaned closure.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+typedef struct zc_loaned_closure_matching_status_t {
+  size_t _0[3];
+} zc_loaned_closure_matching_status_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Moved closure.
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
@@ -993,45 +1229,6 @@ typedef struct zc_liveliness_subscriber_options_t {
 typedef struct zc_liveliness_get_options_t {
   uint32_t timeout_ms;
 } zc_liveliness_get_options_t;
-#endif
-typedef struct zc_moved_liveliness_token_t {
-  struct zc_owned_liveliness_token_t _this;
-} zc_moved_liveliness_token_t;
-typedef struct zc_moved_matching_listener_t {
-  struct zc_owned_matching_listener_t _this;
-} zc_moved_matching_listener_t;
-typedef struct zc_moved_shm_client_list_t {
-  struct zc_owned_shm_client_list_t _this;
-} zc_moved_shm_client_list_t;
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Options passed to the `ze_declare_publication_cache()` function.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-typedef struct ze_publication_cache_options_t {
-  /**
-   * The prefix used for queryable.
-   */
-  const struct z_loaned_keyexpr_t *queryable_prefix;
-#if defined(Z_FEATURE_UNSTABLE_API)
-  /**
-   * The restriction for the matching queries that will be receive by this publication cache.
-   */
-  enum zc_locality_t queryable_origin;
-#endif
-  /**
-   * The `complete` option for the queryable.
-   */
-  bool queryable_complete;
-  /**
-   * The the history size (i.e. maximum number of messages to store).
-   */
-  size_t history;
-  /**
-   * The limit number of cached resources.
-   */
-  size_t resources_limit;
-} ze_publication_cache_options_t;
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1071,19 +1268,36 @@ typedef struct ze_querying_subscriber_options_t {
   uint64_t query_timeout_ms;
 } ze_querying_subscriber_options_t;
 #endif
-typedef struct ze_moved_publication_cache_t {
-  struct ze_owned_publication_cache_t _this;
-} ze_moved_publication_cache_t;
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief A loaned Zenoh publication cache.
+ * @brief Options passed to the `ze_declare_publication_cache()` function.
  */
-typedef struct ALIGN(8) ze_loaned_publication_cache_t {
-  uint8_t _0[96];
-} ze_loaned_publication_cache_t;
-typedef struct ze_moved_querying_subscriber_t {
-  struct ze_owned_querying_subscriber_t _this;
-} ze_moved_querying_subscriber_t;
+#if defined(Z_FEATURE_UNSTABLE_API)
+typedef struct ze_publication_cache_options_t {
+  /**
+   * The prefix used for queryable.
+   */
+  const struct z_loaned_keyexpr_t *queryable_prefix;
+#if defined(Z_FEATURE_UNSTABLE_API)
+  /**
+   * The restriction for the matching queries that will be receive by this publication cache.
+   */
+  enum zc_locality_t queryable_origin;
+#endif
+  /**
+   * The `complete` option for the queryable.
+   */
+  bool queryable_complete;
+  /**
+   * The the history size (i.e. maximum number of messages to store).
+   */
+  size_t history;
+  /**
+   * The limit number of cached resources.
+   */
+  size_t resources_limit;
+} ze_publication_cache_options_t;
+#endif
 typedef struct ze_moved_serializer_t {
   struct ze_owned_serializer_t _this;
 } ze_moved_serializer_t;
@@ -1106,40 +1320,39 @@ ZENOHC_API extern const unsigned int Z_SHM_POSIX_PROTOCOL_ID;
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 void z_alloc_layout_alloc(struct z_buf_alloc_result_t *out_result,
-                          const struct z_loaned_alloc_layout_t *layout);
+                          const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 void z_alloc_layout_alloc_gc(struct z_buf_alloc_result_t *out_result,
-                             const struct z_loaned_alloc_layout_t *layout);
+                             const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag(struct z_buf_alloc_result_t *out_result,
-                                    const struct z_loaned_alloc_layout_t *layout);
+                                    const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_blocking(struct z_buf_alloc_result_t *out_result,
-                                             const struct z_loaned_alloc_layout_t *layout);
+                                             const z_loaned_alloc_layout_t *layout);
 #endif
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 void z_alloc_layout_alloc_gc_defrag_dealloc(struct z_buf_alloc_result_t *out_result,
-                                            const struct z_loaned_alloc_layout_t *layout);
+                                            const z_loaned_alloc_layout_t *layout);
 #endif
 /**
  * Deletes Alloc Layout
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
-ZENOHC_API void z_alloc_layout_drop(struct z_moved_alloc_layout_t *this_);
+ZENOHC_API void z_alloc_layout_drop(z_moved_alloc_layout_t *this_);
 #endif
 /**
  * Borrows Alloc Layout
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
-ZENOHC_API
-const struct z_loaned_alloc_layout_t *z_alloc_layout_loan(const struct z_owned_alloc_layout_t *this_);
+ZENOHC_API const z_loaned_alloc_layout_t *z_alloc_layout_loan(const z_owned_alloc_layout_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1147,15 +1360,15 @@ const struct z_loaned_alloc_layout_t *z_alloc_layout_loan(const struct z_owned_a
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-z_result_t z_alloc_layout_new(struct z_owned_alloc_layout_t *this_,
-                              const struct z_loaned_shm_provider_t *provider,
+z_result_t z_alloc_layout_new(z_owned_alloc_layout_t *this_,
+                              const z_loaned_shm_provider_t *provider,
                               size_t size,
                               struct z_alloc_alignment_t alignment);
 #endif
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 z_result_t z_alloc_layout_threadsafe_alloc_gc_defrag_async(struct z_buf_alloc_result_t *out_result,
-                                                           const struct z_loaned_alloc_layout_t *layout,
+                                                           const z_loaned_alloc_layout_t *layout,
                                                            struct zc_threadsafe_context_t result_context,
                                                            void (*result_callback)(void*,
                                                                                    struct z_buf_alloc_result_t*));
@@ -1225,7 +1438,7 @@ z_result_t z_bytes_from_buf(struct z_owned_bytes_t *this_,
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 z_result_t z_bytes_from_shm(struct z_owned_bytes_t *this_,
-                            struct z_moved_shm_t *shm);
+                            z_moved_shm_t *shm);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1234,7 +1447,7 @@ z_result_t z_bytes_from_shm(struct z_owned_bytes_t *this_,
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 z_result_t z_bytes_from_shm_mut(struct z_owned_bytes_t *this_,
-                                struct z_moved_shm_mut_t *shm);
+                                z_moved_shm_mut_t *shm);
 #endif
 /**
  * Converts a slice into `z_owned_bytes_t`.
@@ -1361,7 +1574,7 @@ bool z_bytes_slice_iterator_next(struct z_bytes_slice_iterator_t *this_,
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 z_result_t z_bytes_to_loaned_shm(const struct z_loaned_bytes_t *this_,
-                                 const struct z_loaned_shm_t **dst);
+                                 const z_loaned_shm_t **dst);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1373,7 +1586,7 @@ z_result_t z_bytes_to_loaned_shm(const struct z_loaned_bytes_t *this_,
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 z_result_t z_bytes_to_mut_loaned_shm(struct z_loaned_bytes_t *this_,
-                                     struct z_loaned_shm_t **dst);
+                                     z_loaned_shm_t **dst);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1385,7 +1598,7 @@ z_result_t z_bytes_to_mut_loaned_shm(struct z_loaned_bytes_t *this_,
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 z_result_t z_bytes_to_owned_shm(const struct z_loaned_bytes_t *this_,
-                                struct z_owned_shm_t *dst);
+                                z_owned_shm_t *dst);
 #endif
 /**
  * Converts data into an owned slice.
@@ -1458,7 +1671,7 @@ z_result_t z_bytes_writer_write_all(struct z_loaned_bytes_writer_t *this_,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_chunk_alloc_result_drop(struct z_moved_chunk_alloc_result_t *this_);
+void z_chunk_alloc_result_drop(z_moved_chunk_alloc_result_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1466,7 +1679,7 @@ void z_chunk_alloc_result_drop(struct z_moved_chunk_alloc_result_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-const struct z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const struct z_owned_chunk_alloc_result_t *this_);
+const z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1474,7 +1687,7 @@ const struct z_loaned_chunk_alloc_result_t *z_chunk_alloc_result_loan(const stru
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
+void z_chunk_alloc_result_new_error(z_owned_chunk_alloc_result_t *this_,
                                     enum z_alloc_error_t alloc_error);
 #endif
 /**
@@ -1483,7 +1696,7 @@ void z_chunk_alloc_result_new_error(struct z_owned_chunk_alloc_result_t *this_,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-z_result_t z_chunk_alloc_result_new_ok(struct z_owned_chunk_alloc_result_t *this_,
+z_result_t z_chunk_alloc_result_new_ok(z_owned_chunk_alloc_result_t *this_,
                                        struct z_allocated_chunk_t allocated_chunk);
 #endif
 /**
@@ -1633,7 +1846,7 @@ const struct z_loaned_closure_sample_t *z_closure_sample_loan(const struct z_own
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
 void z_closure_zid(struct z_owned_closure_zid_t *this_,
-                   void (*call)(const struct z_id_t *z_id, void *context),
+                   void (*call)(const z_id_t *z_id, void *context),
                    void (*drop)(void *context),
                    void *context);
 #endif
@@ -1644,7 +1857,7 @@ void z_closure_zid(struct z_owned_closure_zid_t *this_,
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
 void z_closure_zid_call(const struct z_loaned_closure_zid_t *closure,
-                        const struct z_id_t *z_id);
+                        const z_id_t *z_id);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -1714,6 +1927,38 @@ ZENOHC_API const struct z_loaned_config_t *z_config_loan(const struct z_owned_co
  */
 ZENOHC_API struct z_loaned_config_t *z_config_loan_mut(struct z_owned_config_t *this_);
 /**
+ * Declares a background queryable for a given keyexpr. The queryable callback will be be called
+ * to proccess incoming queries until the corresponding session is closed or dropped.
+ *
+ * @param session: The zenoh session.
+ * @param key_expr: The key expression the Queryable will reply to.
+ * @param callback: The callback function that will be called each time a matching query is received. Its ownership is passed to queryable.
+ * @param options: Options for the queryable.
+ *
+ * @return 0 in case of success, negative error code otherwise (in this case )
+ */
+ZENOHC_API
+z_result_t z_declare_background_queryable(const struct z_loaned_session_t *session,
+                                          const struct z_loaned_keyexpr_t *key_expr,
+                                          struct z_moved_closure_query_t *callback,
+                                          struct z_queryable_options_t *options);
+/**
+ * Constructs and declares a background subscriber. Subscriber callback will be called to process the messages,
+ * until the corresponding session is closed or dropped.
+ *
+ * @param session: The zenoh session.
+ * @param key_expr: The key expression to subscribe.
+ * @param callback: The callback function that will be called each time a data matching the subscribed expression is received.
+ * @param _options: The options to be passed to the subscriber declaration.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+ZENOHC_API
+z_result_t z_declare_background_subscriber(const struct z_loaned_session_t *session,
+                                           const struct z_loaned_keyexpr_t *key_expr,
+                                           struct z_moved_closure_sample_t *callback,
+                                           struct z_subscriber_options_t *_options);
+/**
  * Constructs and declares a key expression on the network. This reduces key key expression to a numerical id,
  * which allows to save the bandwith, when passing key expression between Zenoh entities.
  *
@@ -1762,7 +2007,7 @@ z_result_t z_declare_queryable(struct z_owned_queryable_t *this_,
                                struct z_moved_closure_query_t *callback,
                                struct z_queryable_options_t *options);
 /**
- * Constructs and declares a subscriber for a given key expression. Dropping subscriber
+ * Constructs and declares a subscriber for a given key expression. Dropping subscriber undeclares its callback.
  *
  * @param this_: An uninitialized location in memory, where subscriber will be constructed.
  * @param session: The zenoh session.
@@ -2297,7 +2542,7 @@ ZENOHC_API const struct z_loaned_encoding_t *z_encoding_zenoh_uint8(void);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-uint32_t z_entity_global_id_eid(const struct z_entity_global_id_t *this_);
+uint32_t z_entity_global_id_eid(const z_entity_global_id_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2305,7 +2550,7 @@ uint32_t z_entity_global_id_eid(const struct z_entity_global_id_t *this_);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-struct z_id_t z_entity_global_id_zid(const struct z_entity_global_id_t *this_);
+z_id_t z_entity_global_id_zid(const z_entity_global_id_t *this_);
 #endif
 /**
  * Constructs send and recieve ends of the fifo channel
@@ -2457,7 +2702,7 @@ ZENOHC_API enum z_whatami_t z_hello_whatami(const struct z_loaned_hello_t *this_
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-struct z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
+z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2465,7 +2710,7 @@ struct z_id_t z_hello_zid(const struct z_loaned_hello_t *this_);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-void z_id_to_string(const struct z_id_t *zid,
+void z_id_to_string(const z_id_t *zid,
                     struct z_owned_string_t *dst);
 #endif
 /**
@@ -2506,19 +2751,19 @@ z_result_t z_info_routers_zid(const struct z_loaned_session_t *session,
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-struct z_id_t z_info_zid(const struct z_loaned_session_t *session);
+z_id_t z_info_zid(const struct z_loaned_session_t *session);
 #endif
 /**
  * Returns ``true`` if `this` is valid.
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
-ZENOHC_API bool z_internal_alloc_layout_check(const struct z_owned_alloc_layout_t *this_);
+ZENOHC_API bool z_internal_alloc_layout_check(const z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Constructs Alloc Layout in its gravestone value.
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
-ZENOHC_API void z_internal_alloc_layout_null(struct z_owned_alloc_layout_t *this_);
+ZENOHC_API void z_internal_alloc_layout_null(z_owned_alloc_layout_t *this_);
 #endif
 /**
  * Returns ``true`` if `this_` is in a valid state, ``false`` if it is in a gravestone state.
@@ -2542,7 +2787,7 @@ ZENOHC_API void z_internal_bytes_writer_null(struct z_owned_bytes_writer_t *this
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-bool z_internal_chunk_alloc_result_check(const struct z_owned_chunk_alloc_result_t *this_);
+bool z_internal_chunk_alloc_result_check(const z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2550,7 +2795,7 @@ bool z_internal_chunk_alloc_result_check(const struct z_owned_chunk_alloc_result
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_internal_chunk_alloc_result_null(struct z_owned_chunk_alloc_result_t *this_);
+void z_internal_chunk_alloc_result_null(z_owned_chunk_alloc_result_t *this_);
 #endif
 /**
  * Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
@@ -2673,7 +2918,7 @@ ZENOHC_API void z_internal_keyexpr_null(struct z_owned_keyexpr_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-bool z_internal_memory_layout_check(const struct z_owned_memory_layout_t *this_);
+bool z_internal_memory_layout_check(const z_owned_memory_layout_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2681,7 +2926,7 @@ bool z_internal_memory_layout_check(const struct z_owned_memory_layout_t *this_)
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_internal_memory_layout_null(struct z_owned_memory_layout_t *this_);
+void z_internal_memory_layout_null(z_owned_memory_layout_t *this_);
 #endif
 /**
  * Returns ``true`` if mutex is valid, ``false`` otherwise.
@@ -2780,7 +3025,7 @@ ZENOHC_API void z_internal_session_null(struct z_owned_session_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-bool z_internal_shm_check(const struct z_owned_shm_t *this_);
+bool z_internal_shm_check(const z_owned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2788,7 +3033,7 @@ bool z_internal_shm_check(const struct z_owned_shm_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-bool z_internal_shm_client_check(const struct z_owned_shm_client_t *this_);
+bool z_internal_shm_client_check(const z_owned_shm_client_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2796,7 +3041,7 @@ bool z_internal_shm_client_check(const struct z_owned_shm_client_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_internal_shm_client_null(struct z_owned_shm_client_t *this_);
+void z_internal_shm_client_null(z_owned_shm_client_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2804,7 +3049,7 @@ void z_internal_shm_client_null(struct z_owned_shm_client_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-bool z_internal_shm_client_storage_check(const struct z_owned_shm_client_storage_t *this_);
+bool z_internal_shm_client_storage_check(const z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2812,7 +3057,7 @@ bool z_internal_shm_client_storage_check(const struct z_owned_shm_client_storage
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_internal_shm_client_storage_null(struct z_owned_shm_client_storage_t *this_);
+void z_internal_shm_client_storage_null(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2820,7 +3065,7 @@ void z_internal_shm_client_storage_null(struct z_owned_shm_client_storage_t *thi
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-bool z_internal_shm_mut_check(const struct z_owned_shm_mut_t *this_);
+bool z_internal_shm_mut_check(const z_owned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2828,7 +3073,7 @@ bool z_internal_shm_mut_check(const struct z_owned_shm_mut_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_internal_shm_mut_null(struct z_owned_shm_mut_t *this_);
+void z_internal_shm_mut_null(z_owned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2836,7 +3081,7 @@ void z_internal_shm_mut_null(struct z_owned_shm_mut_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_internal_shm_null(struct z_owned_shm_t *this_);
+void z_internal_shm_null(z_owned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2844,7 +3089,7 @@ void z_internal_shm_null(struct z_owned_shm_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-bool z_internal_shm_provider_check(const struct z_owned_shm_provider_t *this_);
+bool z_internal_shm_provider_check(const z_owned_shm_provider_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2852,7 +3097,7 @@ bool z_internal_shm_provider_check(const struct z_owned_shm_provider_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_internal_shm_provider_null(struct z_owned_shm_provider_t *this_);
+void z_internal_shm_provider_null(z_owned_shm_provider_t *this_);
 #endif
 /**
  * @return ``true`` if slice is not empty, ``false`` otherwise.
@@ -2868,7 +3113,7 @@ ZENOHC_API void z_internal_slice_null(struct z_owned_slice_t *this_);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-bool z_internal_source_info_check(const struct z_owned_source_info_t *this_);
+bool z_internal_source_info_check(const z_owned_source_info_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -2876,7 +3121,7 @@ bool z_internal_source_info_check(const struct z_owned_source_info_t *this_);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-void z_internal_source_info_null(struct z_owned_source_info_t *this_);
+void z_internal_source_info_null(z_owned_source_info_t *this_);
 #endif
 /**
  * @return ``true`` if the string array is valid, ``false`` if it is in a gravestone state.
@@ -3053,7 +3298,7 @@ enum z_keyexpr_intersection_level_t z_keyexpr_relation_to(const struct z_loaned_
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_memory_layout_drop(struct z_moved_memory_layout_t *this_);
+void z_memory_layout_drop(z_moved_memory_layout_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3061,7 +3306,7 @@ void z_memory_layout_drop(struct z_moved_memory_layout_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_memory_layout_get_data(const struct z_loaned_memory_layout_t *this_,
+void z_memory_layout_get_data(const z_loaned_memory_layout_t *this_,
                               size_t *out_size,
                               struct z_alloc_alignment_t *out_alignment);
 #endif
@@ -3071,7 +3316,7 @@ void z_memory_layout_get_data(const struct z_loaned_memory_layout_t *this_,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-const struct z_loaned_memory_layout_t *z_memory_layout_loan(const struct z_owned_memory_layout_t *this_);
+const z_loaned_memory_layout_t *z_memory_layout_loan(const z_owned_memory_layout_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3079,7 +3324,7 @@ const struct z_loaned_memory_layout_t *z_memory_layout_loan(const struct z_owned
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-z_result_t z_memory_layout_new(struct z_owned_memory_layout_t *this_,
+z_result_t z_memory_layout_new(z_owned_memory_layout_t *this_,
                                size_t size,
                                struct z_alloc_alignment_t alignment);
 #endif
@@ -3135,7 +3380,7 @@ ZENOHC_API void z_open_options_default(struct z_open_options_t *this_);
 ZENOHC_API
 z_result_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
                                           struct z_moved_config_t *config,
-                                          const struct z_loaned_shm_client_storage_t *shm_clients);
+                                          const z_loaned_shm_client_storage_t *shm_clients);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3143,7 +3388,7 @@ z_result_t z_open_with_custom_shm_clients(struct z_owned_session_t *this_,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_posix_shm_client_new(struct z_owned_shm_client_t *this_);
+void z_posix_shm_client_new(z_owned_shm_client_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3151,8 +3396,8 @@ void z_posix_shm_client_new(struct z_owned_shm_client_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-z_result_t z_posix_shm_provider_new(struct z_owned_shm_provider_t *this_,
-                                    const struct z_loaned_memory_layout_t *layout);
+z_result_t z_posix_shm_provider_new(z_owned_shm_provider_t *this_,
+                                    const z_loaned_memory_layout_t *layout);
 #endif
 /**
  * Returns the default value of #z_priority_t.
@@ -3180,7 +3425,7 @@ ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t *this_);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-struct z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
+z_entity_global_id_t z_publisher_id(const struct z_loaned_publisher_t *publisher);
 #endif
 /**
  * Returns the key expression of the publisher.
@@ -3391,18 +3636,16 @@ ZENOHC_API void z_query_reply_options_default(struct z_query_reply_options_t *th
  */
 ZENOHC_API enum z_query_target_t z_query_target_default(void);
 /**
- * Frees memory and resets queryable to its gravestone state.
- * The callback closure is not dropped, and thus the queries continue to be served until the corresponding session is closed.
+ * Undeclares queryable callback and resets it to its gravestone state.
  */
-ZENOHC_API
-void z_queryable_drop(struct z_moved_queryable_t *this_);
+ZENOHC_API void z_queryable_drop(struct z_moved_queryable_t *this_);
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Returns the ID of the queryable.
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-struct z_entity_global_id_t z_queryable_id(const struct z_loaned_queryable_t *queryable);
+z_entity_global_id_t z_queryable_id(const struct z_loaned_queryable_t *queryable);
 #endif
 ZENOHC_API
 const struct z_loaned_queryable_t *z_queryable_loan(const struct z_owned_queryable_t *this_);
@@ -3435,7 +3678,7 @@ ZENOHC_API uint8_t z_random_u8(void);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_ref_shm_client_storage_global(struct z_owned_shm_client_storage_t *this_);
+void z_ref_shm_client_storage_global(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3507,7 +3750,7 @@ ZENOHC_API const struct z_loaned_sample_t *z_reply_ok(const struct z_loaned_repl
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
 bool z_reply_replier_id(const struct z_loaned_reply_t *this_,
-                        struct z_id_t *out_id);
+                        z_id_t *out_id);
 #endif
 /**
  * Constructs send and recieve ends of the ring channel
@@ -3670,7 +3913,7 @@ enum z_reliability_t z_sample_reliability(const struct z_loaned_sample_t *this_)
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-const struct z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
+const z_loaned_source_info_t *z_sample_source_info(const struct z_loaned_sample_t *this_);
 #endif
 /**
  * Returns the sample timestamp.
@@ -3716,7 +3959,7 @@ ZENOHC_API struct z_loaned_session_t *z_session_loan_mut(struct z_owned_session_
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_client_drop(struct z_moved_shm_client_t *this_);
+void z_shm_client_drop(z_moved_shm_client_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3724,7 +3967,7 @@ void z_shm_client_drop(struct z_moved_shm_client_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_client_new(struct z_owned_shm_client_t *this_,
+void z_shm_client_new(z_owned_shm_client_t *this_,
                       struct zc_threadsafe_context_t context,
                       struct zc_shm_client_callbacks_t callbacks);
 #endif
@@ -3734,8 +3977,8 @@ void z_shm_client_new(struct z_owned_shm_client_t *this_,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_client_storage_clone(struct z_owned_shm_client_storage_t *this_,
-                                const struct z_loaned_shm_client_storage_t *from);
+void z_shm_client_storage_clone(z_owned_shm_client_storage_t *this_,
+                                const z_loaned_shm_client_storage_t *from);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3743,7 +3986,7 @@ void z_shm_client_storage_clone(struct z_owned_shm_client_storage_t *this_,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_client_storage_drop(struct z_moved_shm_client_storage_t *this_);
+void z_shm_client_storage_drop(z_moved_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3751,15 +3994,15 @@ void z_shm_client_storage_drop(struct z_moved_shm_client_storage_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-const struct z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const struct z_owned_shm_client_storage_t *this_);
+const z_loaned_shm_client_storage_t *z_shm_client_storage_loan(const z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-z_result_t z_shm_client_storage_new(struct z_owned_shm_client_storage_t *this_,
-                                    const struct zc_loaned_shm_client_list_t *clients,
+z_result_t z_shm_client_storage_new(z_owned_shm_client_storage_t *this_,
+                                    const zc_loaned_shm_client_list_t *clients,
                                     bool add_default_client_set);
 #endif
 /**
@@ -3767,7 +4010,7 @@ z_result_t z_shm_client_storage_new(struct z_owned_shm_client_storage_t *this_,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_client_storage_new_default(struct z_owned_shm_client_storage_t *this_);
+void z_shm_client_storage_new_default(z_owned_shm_client_storage_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3775,8 +4018,8 @@ void z_shm_client_storage_new_default(struct z_owned_shm_client_storage_t *this_
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_clone(struct z_owned_shm_t *out,
-                 const struct z_loaned_shm_t *this_);
+void z_shm_clone(z_owned_shm_t *out,
+                 const z_loaned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3784,7 +4027,7 @@ void z_shm_clone(struct z_owned_shm_t *out,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-const unsigned char *z_shm_data(const struct z_loaned_shm_t *this_);
+const unsigned char *z_shm_data(const z_loaned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3792,7 +4035,7 @@ const unsigned char *z_shm_data(const struct z_loaned_shm_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_drop(struct z_moved_shm_t *this_);
+void z_shm_drop(z_moved_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3800,8 +4043,8 @@ void z_shm_drop(struct z_moved_shm_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_from_mut(struct z_owned_shm_t *this_,
-                    struct z_moved_shm_mut_t *that);
+void z_shm_from_mut(z_owned_shm_t *this_,
+                    z_moved_shm_mut_t *that);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3809,7 +4052,7 @@ void z_shm_from_mut(struct z_owned_shm_t *this_,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-size_t z_shm_len(const struct z_loaned_shm_t *this_);
+size_t z_shm_len(const z_loaned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3817,13 +4060,13 @@ size_t z_shm_len(const struct z_loaned_shm_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-const struct z_loaned_shm_t *z_shm_loan(const struct z_owned_shm_t *this_);
+const z_loaned_shm_t *z_shm_loan(const z_owned_shm_t *this_);
 #endif
 /**
  * @brief Mutably borrows ZShm slice.
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
-ZENOHC_API struct z_loaned_shm_t *z_shm_loan_mut(struct z_owned_shm_t *this_);
+ZENOHC_API z_loaned_shm_t *z_shm_loan_mut(z_owned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3831,7 +4074,7 @@ ZENOHC_API struct z_loaned_shm_t *z_shm_loan_mut(struct z_owned_shm_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-const unsigned char *z_shm_mut_data(const struct z_loaned_shm_mut_t *this_);
+const unsigned char *z_shm_mut_data(const z_loaned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3839,7 +4082,7 @@ const unsigned char *z_shm_mut_data(const struct z_loaned_shm_mut_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-unsigned char *z_shm_mut_data_mut(struct z_loaned_shm_mut_t *this_);
+unsigned char *z_shm_mut_data_mut(z_loaned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3847,7 +4090,7 @@ unsigned char *z_shm_mut_data_mut(struct z_loaned_shm_mut_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_mut_drop(struct z_moved_shm_mut_t *this_);
+void z_shm_mut_drop(z_moved_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3855,7 +4098,7 @@ void z_shm_mut_drop(struct z_moved_shm_mut_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-size_t z_shm_mut_len(const struct z_loaned_shm_mut_t *this_);
+size_t z_shm_mut_len(const z_loaned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3863,7 +4106,7 @@ size_t z_shm_mut_len(const struct z_loaned_shm_mut_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-const struct z_loaned_shm_mut_t *z_shm_mut_loan(const struct z_owned_shm_mut_t *this_);
+const z_loaned_shm_mut_t *z_shm_mut_loan(const z_owned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3871,7 +4114,7 @@ const struct z_loaned_shm_mut_t *z_shm_mut_loan(const struct z_owned_shm_mut_t *
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-struct z_loaned_shm_mut_t *z_shm_mut_loan_mut(struct z_owned_shm_mut_t *this_);
+z_loaned_shm_mut_t *z_shm_mut_loan_mut(z_owned_shm_mut_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3885,9 +4128,9 @@ struct z_loaned_shm_mut_t *z_shm_mut_loan_mut(struct z_owned_shm_mut_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-z_result_t z_shm_mut_try_from_immut(struct z_owned_shm_mut_t *this_,
-                                    struct z_moved_shm_t *that,
-                                    struct z_owned_shm_t *immut);
+z_result_t z_shm_mut_try_from_immut(z_owned_shm_mut_t *this_,
+                                    z_moved_shm_t *that,
+                                    z_owned_shm_t *immut);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3895,7 +4138,7 @@ z_result_t z_shm_mut_try_from_immut(struct z_owned_shm_mut_t *this_,
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 void z_shm_provider_alloc(struct z_buf_layout_alloc_result_t *out_result,
-                          const struct z_loaned_shm_provider_t *provider,
+                          const z_loaned_shm_provider_t *provider,
                           size_t size,
                           struct z_alloc_alignment_t alignment);
 #endif
@@ -3905,7 +4148,7 @@ void z_shm_provider_alloc(struct z_buf_layout_alloc_result_t *out_result,
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 void z_shm_provider_alloc_gc(struct z_buf_layout_alloc_result_t *out_result,
-                             const struct z_loaned_shm_provider_t *provider,
+                             const z_loaned_shm_provider_t *provider,
                              size_t size,
                              struct z_alloc_alignment_t alignment);
 #endif
@@ -3915,7 +4158,7 @@ void z_shm_provider_alloc_gc(struct z_buf_layout_alloc_result_t *out_result,
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag(struct z_buf_layout_alloc_result_t *out_result,
-                                    const struct z_loaned_shm_provider_t *provider,
+                                    const z_loaned_shm_provider_t *provider,
                                     size_t size,
                                     struct z_alloc_alignment_t alignment);
 #endif
@@ -3925,7 +4168,7 @@ void z_shm_provider_alloc_gc_defrag(struct z_buf_layout_alloc_result_t *out_resu
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result_t *out_result,
-                                                const struct z_loaned_shm_provider_t *provider,
+                                                const z_loaned_shm_provider_t *provider,
                                                 size_t size,
                                                 struct z_alloc_alignment_t alignment,
                                                 struct zc_threadsafe_context_t result_context,
@@ -3938,7 +4181,7 @@ z_result_t z_shm_provider_alloc_gc_defrag_async(struct z_buf_layout_alloc_result
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_blocking(struct z_buf_layout_alloc_result_t *out_result,
-                                             const struct z_loaned_shm_provider_t *provider,
+                                             const z_loaned_shm_provider_t *provider,
                                              size_t size,
                                              struct z_alloc_alignment_t alignment);
 #endif
@@ -3948,7 +4191,7 @@ void z_shm_provider_alloc_gc_defrag_blocking(struct z_buf_layout_alloc_result_t 
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 void z_shm_provider_alloc_gc_defrag_dealloc(struct z_buf_layout_alloc_result_t *out_result,
-                                            const struct z_loaned_shm_provider_t *provider,
+                                            const z_loaned_shm_provider_t *provider,
                                             size_t size,
                                             struct z_alloc_alignment_t alignment);
 #endif
@@ -3957,14 +4200,14 @@ void z_shm_provider_alloc_gc_defrag_dealloc(struct z_buf_layout_alloc_result_t *
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-size_t z_shm_provider_available(const struct z_loaned_shm_provider_t *provider);
+size_t z_shm_provider_available(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-size_t z_shm_provider_defragment(const struct z_loaned_shm_provider_t *provider);
+size_t z_shm_provider_defragment(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3972,14 +4215,14 @@ size_t z_shm_provider_defragment(const struct z_loaned_shm_provider_t *provider)
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_provider_drop(struct z_moved_shm_provider_t *this_);
+void z_shm_provider_drop(z_moved_shm_provider_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-size_t z_shm_provider_garbage_collect(const struct z_loaned_shm_provider_t *provider);
+size_t z_shm_provider_garbage_collect(const z_loaned_shm_provider_t *provider);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -3987,15 +4230,15 @@ size_t z_shm_provider_garbage_collect(const struct z_loaned_shm_provider_t *prov
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-const struct z_loaned_shm_provider_t *z_shm_provider_loan(const struct z_owned_shm_provider_t *this_);
+const z_loaned_shm_provider_t *z_shm_provider_loan(const z_owned_shm_provider_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-z_result_t z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
-                              const struct z_loaned_shm_provider_t *provider,
+z_result_t z_shm_provider_map(z_owned_shm_mut_t *out_result,
+                              const z_loaned_shm_provider_t *provider,
                               struct z_allocated_chunk_t allocated_chunk,
                               size_t len);
 #endif
@@ -4005,7 +4248,7 @@ z_result_t z_shm_provider_map(struct z_owned_shm_mut_t *out_result,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
+void z_shm_provider_new(z_owned_shm_provider_t *this_,
                         z_protocol_id_t id,
                         struct zc_context_t context,
                         struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -4016,7 +4259,7 @@ void z_shm_provider_new(struct z_owned_shm_provider_t *this_,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
+void z_shm_provider_threadsafe_new(z_owned_shm_provider_t *this_,
                                    z_protocol_id_t id,
                                    struct zc_threadsafe_context_t context,
                                    struct zc_shm_provider_backend_callbacks_t callbacks);
@@ -4027,7 +4270,7 @@ void z_shm_provider_threadsafe_new(struct z_owned_shm_provider_t *this_,
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-struct z_loaned_shm_mut_t *z_shm_try_mut(struct z_owned_shm_t *this_);
+z_loaned_shm_mut_t *z_shm_try_mut(z_owned_shm_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4035,7 +4278,7 @@ struct z_loaned_shm_mut_t *z_shm_try_mut(struct z_owned_shm_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-struct z_loaned_shm_mut_t *z_shm_try_reloan_mut(struct z_loaned_shm_t *this_);
+z_loaned_shm_mut_t *z_shm_try_reloan_mut(z_loaned_shm_t *this_);
 #endif
 /**
  * Puts current thread to sleep for specified amount of milliseconds.
@@ -4108,7 +4351,7 @@ ZENOHC_API const struct z_loaned_slice_t *z_slice_loan(const struct z_owned_slic
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-void z_source_info_drop(struct z_moved_source_info_t *this_);
+void z_source_info_drop(z_moved_source_info_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4116,7 +4359,7 @@ void z_source_info_drop(struct z_moved_source_info_t *this_);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-struct z_entity_global_id_t z_source_info_id(const struct z_loaned_source_info_t *this_);
+z_entity_global_id_t z_source_info_id(const z_loaned_source_info_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4124,7 +4367,7 @@ struct z_entity_global_id_t z_source_info_id(const struct z_loaned_source_info_t
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-const struct z_loaned_source_info_t *z_source_info_loan(const struct z_owned_source_info_t *this_);
+const z_loaned_source_info_t *z_source_info_loan(const z_owned_source_info_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4132,8 +4375,8 @@ const struct z_loaned_source_info_t *z_source_info_loan(const struct z_owned_sou
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-z_result_t z_source_info_new(struct z_owned_source_info_t *this_,
-                             const struct z_entity_global_id_t *source_id,
+z_result_t z_source_info_new(z_owned_source_info_t *this_,
+                             const z_entity_global_id_t *source_id,
                              uint32_t source_sn);
 #endif
 /**
@@ -4142,7 +4385,7 @@ z_result_t z_source_info_new(struct z_owned_source_info_t *this_,
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-uint32_t z_source_info_sn(const struct z_loaned_source_info_t *this_);
+uint32_t z_source_info_sn(const z_loaned_source_info_t *this_);
 #endif
 /**
  * Constructs an owned copy of a string array.
@@ -4260,11 +4503,9 @@ ZENOHC_API size_t z_string_len(const struct z_loaned_string_t *this_);
  */
 ZENOHC_API const struct z_loaned_string_t *z_string_loan(const struct z_owned_string_t *this_);
 /**
- * Drops subscriber and resets it to its gravestone state.
- * The callback closure is not dropped and still keeps receiving and processing samples until the corresponding session is closed.
+ * Undeclares subscriber callback and resets it to its gravestone state.
  */
-ZENOHC_API
-void z_subscriber_drop(struct z_moved_subscriber_t *this_);
+ZENOHC_API void z_subscriber_drop(struct z_moved_subscriber_t *this_);
 /**
  * Returns the key expression of the subscriber.
  */
@@ -4336,7 +4577,7 @@ const char *z_time_now_as_str(const char *buf,
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-struct z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
+z_id_t z_timestamp_id(const struct z_timestamp_t *this_);
 #endif
 /**
  * Create uhlc timestamp from session id.
@@ -4356,24 +4597,6 @@ ZENOHC_API uint64_t z_timestamp_ntp64_time(const struct z_timestamp_t *this_);
 ZENOHC_API
 z_result_t z_undeclare_keyexpr(struct z_moved_keyexpr_t *this_,
                                const struct z_loaned_session_t *session);
-/**
- * @brief Undeclares the given publisher, droping and invalidating it.
- *
- * @return 0 in case of success, negative error code otherwise.
- */
-ZENOHC_API z_result_t z_undeclare_publisher(struct z_moved_publisher_t *this_);
-/**
- * Undeclares a `z_owned_queryable_t` and drops it.
- *
- * Returns 0 in case of success, negative error code otherwise.
- */
-ZENOHC_API z_result_t z_undeclare_queryable(struct z_moved_queryable_t *this_);
-/**
- * Undeclares and drops subscriber.
- *
- * @return 0 in case of success, negative error code otherwise.
- */
-ZENOHC_API z_result_t z_undeclare_subscriber(struct z_moved_subscriber_t *this_);
 /**
  * Constructs a view key expression in empty state
  */
@@ -4728,7 +4951,7 @@ void zc_internal_closure_matching_status_null(struct zc_owned_closure_matching_s
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-bool zc_internal_liveliness_token_check(const struct zc_owned_liveliness_token_t *this_);
+bool zc_internal_liveliness_token_check(const zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4736,7 +4959,7 @@ bool zc_internal_liveliness_token_check(const struct zc_owned_liveliness_token_t
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-void zc_internal_liveliness_token_null(struct zc_owned_liveliness_token_t *this_);
+void zc_internal_liveliness_token_null(zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4744,7 +4967,7 @@ void zc_internal_liveliness_token_null(struct zc_owned_liveliness_token_t *this_
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-bool zc_internal_matching_listener_check(const struct zc_owned_matching_listener_t *this_);
+bool zc_internal_matching_listener_check(const zc_owned_matching_listener_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4752,7 +4975,7 @@ bool zc_internal_matching_listener_check(const struct zc_owned_matching_listener
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-void zc_internal_matching_listener_null(struct zc_owned_matching_listener_t *this_);
+void zc_internal_matching_listener_null(zc_owned_matching_listener_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4760,7 +4983,7 @@ void zc_internal_matching_listener_null(struct zc_owned_matching_listener_t *thi
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-bool zc_internal_shm_client_list_check(const struct zc_owned_shm_client_list_t *this_);
+bool zc_internal_shm_client_list_check(const zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4768,7 +4991,7 @@ bool zc_internal_shm_client_list_check(const struct zc_owned_shm_client_list_t *
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void zc_internal_shm_client_list_null(struct zc_owned_shm_client_list_t *this_);
+void zc_internal_shm_client_list_null(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4777,6 +5000,24 @@ void zc_internal_shm_client_list_null(struct zc_owned_shm_client_list_t *this_);
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
 void zc_liveliness_declaration_options_default(struct zc_liveliness_declaration_options_t *this_);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Declares a background subscriber on liveliness tokens that intersect `key_expr`. Subscriber callback will be called to process the messages,
+ * until the corresponding session is closed or dropped.
+ * @param session: The Zenoh session.
+ * @param key_expr: The key expression to subscribe to.
+ * @param callback: The callback function that will be called each time a liveliness token status is changed.
+ * @param options: The options to be passed to the liveliness subscriber declaration.
+ *
+ * @return 0 in case of success, negative error values otherwise.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+z_result_t zc_liveliness_declare_background_subscriber(const struct z_loaned_session_t *session,
+                                                       const struct z_loaned_keyexpr_t *key_expr,
+                                                       struct z_moved_closure_sample_t *callback,
+                                                       struct zc_liveliness_subscriber_options_t *options);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4812,7 +5053,7 @@ z_result_t zc_liveliness_declare_subscriber(struct z_owned_subscriber_t *this_,
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-z_result_t zc_liveliness_declare_token(struct zc_owned_liveliness_token_t *this_,
+z_result_t zc_liveliness_declare_token(zc_owned_liveliness_token_t *this_,
                                        const struct z_loaned_session_t *session,
                                        const struct z_loaned_keyexpr_t *key_expr,
                                        const struct zc_liveliness_declaration_options_t *_options);
@@ -4855,7 +5096,7 @@ void zc_liveliness_subscriber_options_default(struct zc_liveliness_subscriber_op
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-void zc_liveliness_token_drop(struct zc_moved_liveliness_token_t *this_);
+void zc_liveliness_token_drop(zc_moved_liveliness_token_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4863,7 +5104,7 @@ void zc_liveliness_token_drop(struct zc_moved_liveliness_token_t *this_);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-const struct zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const struct zc_owned_liveliness_token_t *this_);
+const zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const zc_owned_liveliness_token_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4871,7 +5112,7 @@ const struct zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const struct
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-z_result_t zc_liveliness_undeclare_token(struct zc_moved_liveliness_token_t *this_);
+z_result_t zc_liveliness_undeclare_token(zc_moved_liveliness_token_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4904,27 +5145,32 @@ z_result_t zc_publisher_get_matching_status(const struct z_loaned_publisher_t *t
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-z_result_t zc_publisher_matching_listener_declare(struct zc_owned_matching_listener_t *this_,
+z_result_t zc_publisher_matching_listener_declare(zc_owned_matching_listener_t *this_,
                                                   const struct z_loaned_publisher_t *publisher,
                                                   struct zc_moved_closure_matching_status_t *callback);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Undeclares the given matching listener, droping and invalidating it.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-void zc_publisher_matching_listener_drop(struct zc_moved_matching_listener_t *this_);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Undeclares the given matching listener, droping and invalidating it.
+ * @brief Declares a matching listener, registering a callback for notifying subscribers matching with a given publisher.
+ * The callback will be run in the background until the corresponding publisher is dropped.
+ *
+ * @param publisher: A publisher to associate with matching listener.
+ * @param callback: A closure that will be called every time the matching status of the publisher changes (If last subscriber, disconnects or when the first subscriber connects).
  *
  * @return 0 in case of success, negative error code otherwise.
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-z_result_t zc_publisher_matching_listener_undeclare(struct zc_moved_matching_listener_t *this_);
+z_result_t zc_publisher_matching_listener_declare_background(const struct z_loaned_publisher_t *publisher,
+                                                             struct zc_moved_closure_matching_status_t *callback);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Undeclares the given matching listener, droping and invalidating it.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+void zc_publisher_matching_listener_drop(zc_moved_matching_listener_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4939,9 +5185,9 @@ enum zc_reply_keyexpr_t zc_reply_keyexpr_default(void);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-z_result_t zc_shm_client_list_add_client(struct zc_loaned_shm_client_list_t *this_,
+z_result_t zc_shm_client_list_add_client(zc_loaned_shm_client_list_t *this_,
                                          z_protocol_id_t id,
-                                         struct z_moved_shm_client_t *client);
+                                         z_moved_shm_client_t *client);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4949,7 +5195,7 @@ z_result_t zc_shm_client_list_add_client(struct zc_loaned_shm_client_list_t *thi
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void zc_shm_client_list_drop(struct zc_moved_shm_client_list_t *this_);
+void zc_shm_client_list_drop(zc_moved_shm_client_list_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4957,7 +5203,7 @@ void zc_shm_client_list_drop(struct zc_moved_shm_client_list_t *this_);
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-const struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const struct zc_owned_shm_client_list_t *this_);
+const zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4965,7 +5211,7 @@ const struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan(const struct z
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(struct zc_owned_shm_client_list_t *this_);
+zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4973,7 +5219,7 @@ struct zc_loaned_shm_client_list_t *zc_shm_client_list_loan_mut(struct zc_owned_
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
-void zc_shm_client_list_new(struct zc_owned_shm_client_list_t *this_);
+void zc_shm_client_list_new(zc_owned_shm_client_list_t *this_);
 #endif
 /**
  * Stops all Zenoh tasks and drops all related static variables.
@@ -4994,6 +5240,25 @@ ZENOHC_API
 void zc_try_init_log_from_env(void);
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Declares a background querying subscriber for a given key expression. Subscriber callback will be called to process the messages,
+ * until the corresponding session is closed or dropped.
+ *
+ * @param session: A Zenoh session.
+ * @param key_expr: A key expression to subscribe to.
+ * @param callback: The callback function that will be called each time a data matching the subscribed expression is received.
+ * @param options: Additional options for the querying subscriber.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+z_result_t ze_declare_background_querying_subscriber(const struct z_loaned_session_t *session,
+                                                     const struct z_loaned_keyexpr_t *key_expr,
+                                                     struct z_moved_closure_sample_t *callback,
+                                                     struct ze_querying_subscriber_options_t *options);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Constructs and declares a publication cache.
  *
  * @param this_: An uninitialized location in memory where publication cache will be constructed.
@@ -5005,7 +5270,7 @@ void zc_try_init_log_from_env(void);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-z_result_t ze_declare_publication_cache(struct ze_owned_publication_cache_t *this_,
+z_result_t ze_declare_publication_cache(ze_owned_publication_cache_t *this_,
                                         const struct z_loaned_session_t *session,
                                         const struct z_loaned_keyexpr_t *key_expr,
                                         struct ze_publication_cache_options_t *options);
@@ -5024,7 +5289,7 @@ z_result_t ze_declare_publication_cache(struct ze_owned_publication_cache_t *thi
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-z_result_t ze_declare_querying_subscriber(struct ze_owned_querying_subscriber_t *this_,
+z_result_t ze_declare_querying_subscriber(ze_owned_querying_subscriber_t *this_,
                                           const struct z_loaned_session_t *session,
                                           const struct z_loaned_keyexpr_t *key_expr,
                                           struct z_moved_closure_sample_t *callback,
@@ -5209,7 +5474,7 @@ ZENOHC_API bool ze_deserializer_is_done(const struct ze_deserializer_t *this_);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-bool ze_internal_publication_cache_check(const struct ze_owned_publication_cache_t *this_);
+bool ze_internal_publication_cache_check(const ze_owned_publication_cache_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5217,7 +5482,7 @@ bool ze_internal_publication_cache_check(const struct ze_owned_publication_cache
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-void ze_internal_publication_cache_null(struct ze_owned_publication_cache_t *this_);
+void ze_internal_publication_cache_null(ze_owned_publication_cache_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5225,13 +5490,13 @@ void ze_internal_publication_cache_null(struct ze_owned_publication_cache_t *thi
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-bool ze_internal_querying_subscriber_check(const struct ze_owned_querying_subscriber_t *this_);
+bool ze_internal_querying_subscriber_check(const ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * Constructs a querying subscriber in a gravestone state.
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API void ze_internal_querying_subscriber_null(struct ze_owned_querying_subscriber_t *this_);
+ZENOHC_API void ze_internal_querying_subscriber_null(ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * @brief Returns ``true`` if `this_` is in a valid state, ``false`` if it is in a gravestone state.
@@ -5247,7 +5512,7 @@ ZENOHC_API void ze_internal_serializer_null(struct ze_owned_serializer_t *this_)
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-void ze_publication_cache_drop(struct ze_moved_publication_cache_t *this_);
+void ze_publication_cache_drop(ze_moved_publication_cache_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5255,7 +5520,7 @@ void ze_publication_cache_drop(struct ze_moved_publication_cache_t *this_);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-const struct z_loaned_keyexpr_t *ze_publication_cache_keyexpr(const struct ze_loaned_publication_cache_t *this_);
+const struct z_loaned_keyexpr_t *ze_publication_cache_keyexpr(const ze_loaned_publication_cache_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5263,7 +5528,7 @@ const struct z_loaned_keyexpr_t *ze_publication_cache_keyexpr(const struct ze_lo
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-const struct ze_loaned_publication_cache_t *ze_publication_cache_loan(const struct ze_owned_publication_cache_t *this_);
+const ze_loaned_publication_cache_t *ze_publication_cache_loan(const ze_owned_publication_cache_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5275,12 +5540,11 @@ void ze_publication_cache_options_default(struct ze_publication_cache_options_t 
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Drops querying subscriber.
- * The callback closure is not dropped, and thus the queries continue to be served until the corresponding session is closed.
+ * @brief Undeclares querying subscriber callback and resets it to its gravestone state.
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_t *this_);
+void ze_querying_subscriber_drop(ze_moved_querying_subscriber_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5290,7 +5554,7 @@ void ze_querying_subscriber_drop(struct ze_moved_querying_subscriber_t *this_);
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-z_result_t ze_querying_subscriber_get(const struct ze_loaned_querying_subscriber_t *this_,
+z_result_t ze_querying_subscriber_get(const ze_loaned_querying_subscriber_t *this_,
                                       const struct z_loaned_keyexpr_t *selector,
                                       struct z_get_options_t *options);
 #endif
@@ -5300,7 +5564,7 @@ z_result_t ze_querying_subscriber_get(const struct ze_loaned_querying_subscriber
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-const struct ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const struct ze_owned_querying_subscriber_t *this_);
+const ze_loaned_querying_subscriber_t *ze_querying_subscriber_loan(const ze_owned_querying_subscriber_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5485,22 +5749,3 @@ ZENOHC_API void ze_serializer_serialize_uint64(struct ze_loaned_serializer_t *th
  * @brief Serializes an unsigned integer.
  */
 ZENOHC_API void ze_serializer_serialize_uint8(struct ze_loaned_serializer_t *this_, uint8_t val);
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Undeclares and drops publication cache.
- * @return 0 in case of success, negative error code otherwise.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-z_result_t ze_undeclare_publication_cache(struct ze_moved_publication_cache_t *this_);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Undeclares the given querying subscriber, drops it and resets to a gravestone state.
- *
- * @return 0 in case of success, negative error code otherwise.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-z_result_t ze_undeclare_querying_subscriber(struct ze_moved_querying_subscriber_t *this_);
-#endif

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -4,15 +4,12 @@
 
 #ifndef __cplusplus
 
-static inline z_moved_alloc_layout_t* z_alloc_layout_move(z_owned_alloc_layout_t* x) { return (z_moved_alloc_layout_t*)(x); }
 static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return (z_moved_bytes_t*)(x); }
 static inline z_moved_bytes_writer_t* z_bytes_writer_move(z_owned_bytes_writer_t* x) { return (z_moved_bytes_writer_t*)(x); }
-static inline z_moved_chunk_alloc_result_t* z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return (z_moved_chunk_alloc_result_t*)(x); }
 static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return (z_moved_closure_hello_t*)(x); }
 static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return (z_moved_closure_query_t*)(x); }
 static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return (z_moved_closure_reply_t*)(x); }
 static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return (z_moved_closure_sample_t*)(x); }
-static inline z_moved_closure_zid_t* z_closure_zid_move(z_owned_closure_zid_t* x) { return (z_moved_closure_zid_t*)(x); }
 static inline z_moved_condvar_t* z_condvar_move(z_owned_condvar_t* x) { return (z_moved_condvar_t*)(x); }
 static inline z_moved_config_t* z_config_move(z_owned_config_t* x) { return (z_moved_config_t*)(x); }
 static inline z_moved_encoding_t* z_encoding_move(z_owned_encoding_t* x) { return (z_moved_encoding_t*)(x); }
@@ -21,7 +18,6 @@ static inline z_moved_fifo_handler_reply_t* z_fifo_handler_reply_move(z_owned_fi
 static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return (z_moved_fifo_handler_sample_t*)(x); }
 static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return (z_moved_hello_t*)(x); }
 static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return (z_moved_keyexpr_t*)(x); }
-static inline z_moved_memory_layout_t* z_memory_layout_move(z_owned_memory_layout_t* x) { return (z_moved_memory_layout_t*)(x); }
 static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return (z_moved_mutex_t*)(x); }
 static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return (z_moved_publisher_t*)(x); }
 static inline z_moved_query_t* z_query_move(z_owned_query_t* x) { return (z_moved_query_t*)(x); }
@@ -33,38 +29,23 @@ static inline z_moved_ring_handler_reply_t* z_ring_handler_reply_move(z_owned_ri
 static inline z_moved_ring_handler_sample_t* z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return (z_moved_ring_handler_sample_t*)(x); }
 static inline z_moved_sample_t* z_sample_move(z_owned_sample_t* x) { return (z_moved_sample_t*)(x); }
 static inline z_moved_session_t* z_session_move(z_owned_session_t* x) { return (z_moved_session_t*)(x); }
-static inline z_moved_shm_client_t* z_shm_client_move(z_owned_shm_client_t* x) { return (z_moved_shm_client_t*)(x); }
-static inline z_moved_shm_client_storage_t* z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return (z_moved_shm_client_storage_t*)(x); }
-static inline z_moved_shm_t* z_shm_move(z_owned_shm_t* x) { return (z_moved_shm_t*)(x); }
-static inline z_moved_shm_mut_t* z_shm_mut_move(z_owned_shm_mut_t* x) { return (z_moved_shm_mut_t*)(x); }
-static inline z_moved_shm_provider_t* z_shm_provider_move(z_owned_shm_provider_t* x) { return (z_moved_shm_provider_t*)(x); }
 static inline z_moved_slice_t* z_slice_move(z_owned_slice_t* x) { return (z_moved_slice_t*)(x); }
-static inline z_moved_source_info_t* z_source_info_move(z_owned_source_info_t* x) { return (z_moved_source_info_t*)(x); }
 static inline z_moved_string_array_t* z_string_array_move(z_owned_string_array_t* x) { return (z_moved_string_array_t*)(x); }
 static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return (z_moved_string_t*)(x); }
 static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return (z_moved_subscriber_t*)(x); }
 static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return (z_moved_task_t*)(x); }
 static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return (zc_moved_closure_log_t*)(x); }
-static inline zc_moved_closure_matching_status_t* zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return (zc_moved_closure_matching_status_t*)(x); }
-static inline zc_moved_liveliness_token_t* zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return (zc_moved_liveliness_token_t*)(x); }
-static inline zc_moved_matching_listener_t* zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return (zc_moved_matching_listener_t*)(x); }
-static inline zc_moved_shm_client_list_t* zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return (zc_moved_shm_client_list_t*)(x); }
-static inline ze_moved_publication_cache_t* ze_publication_cache_move(ze_owned_publication_cache_t* x) { return (ze_moved_publication_cache_t*)(x); }
-static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return (ze_moved_querying_subscriber_t*)(x); }
 static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x) { return (ze_moved_serializer_t*)(x); }
 
 
 #define z_loan(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_alloc_layout_loan, \
         z_owned_bytes_t : z_bytes_loan, \
         z_owned_bytes_writer_t : z_bytes_writer_loan, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_loan, \
         z_owned_closure_hello_t : z_closure_hello_loan, \
         z_owned_closure_query_t : z_closure_query_loan, \
         z_owned_closure_reply_t : z_closure_reply_loan, \
         z_owned_closure_sample_t : z_closure_sample_loan, \
-        z_owned_closure_zid_t : z_closure_zid_loan, \
         z_owned_condvar_t : z_condvar_loan, \
         z_owned_config_t : z_config_loan, \
         z_owned_encoding_t : z_encoding_loan, \
@@ -73,7 +54,6 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_loan, \
         z_owned_hello_t : z_hello_loan, \
         z_owned_keyexpr_t : z_keyexpr_loan, \
-        z_owned_memory_layout_t : z_memory_layout_loan, \
         z_owned_publisher_t : z_publisher_loan, \
         z_owned_query_t : z_query_loan, \
         z_owned_queryable_t : z_queryable_loan, \
@@ -84,12 +64,7 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_ring_handler_sample_t : z_ring_handler_sample_loan, \
         z_owned_sample_t : z_sample_loan, \
         z_owned_session_t : z_session_loan, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_loan, \
-        z_owned_shm_t : z_shm_loan, \
-        z_owned_shm_mut_t : z_shm_mut_loan, \
-        z_owned_shm_provider_t : z_shm_provider_loan, \
         z_owned_slice_t : z_slice_loan, \
-        z_owned_source_info_t : z_source_info_loan, \
         z_owned_string_array_t : z_string_array_loan, \
         z_owned_string_t : z_string_loan, \
         z_owned_subscriber_t : z_subscriber_loan, \
@@ -97,11 +72,6 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_view_slice_t : z_view_slice_loan, \
         z_view_string_t : z_view_string_loan, \
         zc_owned_closure_log_t : zc_closure_log_loan, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_loan, \
-        zc_owned_liveliness_token_t : zc_liveliness_token_loan, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_loan, \
-        ze_owned_publication_cache_t : ze_publication_cache_loan, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_loan, \
         ze_owned_serializer_t : ze_serializer_loan \
     )(&this_)
 
@@ -115,24 +85,18 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_mutex_t : z_mutex_loan_mut, \
         z_owned_publisher_t : z_publisher_loan_mut, \
         z_owned_session_t : z_session_loan_mut, \
-        z_owned_shm_t : z_shm_loan_mut, \
-        z_owned_shm_mut_t : z_shm_mut_loan_mut, \
         z_owned_string_array_t : z_string_array_loan_mut, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_loan_mut, \
         ze_owned_serializer_t : ze_serializer_loan_mut \
     )(&this_)
 
 #define z_drop(this_) \
     _Generic((this_), \
-        z_moved_alloc_layout_t* : z_alloc_layout_drop, \
         z_moved_bytes_t* : z_bytes_drop, \
         z_moved_bytes_writer_t* : z_bytes_writer_drop, \
-        z_moved_chunk_alloc_result_t* : z_chunk_alloc_result_drop, \
         z_moved_closure_hello_t* : z_closure_hello_drop, \
         z_moved_closure_query_t* : z_closure_query_drop, \
         z_moved_closure_reply_t* : z_closure_reply_drop, \
         z_moved_closure_sample_t* : z_closure_sample_drop, \
-        z_moved_closure_zid_t* : z_closure_zid_drop, \
         z_moved_condvar_t* : z_condvar_drop, \
         z_moved_config_t* : z_config_drop, \
         z_moved_encoding_t* : z_encoding_drop, \
@@ -141,7 +105,6 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_moved_fifo_handler_sample_t* : z_fifo_handler_sample_drop, \
         z_moved_hello_t* : z_hello_drop, \
         z_moved_keyexpr_t* : z_keyexpr_drop, \
-        z_moved_memory_layout_t* : z_memory_layout_drop, \
         z_moved_mutex_t* : z_mutex_drop, \
         z_moved_publisher_t* : z_publisher_drop, \
         z_moved_query_t* : z_query_drop, \
@@ -153,38 +116,23 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_moved_ring_handler_sample_t* : z_ring_handler_sample_drop, \
         z_moved_sample_t* : z_sample_drop, \
         z_moved_session_t* : z_session_drop, \
-        z_moved_shm_client_t* : z_shm_client_drop, \
-        z_moved_shm_client_storage_t* : z_shm_client_storage_drop, \
-        z_moved_shm_t* : z_shm_drop, \
-        z_moved_shm_mut_t* : z_shm_mut_drop, \
-        z_moved_shm_provider_t* : z_shm_provider_drop, \
         z_moved_slice_t* : z_slice_drop, \
-        z_moved_source_info_t* : z_source_info_drop, \
         z_moved_string_array_t* : z_string_array_drop, \
         z_moved_string_t* : z_string_drop, \
         z_moved_subscriber_t* : z_subscriber_drop, \
         z_moved_task_t* : z_task_drop, \
         zc_moved_closure_log_t* : zc_closure_log_drop, \
-        zc_moved_closure_matching_status_t* : zc_closure_matching_status_drop, \
-        zc_moved_liveliness_token_t* : zc_liveliness_token_drop, \
-        zc_moved_matching_listener_t* : zc_publisher_matching_listener_drop, \
-        zc_moved_shm_client_list_t* : zc_shm_client_list_drop, \
-        ze_moved_publication_cache_t* : ze_publication_cache_drop, \
-        ze_moved_querying_subscriber_t* : ze_querying_subscriber_drop, \
         ze_moved_serializer_t* : ze_serializer_drop \
     )(this_)
 
 #define z_move(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_alloc_layout_move, \
         z_owned_bytes_t : z_bytes_move, \
         z_owned_bytes_writer_t : z_bytes_writer_move, \
-        z_owned_chunk_alloc_result_t : z_chunk_alloc_result_move, \
         z_owned_closure_hello_t : z_closure_hello_move, \
         z_owned_closure_query_t : z_closure_query_move, \
         z_owned_closure_reply_t : z_closure_reply_move, \
         z_owned_closure_sample_t : z_closure_sample_move, \
-        z_owned_closure_zid_t : z_closure_zid_move, \
         z_owned_condvar_t : z_condvar_move, \
         z_owned_config_t : z_config_move, \
         z_owned_encoding_t : z_encoding_move, \
@@ -193,7 +141,6 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_fifo_handler_sample_t : z_fifo_handler_sample_move, \
         z_owned_hello_t : z_hello_move, \
         z_owned_keyexpr_t : z_keyexpr_move, \
-        z_owned_memory_layout_t : z_memory_layout_move, \
         z_owned_mutex_t : z_mutex_move, \
         z_owned_publisher_t : z_publisher_move, \
         z_owned_query_t : z_query_move, \
@@ -205,38 +152,23 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_ring_handler_sample_t : z_ring_handler_sample_move, \
         z_owned_sample_t : z_sample_move, \
         z_owned_session_t : z_session_move, \
-        z_owned_shm_client_t : z_shm_client_move, \
-        z_owned_shm_client_storage_t : z_shm_client_storage_move, \
-        z_owned_shm_t : z_shm_move, \
-        z_owned_shm_mut_t : z_shm_mut_move, \
-        z_owned_shm_provider_t : z_shm_provider_move, \
         z_owned_slice_t : z_slice_move, \
-        z_owned_source_info_t : z_source_info_move, \
         z_owned_string_array_t : z_string_array_move, \
         z_owned_string_t : z_string_move, \
         z_owned_subscriber_t : z_subscriber_move, \
         z_owned_task_t : z_task_move, \
         zc_owned_closure_log_t : zc_closure_log_move, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_move, \
-        zc_owned_liveliness_token_t : zc_liveliness_token_move, \
-        zc_owned_matching_listener_t : zc_publisher_matching_listener_move, \
-        zc_owned_shm_client_list_t : zc_shm_client_list_move, \
-        ze_owned_publication_cache_t : ze_publication_cache_move, \
-        ze_owned_querying_subscriber_t : ze_querying_subscriber_move, \
         ze_owned_serializer_t : ze_serializer_move \
     )(&this_)
 
 #define z_internal_null(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t* : z_internal_alloc_layout_null, \
         z_owned_bytes_t* : z_internal_bytes_null, \
         z_owned_bytes_writer_t* : z_internal_bytes_writer_null, \
-        z_owned_chunk_alloc_result_t* : z_internal_chunk_alloc_result_null, \
         z_owned_closure_hello_t* : z_internal_closure_hello_null, \
         z_owned_closure_query_t* : z_internal_closure_query_null, \
         z_owned_closure_reply_t* : z_internal_closure_reply_null, \
         z_owned_closure_sample_t* : z_internal_closure_sample_null, \
-        z_owned_closure_zid_t* : z_internal_closure_zid_null, \
         z_owned_condvar_t* : z_internal_condvar_null, \
         z_owned_config_t* : z_internal_config_null, \
         z_owned_encoding_t* : z_internal_encoding_null, \
@@ -245,7 +177,6 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_fifo_handler_sample_t* : z_internal_fifo_handler_sample_null, \
         z_owned_hello_t* : z_internal_hello_null, \
         z_owned_keyexpr_t* : z_internal_keyexpr_null, \
-        z_owned_memory_layout_t* : z_internal_memory_layout_null, \
         z_owned_mutex_t* : z_internal_mutex_null, \
         z_owned_publisher_t* : z_internal_publisher_null, \
         z_owned_query_t* : z_internal_query_null, \
@@ -257,36 +188,21 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_ring_handler_sample_t* : z_internal_ring_handler_sample_null, \
         z_owned_sample_t* : z_internal_sample_null, \
         z_owned_session_t* : z_internal_session_null, \
-        z_owned_shm_client_t* : z_internal_shm_client_null, \
-        z_owned_shm_client_storage_t* : z_internal_shm_client_storage_null, \
-        z_owned_shm_mut_t* : z_internal_shm_mut_null, \
-        z_owned_shm_t* : z_internal_shm_null, \
-        z_owned_shm_provider_t* : z_internal_shm_provider_null, \
         z_owned_slice_t* : z_internal_slice_null, \
-        z_owned_source_info_t* : z_internal_source_info_null, \
         z_owned_string_array_t* : z_internal_string_array_null, \
         z_owned_string_t* : z_internal_string_null, \
         z_owned_subscriber_t* : z_internal_subscriber_null, \
         z_owned_task_t* : z_internal_task_null, \
         zc_owned_closure_log_t* : zc_internal_closure_log_null, \
-        zc_owned_closure_matching_status_t* : zc_internal_closure_matching_status_null, \
-        zc_owned_liveliness_token_t* : zc_internal_liveliness_token_null, \
-        zc_owned_matching_listener_t* : zc_internal_matching_listener_null, \
-        zc_owned_shm_client_list_t* : zc_internal_shm_client_list_null, \
-        ze_owned_publication_cache_t* : ze_internal_publication_cache_null, \
-        ze_owned_querying_subscriber_t* : ze_internal_querying_subscriber_null, \
         ze_owned_serializer_t* : ze_internal_serializer_null \
     )(this_)
 
-static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) { *this_ = x->_this; z_internal_alloc_layout_null(&x->_this); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *this_ = x->_this; z_internal_bytes_null(&x->_this); }
 static inline void z_bytes_writer_take(z_owned_bytes_writer_t* this_, z_moved_bytes_writer_t* x) { *this_ = x->_this; z_internal_bytes_writer_null(&x->_this); }
-static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) { *this_ = x->_this; z_internal_chunk_alloc_result_null(&x->_this); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_internal_closure_hello_null(&x->_this); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_internal_closure_query_null(&x->_this); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_internal_closure_reply_null(&x->_this); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_internal_closure_sample_null(&x->_this); }
-static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) { *closure_ = x->_this; z_internal_closure_zid_null(&x->_this); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) { *this_ = x->_this; z_internal_condvar_null(&x->_this); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t* x) { *this_ = x->_this; z_internal_config_null(&x->_this); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t* x) { *this_ = x->_this; z_internal_encoding_null(&x->_this); }
@@ -295,7 +211,6 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t* x) { *this_ = x->_this; z_internal_fifo_handler_sample_null(&x->_this); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_internal_hello_null(&x->_this); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_internal_keyexpr_null(&x->_this); }
-static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) { *this_ = x->_this; z_internal_memory_layout_null(&x->_this); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_internal_mutex_null(&x->_this); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_internal_publisher_null(&x->_this); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t* x) { *this_ = x->_this; z_internal_query_null(&x->_this); }
@@ -307,38 +222,23 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t* x) { *this_ = x->_this; z_internal_ring_handler_sample_null(&x->_this); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t* x) { *this_ = x->_this; z_internal_sample_null(&x->_this); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t* x) { *this_ = x->_this; z_internal_session_null(&x->_this); }
-static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) { *this_ = x->_this; z_internal_shm_client_null(&x->_this); }
-static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) { *this_ = x->_this; z_internal_shm_client_storage_null(&x->_this); }
-static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t* x) { *this_ = x->_this; z_internal_shm_null(&x->_this); }
-static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) { *this_ = x->_this; z_internal_shm_mut_null(&x->_this); }
-static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) { *this_ = x->_this; z_internal_shm_provider_null(&x->_this); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t* x) { *this_ = x->_this; z_internal_slice_null(&x->_this); }
-static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) { *this_ = x->_this; z_internal_source_info_null(&x->_this); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) { *this_ = x->_this; z_internal_string_array_null(&x->_this); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) { *this_ = x->_this; z_internal_string_null(&x->_this); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_internal_subscriber_null(&x->_this); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_internal_task_null(&x->_this); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_internal_closure_log_null(&x->_this); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) { *closure_ = x->_this; zc_internal_closure_matching_status_null(&x->_this); }
-static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) { *this_ = x->_this; zc_internal_liveliness_token_null(&x->_this); }
-static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) { *this_ = x->_this; zc_internal_matching_listener_null(&x->_this); }
-static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) { *this_ = x->_this; zc_internal_shm_client_list_null(&x->_this); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) { *this_ = x->_this; ze_internal_publication_cache_null(&x->_this); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) { *this_ = x->_this; ze_internal_querying_subscriber_null(&x->_this); }
 static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_serializer_t* x) { *this_ = x->_this; ze_internal_serializer_null(&x->_this); }
 
 
 #define z_take(this_, x) \
     _Generic((this_), \
-        z_owned_alloc_layout_t* : z_alloc_layout_take, \
         z_owned_bytes_t* : z_bytes_take, \
         z_owned_bytes_writer_t* : z_bytes_writer_take, \
-        z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_take, \
         z_owned_closure_hello_t* : z_closure_hello_take, \
         z_owned_closure_query_t* : z_closure_query_take, \
         z_owned_closure_reply_t* : z_closure_reply_take, \
         z_owned_closure_sample_t* : z_closure_sample_take, \
-        z_owned_closure_zid_t* : z_closure_zid_take, \
         z_owned_condvar_t* : z_condvar_take, \
         z_owned_config_t* : z_config_take, \
         z_owned_encoding_t* : z_encoding_take, \
@@ -347,7 +247,6 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_fifo_handler_sample_t* : z_fifo_handler_sample_take, \
         z_owned_hello_t* : z_hello_take, \
         z_owned_keyexpr_t* : z_keyexpr_take, \
-        z_owned_memory_layout_t* : z_memory_layout_take, \
         z_owned_mutex_t* : z_mutex_take, \
         z_owned_publisher_t* : z_publisher_take, \
         z_owned_query_t* : z_query_take, \
@@ -359,38 +258,23 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_ring_handler_sample_t* : z_ring_handler_sample_take, \
         z_owned_sample_t* : z_sample_take, \
         z_owned_session_t* : z_session_take, \
-        z_owned_shm_client_t* : z_shm_client_take, \
-        z_owned_shm_client_storage_t* : z_shm_client_storage_take, \
-        z_owned_shm_t* : z_shm_take, \
-        z_owned_shm_mut_t* : z_shm_mut_take, \
-        z_owned_shm_provider_t* : z_shm_provider_take, \
         z_owned_slice_t* : z_slice_take, \
-        z_owned_source_info_t* : z_source_info_take, \
         z_owned_string_array_t* : z_string_array_take, \
         z_owned_string_t* : z_string_take, \
         z_owned_subscriber_t* : z_subscriber_take, \
         z_owned_task_t* : z_task_take, \
         zc_owned_closure_log_t* : zc_closure_log_take, \
-        zc_owned_closure_matching_status_t* : zc_closure_matching_status_take, \
-        zc_owned_liveliness_token_t* : zc_liveliness_token_take, \
-        zc_owned_matching_listener_t* : zc_publisher_matching_listener_take, \
-        zc_owned_shm_client_list_t* : zc_shm_client_list_take, \
-        ze_owned_publication_cache_t* : ze_publication_cache_take, \
-        ze_owned_querying_subscriber_t* : ze_querying_subscriber_take, \
         ze_owned_serializer_t* : ze_serializer_take \
     )(this_, x)
 
 #define z_internal_check(this_) \
     _Generic((this_), \
-        z_owned_alloc_layout_t : z_internal_alloc_layout_check, \
         z_owned_bytes_t : z_internal_bytes_check, \
         z_owned_bytes_writer_t : z_internal_bytes_writer_check, \
-        z_owned_chunk_alloc_result_t : z_internal_chunk_alloc_result_check, \
         z_owned_closure_hello_t : z_internal_closure_hello_check, \
         z_owned_closure_query_t : z_internal_closure_query_check, \
         z_owned_closure_reply_t : z_internal_closure_reply_check, \
         z_owned_closure_sample_t : z_internal_closure_sample_check, \
-        z_owned_closure_zid_t : z_internal_closure_zid_check, \
         z_owned_condvar_t : z_internal_condvar_check, \
         z_owned_config_t : z_internal_config_check, \
         z_owned_encoding_t : z_internal_encoding_check, \
@@ -399,7 +283,6 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_fifo_handler_sample_t : z_internal_fifo_handler_sample_check, \
         z_owned_hello_t : z_internal_hello_check, \
         z_owned_keyexpr_t : z_internal_keyexpr_check, \
-        z_owned_memory_layout_t : z_internal_memory_layout_check, \
         z_owned_mutex_t : z_internal_mutex_check, \
         z_owned_publisher_t : z_internal_publisher_check, \
         z_owned_query_t : z_internal_query_check, \
@@ -411,24 +294,12 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_ring_handler_sample_t : z_internal_ring_handler_sample_check, \
         z_owned_sample_t : z_internal_sample_check, \
         z_owned_session_t : z_internal_session_check, \
-        z_owned_shm_t : z_internal_shm_check, \
-        z_owned_shm_client_t : z_internal_shm_client_check, \
-        z_owned_shm_client_storage_t : z_internal_shm_client_storage_check, \
-        z_owned_shm_mut_t : z_internal_shm_mut_check, \
-        z_owned_shm_provider_t : z_internal_shm_provider_check, \
         z_owned_slice_t : z_internal_slice_check, \
-        z_owned_source_info_t : z_internal_source_info_check, \
         z_owned_string_array_t : z_internal_string_array_check, \
         z_owned_string_t : z_internal_string_check, \
         z_owned_subscriber_t : z_internal_subscriber_check, \
         z_owned_task_t : z_internal_task_check, \
         zc_owned_closure_log_t : zc_internal_closure_log_check, \
-        zc_owned_closure_matching_status_t : zc_internal_closure_matching_status_check, \
-        zc_owned_liveliness_token_t : zc_internal_liveliness_token_check, \
-        zc_owned_matching_listener_t : zc_internal_matching_listener_check, \
-        zc_owned_shm_client_list_t : zc_internal_shm_client_list_check, \
-        ze_owned_publication_cache_t : ze_internal_publication_cache_check, \
-        ze_owned_querying_subscriber_t : ze_internal_querying_subscriber_check, \
         ze_owned_serializer_t : ze_internal_serializer_check \
     )(&this_)
 
@@ -437,9 +308,7 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         const z_loaned_closure_hello_t* : z_closure_hello_call, \
         const z_loaned_closure_query_t* : z_closure_query_call, \
         const z_loaned_closure_reply_t* : z_closure_reply_call, \
-        const z_loaned_closure_sample_t* : z_closure_sample_call, \
-        const z_loaned_closure_zid_t* : z_closure_zid_call, \
-        const zc_loaned_closure_matching_status_t* : zc_closure_matching_status_call \
+        const z_loaned_closure_sample_t* : z_closure_sample_call \
     )(closure, hello)
 
 #define z_closure(this_, call, drop, context) \
@@ -448,9 +317,7 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_closure_query_t* : z_closure_query, \
         z_owned_closure_reply_t* : z_closure_reply, \
         z_owned_closure_sample_t* : z_closure_sample, \
-        z_owned_closure_zid_t* : z_closure_zid, \
-        zc_owned_closure_log_t* : zc_closure_log, \
-        zc_owned_closure_matching_status_t* : zc_closure_matching_status \
+        zc_owned_closure_log_t* : zc_closure_log \
     )(this_, call, drop, context)
 
 #define z_try_recv(this_, query) \
@@ -484,8 +351,6 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_reply_t* : z_reply_clone, \
         z_owned_reply_err_t* : z_reply_err_clone, \
         z_owned_sample_t* : z_sample_clone, \
-        z_owned_shm_client_storage_t* : z_shm_client_storage_clone, \
-        z_owned_shm_t* : z_shm_clone, \
         z_owned_slice_t* : z_slice_clone, \
         z_owned_string_array_t* : z_string_array_clone, \
         z_owned_string_t* : z_string_clone \
@@ -493,15 +358,12 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
 #else  // #ifndef __cplusplus
 
 
-static inline z_moved_alloc_layout_t* z_alloc_layout_move(z_owned_alloc_layout_t* x) { return reinterpret_cast<z_moved_alloc_layout_t*>(x); }
 static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return reinterpret_cast<z_moved_bytes_t*>(x); }
 static inline z_moved_bytes_writer_t* z_bytes_writer_move(z_owned_bytes_writer_t* x) { return reinterpret_cast<z_moved_bytes_writer_t*>(x); }
-static inline z_moved_chunk_alloc_result_t* z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return reinterpret_cast<z_moved_chunk_alloc_result_t*>(x); }
 static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return reinterpret_cast<z_moved_closure_hello_t*>(x); }
 static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return reinterpret_cast<z_moved_closure_query_t*>(x); }
 static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return reinterpret_cast<z_moved_closure_reply_t*>(x); }
 static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return reinterpret_cast<z_moved_closure_sample_t*>(x); }
-static inline z_moved_closure_zid_t* z_closure_zid_move(z_owned_closure_zid_t* x) { return reinterpret_cast<z_moved_closure_zid_t*>(x); }
 static inline z_moved_condvar_t* z_condvar_move(z_owned_condvar_t* x) { return reinterpret_cast<z_moved_condvar_t*>(x); }
 static inline z_moved_config_t* z_config_move(z_owned_config_t* x) { return reinterpret_cast<z_moved_config_t*>(x); }
 static inline z_moved_encoding_t* z_encoding_move(z_owned_encoding_t* x) { return reinterpret_cast<z_moved_encoding_t*>(x); }
@@ -510,7 +372,6 @@ static inline z_moved_fifo_handler_reply_t* z_fifo_handler_reply_move(z_owned_fi
 static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_fifo_handler_sample_t* x) { return reinterpret_cast<z_moved_fifo_handler_sample_t*>(x); }
 static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return reinterpret_cast<z_moved_hello_t*>(x); }
 static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return reinterpret_cast<z_moved_keyexpr_t*>(x); }
-static inline z_moved_memory_layout_t* z_memory_layout_move(z_owned_memory_layout_t* x) { return reinterpret_cast<z_moved_memory_layout_t*>(x); }
 static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return reinterpret_cast<z_moved_mutex_t*>(x); }
 static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return reinterpret_cast<z_moved_publisher_t*>(x); }
 static inline z_moved_query_t* z_query_move(z_owned_query_t* x) { return reinterpret_cast<z_moved_query_t*>(x); }
@@ -522,37 +383,22 @@ static inline z_moved_ring_handler_reply_t* z_ring_handler_reply_move(z_owned_ri
 static inline z_moved_ring_handler_sample_t* z_ring_handler_sample_move(z_owned_ring_handler_sample_t* x) { return reinterpret_cast<z_moved_ring_handler_sample_t*>(x); }
 static inline z_moved_sample_t* z_sample_move(z_owned_sample_t* x) { return reinterpret_cast<z_moved_sample_t*>(x); }
 static inline z_moved_session_t* z_session_move(z_owned_session_t* x) { return reinterpret_cast<z_moved_session_t*>(x); }
-static inline z_moved_shm_client_t* z_shm_client_move(z_owned_shm_client_t* x) { return reinterpret_cast<z_moved_shm_client_t*>(x); }
-static inline z_moved_shm_client_storage_t* z_shm_client_storage_move(z_owned_shm_client_storage_t* x) { return reinterpret_cast<z_moved_shm_client_storage_t*>(x); }
-static inline z_moved_shm_t* z_shm_move(z_owned_shm_t* x) { return reinterpret_cast<z_moved_shm_t*>(x); }
-static inline z_moved_shm_mut_t* z_shm_mut_move(z_owned_shm_mut_t* x) { return reinterpret_cast<z_moved_shm_mut_t*>(x); }
-static inline z_moved_shm_provider_t* z_shm_provider_move(z_owned_shm_provider_t* x) { return reinterpret_cast<z_moved_shm_provider_t*>(x); }
 static inline z_moved_slice_t* z_slice_move(z_owned_slice_t* x) { return reinterpret_cast<z_moved_slice_t*>(x); }
-static inline z_moved_source_info_t* z_source_info_move(z_owned_source_info_t* x) { return reinterpret_cast<z_moved_source_info_t*>(x); }
 static inline z_moved_string_array_t* z_string_array_move(z_owned_string_array_t* x) { return reinterpret_cast<z_moved_string_array_t*>(x); }
 static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return reinterpret_cast<z_moved_string_t*>(x); }
 static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return reinterpret_cast<z_moved_subscriber_t*>(x); }
 static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return reinterpret_cast<z_moved_task_t*>(x); }
 static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return reinterpret_cast<zc_moved_closure_log_t*>(x); }
-static inline zc_moved_closure_matching_status_t* zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return reinterpret_cast<zc_moved_closure_matching_status_t*>(x); }
-static inline zc_moved_liveliness_token_t* zc_liveliness_token_move(zc_owned_liveliness_token_t* x) { return reinterpret_cast<zc_moved_liveliness_token_t*>(x); }
-static inline zc_moved_matching_listener_t* zc_publisher_matching_listener_move(zc_owned_matching_listener_t* x) { return reinterpret_cast<zc_moved_matching_listener_t*>(x); }
-static inline zc_moved_shm_client_list_t* zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return reinterpret_cast<zc_moved_shm_client_list_t*>(x); }
-static inline ze_moved_publication_cache_t* ze_publication_cache_move(ze_owned_publication_cache_t* x) { return reinterpret_cast<ze_moved_publication_cache_t*>(x); }
-static inline ze_moved_querying_subscriber_t* ze_querying_subscriber_move(ze_owned_querying_subscriber_t* x) { return reinterpret_cast<ze_moved_querying_subscriber_t*>(x); }
 static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x) { return reinterpret_cast<ze_moved_serializer_t*>(x); }
 
 
 
-inline const z_loaned_alloc_layout_t* z_loan(const z_owned_alloc_layout_t& this_) { return z_alloc_layout_loan(&this_); };
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& this_) { return z_bytes_loan(&this_); };
 inline const z_loaned_bytes_writer_t* z_loan(const z_owned_bytes_writer_t& this_) { return z_bytes_writer_loan(&this_); };
-inline const z_loaned_chunk_alloc_result_t* z_loan(const z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_loan(&this_); };
 inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t& closure) { return z_closure_hello_loan(&closure); };
 inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t& closure) { return z_closure_query_loan(&closure); };
 inline const z_loaned_closure_reply_t* z_loan(const z_owned_closure_reply_t& closure) { return z_closure_reply_loan(&closure); };
 inline const z_loaned_closure_sample_t* z_loan(const z_owned_closure_sample_t& closure) { return z_closure_sample_loan(&closure); };
-inline const z_loaned_closure_zid_t* z_loan(const z_owned_closure_zid_t& closure) { return z_closure_zid_loan(&closure); };
 inline const z_loaned_condvar_t* z_loan(const z_owned_condvar_t& this_) { return z_condvar_loan(&this_); };
 inline const z_loaned_config_t* z_loan(const z_owned_config_t& this_) { return z_config_loan(&this_); };
 inline const z_loaned_encoding_t* z_loan(const z_owned_encoding_t& this_) { return z_encoding_loan(&this_); };
@@ -561,7 +407,6 @@ inline const z_loaned_fifo_handler_reply_t* z_loan(const z_owned_fifo_handler_re
 inline const z_loaned_fifo_handler_sample_t* z_loan(const z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_loan(&this_); };
 inline const z_loaned_hello_t* z_loan(const z_owned_hello_t& this_) { return z_hello_loan(&this_); };
 inline const z_loaned_keyexpr_t* z_loan(const z_owned_keyexpr_t& this_) { return z_keyexpr_loan(&this_); };
-inline const z_loaned_memory_layout_t* z_loan(const z_owned_memory_layout_t& this_) { return z_memory_layout_loan(&this_); };
 inline const z_loaned_publisher_t* z_loan(const z_owned_publisher_t& this_) { return z_publisher_loan(&this_); };
 inline const z_loaned_query_t* z_loan(const z_owned_query_t& this_) { return z_query_loan(&this_); };
 inline const z_loaned_queryable_t* z_loan(const z_owned_queryable_t& this_) { return z_queryable_loan(&this_); };
@@ -572,12 +417,7 @@ inline const z_loaned_ring_handler_reply_t* z_loan(const z_owned_ring_handler_re
 inline const z_loaned_ring_handler_sample_t* z_loan(const z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_loan(&this_); };
 inline const z_loaned_sample_t* z_loan(const z_owned_sample_t& this_) { return z_sample_loan(&this_); };
 inline const z_loaned_session_t* z_loan(const z_owned_session_t& this_) { return z_session_loan(&this_); };
-inline const z_loaned_shm_client_storage_t* z_loan(const z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_loan(&this_); };
-inline const z_loaned_shm_t* z_loan(const z_owned_shm_t& this_) { return z_shm_loan(&this_); };
-inline const z_loaned_shm_mut_t* z_loan(const z_owned_shm_mut_t& this_) { return z_shm_mut_loan(&this_); };
-inline const z_loaned_shm_provider_t* z_loan(const z_owned_shm_provider_t& this_) { return z_shm_provider_loan(&this_); };
 inline const z_loaned_slice_t* z_loan(const z_owned_slice_t& this_) { return z_slice_loan(&this_); };
-inline const z_loaned_source_info_t* z_loan(const z_owned_source_info_t& this_) { return z_source_info_loan(&this_); };
 inline const z_loaned_string_array_t* z_loan(const z_owned_string_array_t& this_) { return z_string_array_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_owned_string_t& this_) { return z_string_loan(&this_); };
 inline const z_loaned_subscriber_t* z_loan(const z_owned_subscriber_t& this_) { return z_subscriber_loan(&this_); };
@@ -585,11 +425,6 @@ inline const z_loaned_keyexpr_t* z_loan(const z_view_keyexpr_t& this_) { return 
 inline const z_loaned_slice_t* z_loan(const z_view_slice_t& this_) { return z_view_slice_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_view_string_t& this_) { return z_view_string_loan(&this_); };
 inline const zc_loaned_closure_log_t* z_loan(const zc_owned_closure_log_t& closure) { return zc_closure_log_loan(&closure); };
-inline const zc_loaned_closure_matching_status_t* z_loan(const zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_loan(&closure); };
-inline const zc_loaned_liveliness_token_t* z_loan(const zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_loan(&this_); };
-inline const zc_loaned_shm_client_list_t* z_loan(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan(&this_); };
-inline const ze_loaned_publication_cache_t* z_loan(const ze_owned_publication_cache_t& this_) { return ze_publication_cache_loan(&this_); };
-inline const ze_loaned_querying_subscriber_t* z_loan(const ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_loan(&this_); };
 inline const ze_loaned_serializer_t* z_loan(const ze_owned_serializer_t& this_) { return ze_serializer_loan(&this_); };
 
 
@@ -601,22 +436,16 @@ inline z_loaned_encoding_t* z_loan_mut(z_owned_encoding_t& this_) { return z_enc
 inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t& this_) { return z_mutex_loan_mut(&this_); };
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& this_) { return z_publisher_loan_mut(&this_); };
 inline z_loaned_session_t* z_loan_mut(z_owned_session_t& this_) { return z_session_loan_mut(&this_); };
-inline z_loaned_shm_t* z_loan_mut(z_owned_shm_t& this_) { return z_shm_loan_mut(&this_); };
-inline z_loaned_shm_mut_t* z_loan_mut(z_owned_shm_mut_t& this_) { return z_shm_mut_loan_mut(&this_); };
 inline z_loaned_string_array_t* z_loan_mut(z_owned_string_array_t& this_) { return z_string_array_loan_mut(&this_); };
-inline zc_loaned_shm_client_list_t* z_loan_mut(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan_mut(&this_); };
 inline ze_loaned_serializer_t* z_loan_mut(ze_owned_serializer_t& this_) { return ze_serializer_loan_mut(&this_); };
 
 
-inline void z_drop(z_moved_alloc_layout_t* this_) { z_alloc_layout_drop(this_); };
 inline void z_drop(z_moved_bytes_t* this_) { z_bytes_drop(this_); };
 inline void z_drop(z_moved_bytes_writer_t* this_) { z_bytes_writer_drop(this_); };
-inline void z_drop(z_moved_chunk_alloc_result_t* this_) { z_chunk_alloc_result_drop(this_); };
 inline void z_drop(z_moved_closure_hello_t* this_) { z_closure_hello_drop(this_); };
 inline void z_drop(z_moved_closure_query_t* closure_) { z_closure_query_drop(closure_); };
 inline void z_drop(z_moved_closure_reply_t* closure_) { z_closure_reply_drop(closure_); };
 inline void z_drop(z_moved_closure_sample_t* closure_) { z_closure_sample_drop(closure_); };
-inline void z_drop(z_moved_closure_zid_t* closure_) { z_closure_zid_drop(closure_); };
 inline void z_drop(z_moved_condvar_t* this_) { z_condvar_drop(this_); };
 inline void z_drop(z_moved_config_t* this_) { z_config_drop(this_); };
 inline void z_drop(z_moved_encoding_t* this_) { z_encoding_drop(this_); };
@@ -625,7 +454,6 @@ inline void z_drop(z_moved_fifo_handler_reply_t* this_) { z_fifo_handler_reply_d
 inline void z_drop(z_moved_fifo_handler_sample_t* this_) { z_fifo_handler_sample_drop(this_); };
 inline void z_drop(z_moved_hello_t* this_) { z_hello_drop(this_); };
 inline void z_drop(z_moved_keyexpr_t* this_) { z_keyexpr_drop(this_); };
-inline void z_drop(z_moved_memory_layout_t* this_) { z_memory_layout_drop(this_); };
 inline void z_drop(z_moved_mutex_t* this_) { z_mutex_drop(this_); };
 inline void z_drop(z_moved_publisher_t* this_) { z_publisher_drop(this_); };
 inline void z_drop(z_moved_query_t* this_) { z_query_drop(this_); };
@@ -637,36 +465,21 @@ inline void z_drop(z_moved_ring_handler_reply_t* this_) { z_ring_handler_reply_d
 inline void z_drop(z_moved_ring_handler_sample_t* this_) { z_ring_handler_sample_drop(this_); };
 inline void z_drop(z_moved_sample_t* this_) { z_sample_drop(this_); };
 inline void z_drop(z_moved_session_t* this_) { z_session_drop(this_); };
-inline void z_drop(z_moved_shm_client_t* this_) { z_shm_client_drop(this_); };
-inline void z_drop(z_moved_shm_client_storage_t* this_) { z_shm_client_storage_drop(this_); };
-inline void z_drop(z_moved_shm_t* this_) { z_shm_drop(this_); };
-inline void z_drop(z_moved_shm_mut_t* this_) { z_shm_mut_drop(this_); };
-inline void z_drop(z_moved_shm_provider_t* this_) { z_shm_provider_drop(this_); };
 inline void z_drop(z_moved_slice_t* this_) { z_slice_drop(this_); };
-inline void z_drop(z_moved_source_info_t* this_) { z_source_info_drop(this_); };
 inline void z_drop(z_moved_string_array_t* this_) { z_string_array_drop(this_); };
 inline void z_drop(z_moved_string_t* this_) { z_string_drop(this_); };
 inline void z_drop(z_moved_subscriber_t* this_) { z_subscriber_drop(this_); };
 inline void z_drop(z_moved_task_t* this_) { z_task_drop(this_); };
 inline void z_drop(zc_moved_closure_log_t* closure_) { zc_closure_log_drop(closure_); };
-inline void z_drop(zc_moved_closure_matching_status_t* closure_) { zc_closure_matching_status_drop(closure_); };
-inline void z_drop(zc_moved_liveliness_token_t* this_) { zc_liveliness_token_drop(this_); };
-inline void z_drop(zc_moved_matching_listener_t* this_) { zc_publisher_matching_listener_drop(this_); };
-inline void z_drop(zc_moved_shm_client_list_t* this_) { zc_shm_client_list_drop(this_); };
-inline void z_drop(ze_moved_publication_cache_t* this_) { ze_publication_cache_drop(this_); };
-inline void z_drop(ze_moved_querying_subscriber_t* this_) { ze_querying_subscriber_drop(this_); };
 inline void z_drop(ze_moved_serializer_t* this_) { ze_serializer_drop(this_); };
 
 
-inline z_moved_alloc_layout_t* z_move(z_owned_alloc_layout_t& this_) { return z_alloc_layout_move(&this_); };
 inline z_moved_bytes_t* z_move(z_owned_bytes_t& this_) { return z_bytes_move(&this_); };
 inline z_moved_bytes_writer_t* z_move(z_owned_bytes_writer_t& this_) { return z_bytes_writer_move(&this_); };
-inline z_moved_chunk_alloc_result_t* z_move(z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_move(&this_); };
 inline z_moved_closure_hello_t* z_move(z_owned_closure_hello_t& this_) { return z_closure_hello_move(&this_); };
 inline z_moved_closure_query_t* z_move(z_owned_closure_query_t& closure_) { return z_closure_query_move(&closure_); };
 inline z_moved_closure_reply_t* z_move(z_owned_closure_reply_t& closure_) { return z_closure_reply_move(&closure_); };
 inline z_moved_closure_sample_t* z_move(z_owned_closure_sample_t& closure_) { return z_closure_sample_move(&closure_); };
-inline z_moved_closure_zid_t* z_move(z_owned_closure_zid_t& closure_) { return z_closure_zid_move(&closure_); };
 inline z_moved_condvar_t* z_move(z_owned_condvar_t& this_) { return z_condvar_move(&this_); };
 inline z_moved_config_t* z_move(z_owned_config_t& this_) { return z_config_move(&this_); };
 inline z_moved_encoding_t* z_move(z_owned_encoding_t& this_) { return z_encoding_move(&this_); };
@@ -675,7 +488,6 @@ inline z_moved_fifo_handler_reply_t* z_move(z_owned_fifo_handler_reply_t& this_)
 inline z_moved_fifo_handler_sample_t* z_move(z_owned_fifo_handler_sample_t& this_) { return z_fifo_handler_sample_move(&this_); };
 inline z_moved_hello_t* z_move(z_owned_hello_t& this_) { return z_hello_move(&this_); };
 inline z_moved_keyexpr_t* z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
-inline z_moved_memory_layout_t* z_move(z_owned_memory_layout_t& this_) { return z_memory_layout_move(&this_); };
 inline z_moved_mutex_t* z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
 inline z_moved_publisher_t* z_move(z_owned_publisher_t& this_) { return z_publisher_move(&this_); };
 inline z_moved_query_t* z_move(z_owned_query_t& this_) { return z_query_move(&this_); };
@@ -687,36 +499,21 @@ inline z_moved_ring_handler_reply_t* z_move(z_owned_ring_handler_reply_t& this_)
 inline z_moved_ring_handler_sample_t* z_move(z_owned_ring_handler_sample_t& this_) { return z_ring_handler_sample_move(&this_); };
 inline z_moved_sample_t* z_move(z_owned_sample_t& this_) { return z_sample_move(&this_); };
 inline z_moved_session_t* z_move(z_owned_session_t& this_) { return z_session_move(&this_); };
-inline z_moved_shm_client_t* z_move(z_owned_shm_client_t& this_) { return z_shm_client_move(&this_); };
-inline z_moved_shm_client_storage_t* z_move(z_owned_shm_client_storage_t& this_) { return z_shm_client_storage_move(&this_); };
-inline z_moved_shm_t* z_move(z_owned_shm_t& this_) { return z_shm_move(&this_); };
-inline z_moved_shm_mut_t* z_move(z_owned_shm_mut_t& this_) { return z_shm_mut_move(&this_); };
-inline z_moved_shm_provider_t* z_move(z_owned_shm_provider_t& this_) { return z_shm_provider_move(&this_); };
 inline z_moved_slice_t* z_move(z_owned_slice_t& this_) { return z_slice_move(&this_); };
-inline z_moved_source_info_t* z_move(z_owned_source_info_t& this_) { return z_source_info_move(&this_); };
 inline z_moved_string_array_t* z_move(z_owned_string_array_t& this_) { return z_string_array_move(&this_); };
 inline z_moved_string_t* z_move(z_owned_string_t& this_) { return z_string_move(&this_); };
 inline z_moved_subscriber_t* z_move(z_owned_subscriber_t& this_) { return z_subscriber_move(&this_); };
 inline z_moved_task_t* z_move(z_owned_task_t& this_) { return z_task_move(&this_); };
 inline zc_moved_closure_log_t* z_move(zc_owned_closure_log_t& closure_) { return zc_closure_log_move(&closure_); };
-inline zc_moved_closure_matching_status_t* z_move(zc_owned_closure_matching_status_t& closure_) { return zc_closure_matching_status_move(&closure_); };
-inline zc_moved_liveliness_token_t* z_move(zc_owned_liveliness_token_t& this_) { return zc_liveliness_token_move(&this_); };
-inline zc_moved_matching_listener_t* z_move(zc_owned_matching_listener_t& this_) { return zc_publisher_matching_listener_move(&this_); };
-inline zc_moved_shm_client_list_t* z_move(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_move(&this_); };
-inline ze_moved_publication_cache_t* z_move(ze_owned_publication_cache_t& this_) { return ze_publication_cache_move(&this_); };
-inline ze_moved_querying_subscriber_t* z_move(ze_owned_querying_subscriber_t& this_) { return ze_querying_subscriber_move(&this_); };
 inline ze_moved_serializer_t* z_move(ze_owned_serializer_t& this_) { return ze_serializer_move(&this_); };
 
 
-inline void z_internal_null(z_owned_alloc_layout_t* this_) { z_internal_alloc_layout_null(this_); };
 inline void z_internal_null(z_owned_bytes_t* this_) { z_internal_bytes_null(this_); };
 inline void z_internal_null(z_owned_bytes_writer_t* this_) { z_internal_bytes_writer_null(this_); };
-inline void z_internal_null(z_owned_chunk_alloc_result_t* this_) { z_internal_chunk_alloc_result_null(this_); };
 inline void z_internal_null(z_owned_closure_hello_t* this_) { z_internal_closure_hello_null(this_); };
 inline void z_internal_null(z_owned_closure_query_t* this_) { z_internal_closure_query_null(this_); };
 inline void z_internal_null(z_owned_closure_reply_t* this_) { z_internal_closure_reply_null(this_); };
 inline void z_internal_null(z_owned_closure_sample_t* this_) { z_internal_closure_sample_null(this_); };
-inline void z_internal_null(z_owned_closure_zid_t* this_) { z_internal_closure_zid_null(this_); };
 inline void z_internal_null(z_owned_condvar_t* this_) { z_internal_condvar_null(this_); };
 inline void z_internal_null(z_owned_config_t* this_) { z_internal_config_null(this_); };
 inline void z_internal_null(z_owned_encoding_t* this_) { z_internal_encoding_null(this_); };
@@ -725,7 +522,6 @@ inline void z_internal_null(z_owned_fifo_handler_reply_t* this_) { z_internal_fi
 inline void z_internal_null(z_owned_fifo_handler_sample_t* this_) { z_internal_fifo_handler_sample_null(this_); };
 inline void z_internal_null(z_owned_hello_t* this_) { z_internal_hello_null(this_); };
 inline void z_internal_null(z_owned_keyexpr_t* this_) { z_internal_keyexpr_null(this_); };
-inline void z_internal_null(z_owned_memory_layout_t* this_) { z_internal_memory_layout_null(this_); };
 inline void z_internal_null(z_owned_mutex_t* this_) { z_internal_mutex_null(this_); };
 inline void z_internal_null(z_owned_publisher_t* this_) { z_internal_publisher_null(this_); };
 inline void z_internal_null(z_owned_query_t* this_) { z_internal_query_null(this_); };
@@ -737,35 +533,20 @@ inline void z_internal_null(z_owned_ring_handler_reply_t* this_) { z_internal_ri
 inline void z_internal_null(z_owned_ring_handler_sample_t* this_) { z_internal_ring_handler_sample_null(this_); };
 inline void z_internal_null(z_owned_sample_t* this_) { z_internal_sample_null(this_); };
 inline void z_internal_null(z_owned_session_t* this_) { z_internal_session_null(this_); };
-inline void z_internal_null(z_owned_shm_client_t* this_) { z_internal_shm_client_null(this_); };
-inline void z_internal_null(z_owned_shm_client_storage_t* this_) { z_internal_shm_client_storage_null(this_); };
-inline void z_internal_null(z_owned_shm_mut_t* this_) { z_internal_shm_mut_null(this_); };
-inline void z_internal_null(z_owned_shm_t* this_) { z_internal_shm_null(this_); };
-inline void z_internal_null(z_owned_shm_provider_t* this_) { z_internal_shm_provider_null(this_); };
 inline void z_internal_null(z_owned_slice_t* this_) { z_internal_slice_null(this_); };
-inline void z_internal_null(z_owned_source_info_t* this_) { z_internal_source_info_null(this_); };
 inline void z_internal_null(z_owned_string_array_t* this_) { z_internal_string_array_null(this_); };
 inline void z_internal_null(z_owned_string_t* this_) { z_internal_string_null(this_); };
 inline void z_internal_null(z_owned_subscriber_t* this_) { z_internal_subscriber_null(this_); };
 inline void z_internal_null(z_owned_task_t* this_) { z_internal_task_null(this_); };
 inline void z_internal_null(zc_owned_closure_log_t* this_) { zc_internal_closure_log_null(this_); };
-inline void z_internal_null(zc_owned_closure_matching_status_t* this_) { zc_internal_closure_matching_status_null(this_); };
-inline void z_internal_null(zc_owned_liveliness_token_t* this_) { zc_internal_liveliness_token_null(this_); };
-inline void z_internal_null(zc_owned_matching_listener_t* this_) { zc_internal_matching_listener_null(this_); };
-inline void z_internal_null(zc_owned_shm_client_list_t* this_) { zc_internal_shm_client_list_null(this_); };
-inline void z_internal_null(ze_owned_publication_cache_t* this_) { ze_internal_publication_cache_null(this_); };
-inline void z_internal_null(ze_owned_querying_subscriber_t* this_) { ze_internal_querying_subscriber_null(this_); };
 inline void z_internal_null(ze_owned_serializer_t* this_) { ze_internal_serializer_null(this_); };
 
-static inline void z_alloc_layout_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) { *this_ = x->_this; z_internal_alloc_layout_null(&x->_this); }
 static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *this_ = x->_this; z_internal_bytes_null(&x->_this); }
 static inline void z_bytes_writer_take(z_owned_bytes_writer_t* this_, z_moved_bytes_writer_t* x) { *this_ = x->_this; z_internal_bytes_writer_null(&x->_this); }
-static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) { *this_ = x->_this; z_internal_chunk_alloc_result_null(&x->_this); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_internal_closure_hello_null(&x->_this); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_internal_closure_query_null(&x->_this); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_internal_closure_reply_null(&x->_this); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_internal_closure_sample_null(&x->_this); }
-static inline void z_closure_zid_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) { *closure_ = x->_this; z_internal_closure_zid_null(&x->_this); }
 static inline void z_condvar_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) { *this_ = x->_this; z_internal_condvar_null(&x->_this); }
 static inline void z_config_take(z_owned_config_t* this_, z_moved_config_t* x) { *this_ = x->_this; z_internal_config_null(&x->_this); }
 static inline void z_encoding_take(z_owned_encoding_t* this_, z_moved_encoding_t* x) { *this_ = x->_this; z_internal_encoding_null(&x->_this); }
@@ -774,7 +555,6 @@ static inline void z_fifo_handler_reply_take(z_owned_fifo_handler_reply_t* this_
 static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* this_, z_moved_fifo_handler_sample_t* x) { *this_ = x->_this; z_internal_fifo_handler_sample_null(&x->_this); }
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_internal_hello_null(&x->_this); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_internal_keyexpr_null(&x->_this); }
-static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) { *this_ = x->_this; z_internal_memory_layout_null(&x->_this); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_internal_mutex_null(&x->_this); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_internal_publisher_null(&x->_this); }
 static inline void z_query_take(z_owned_query_t* this_, z_moved_query_t* x) { *this_ = x->_this; z_internal_query_null(&x->_this); }
@@ -786,39 +566,21 @@ static inline void z_ring_handler_reply_take(z_owned_ring_handler_reply_t* this_
 static inline void z_ring_handler_sample_take(z_owned_ring_handler_sample_t* this_, z_moved_ring_handler_sample_t* x) { *this_ = x->_this; z_internal_ring_handler_sample_null(&x->_this); }
 static inline void z_sample_take(z_owned_sample_t* this_, z_moved_sample_t* x) { *this_ = x->_this; z_internal_sample_null(&x->_this); }
 static inline void z_session_take(z_owned_session_t* this_, z_moved_session_t* x) { *this_ = x->_this; z_internal_session_null(&x->_this); }
-static inline void z_shm_client_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) { *this_ = x->_this; z_internal_shm_client_null(&x->_this); }
-static inline void z_shm_client_storage_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) { *this_ = x->_this; z_internal_shm_client_storage_null(&x->_this); }
-static inline void z_shm_take(z_owned_shm_t* this_, z_moved_shm_t* x) { *this_ = x->_this; z_internal_shm_null(&x->_this); }
-static inline void z_shm_mut_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) { *this_ = x->_this; z_internal_shm_mut_null(&x->_this); }
-static inline void z_shm_provider_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) { *this_ = x->_this; z_internal_shm_provider_null(&x->_this); }
 static inline void z_slice_take(z_owned_slice_t* this_, z_moved_slice_t* x) { *this_ = x->_this; z_internal_slice_null(&x->_this); }
-static inline void z_source_info_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) { *this_ = x->_this; z_internal_source_info_null(&x->_this); }
 static inline void z_string_array_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) { *this_ = x->_this; z_internal_string_array_null(&x->_this); }
 static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) { *this_ = x->_this; z_internal_string_null(&x->_this); }
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_internal_subscriber_null(&x->_this); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_internal_task_null(&x->_this); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_internal_closure_log_null(&x->_this); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) { *closure_ = x->_this; zc_internal_closure_matching_status_null(&x->_this); }
-static inline void zc_liveliness_token_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) { *this_ = x->_this; zc_internal_liveliness_token_null(&x->_this); }
-static inline void zc_publisher_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) { *this_ = x->_this; zc_internal_matching_listener_null(&x->_this); }
-static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) { *this_ = x->_this; zc_internal_shm_client_list_null(&x->_this); }
-static inline void ze_publication_cache_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) { *this_ = x->_this; ze_internal_publication_cache_null(&x->_this); }
-static inline void ze_querying_subscriber_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) { *this_ = x->_this; ze_internal_querying_subscriber_null(&x->_this); }
 static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_serializer_t* x) { *this_ = x->_this; ze_internal_serializer_null(&x->_this); }
 
 
 
-inline void z_take(z_owned_alloc_layout_t* this_, z_moved_alloc_layout_t* x) {
-    z_alloc_layout_take(this_, x);
-};
 inline void z_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) {
     z_bytes_take(this_, x);
 };
 inline void z_take(z_owned_bytes_writer_t* this_, z_moved_bytes_writer_t* x) {
     z_bytes_writer_take(this_, x);
-};
-inline void z_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) {
-    z_chunk_alloc_result_take(this_, x);
 };
 inline void z_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) {
     z_closure_hello_take(this_, x);
@@ -831,9 +593,6 @@ inline void z_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x
 };
 inline void z_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) {
     z_closure_sample_take(closure_, x);
-};
-inline void z_take(z_owned_closure_zid_t* closure_, z_moved_closure_zid_t* x) {
-    z_closure_zid_take(closure_, x);
 };
 inline void z_take(z_owned_condvar_t* this_, z_moved_condvar_t* x) {
     z_condvar_take(this_, x);
@@ -858,9 +617,6 @@ inline void z_take(z_owned_hello_t* this_, z_moved_hello_t* x) {
 };
 inline void z_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) {
     z_keyexpr_take(this_, x);
-};
-inline void z_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) {
-    z_memory_layout_take(this_, x);
 };
 inline void z_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) {
     z_mutex_take(this_, x);
@@ -895,26 +651,8 @@ inline void z_take(z_owned_sample_t* this_, z_moved_sample_t* x) {
 inline void z_take(z_owned_session_t* this_, z_moved_session_t* x) {
     z_session_take(this_, x);
 };
-inline void z_take(z_owned_shm_client_t* this_, z_moved_shm_client_t* x) {
-    z_shm_client_take(this_, x);
-};
-inline void z_take(z_owned_shm_client_storage_t* this_, z_moved_shm_client_storage_t* x) {
-    z_shm_client_storage_take(this_, x);
-};
-inline void z_take(z_owned_shm_t* this_, z_moved_shm_t* x) {
-    z_shm_take(this_, x);
-};
-inline void z_take(z_owned_shm_mut_t* this_, z_moved_shm_mut_t* x) {
-    z_shm_mut_take(this_, x);
-};
-inline void z_take(z_owned_shm_provider_t* this_, z_moved_shm_provider_t* x) {
-    z_shm_provider_take(this_, x);
-};
 inline void z_take(z_owned_slice_t* this_, z_moved_slice_t* x) {
     z_slice_take(this_, x);
-};
-inline void z_take(z_owned_source_info_t* this_, z_moved_source_info_t* x) {
-    z_source_info_take(this_, x);
 };
 inline void z_take(z_owned_string_array_t* this_, z_moved_string_array_t* x) {
     z_string_array_take(this_, x);
@@ -931,38 +669,17 @@ inline void z_take(z_owned_task_t* this_, z_moved_task_t* x) {
 inline void z_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) {
     zc_closure_log_take(closure_, x);
 };
-inline void z_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) {
-    zc_closure_matching_status_take(closure_, x);
-};
-inline void z_take(zc_owned_liveliness_token_t* this_, zc_moved_liveliness_token_t* x) {
-    zc_liveliness_token_take(this_, x);
-};
-inline void z_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) {
-    zc_publisher_matching_listener_take(this_, x);
-};
-inline void z_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) {
-    zc_shm_client_list_take(this_, x);
-};
-inline void z_take(ze_owned_publication_cache_t* this_, ze_moved_publication_cache_t* x) {
-    ze_publication_cache_take(this_, x);
-};
-inline void z_take(ze_owned_querying_subscriber_t* this_, ze_moved_querying_subscriber_t* x) {
-    ze_querying_subscriber_take(this_, x);
-};
 inline void z_take(ze_owned_serializer_t* this_, ze_moved_serializer_t* x) {
     ze_serializer_take(this_, x);
 };
 
 
-inline bool z_internal_check(const z_owned_alloc_layout_t& this_) { return z_internal_alloc_layout_check(&this_); };
 inline bool z_internal_check(const z_owned_bytes_t& this_) { return z_internal_bytes_check(&this_); };
 inline bool z_internal_check(const z_owned_bytes_writer_t& this_) { return z_internal_bytes_writer_check(&this_); };
-inline bool z_internal_check(const z_owned_chunk_alloc_result_t& this_) { return z_internal_chunk_alloc_result_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_hello_t& this_) { return z_internal_closure_hello_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_query_t& this_) { return z_internal_closure_query_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_reply_t& this_) { return z_internal_closure_reply_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_sample_t& this_) { return z_internal_closure_sample_check(&this_); };
-inline bool z_internal_check(const z_owned_closure_zid_t& this_) { return z_internal_closure_zid_check(&this_); };
 inline bool z_internal_check(const z_owned_condvar_t& this_) { return z_internal_condvar_check(&this_); };
 inline bool z_internal_check(const z_owned_config_t& this_) { return z_internal_config_check(&this_); };
 inline bool z_internal_check(const z_owned_encoding_t& this_) { return z_internal_encoding_check(&this_); };
@@ -971,7 +688,6 @@ inline bool z_internal_check(const z_owned_fifo_handler_reply_t& this_) { return
 inline bool z_internal_check(const z_owned_fifo_handler_sample_t& this_) { return z_internal_fifo_handler_sample_check(&this_); };
 inline bool z_internal_check(const z_owned_hello_t& this_) { return z_internal_hello_check(&this_); };
 inline bool z_internal_check(const z_owned_keyexpr_t& this_) { return z_internal_keyexpr_check(&this_); };
-inline bool z_internal_check(const z_owned_memory_layout_t& this_) { return z_internal_memory_layout_check(&this_); };
 inline bool z_internal_check(const z_owned_mutex_t& this_) { return z_internal_mutex_check(&this_); };
 inline bool z_internal_check(const z_owned_publisher_t& this_) { return z_internal_publisher_check(&this_); };
 inline bool z_internal_check(const z_owned_query_t& query) { return z_internal_query_check(&query); };
@@ -983,24 +699,12 @@ inline bool z_internal_check(const z_owned_ring_handler_reply_t& this_) { return
 inline bool z_internal_check(const z_owned_ring_handler_sample_t& this_) { return z_internal_ring_handler_sample_check(&this_); };
 inline bool z_internal_check(const z_owned_sample_t& this_) { return z_internal_sample_check(&this_); };
 inline bool z_internal_check(const z_owned_session_t& this_) { return z_internal_session_check(&this_); };
-inline bool z_internal_check(const z_owned_shm_t& this_) { return z_internal_shm_check(&this_); };
-inline bool z_internal_check(const z_owned_shm_client_t& this_) { return z_internal_shm_client_check(&this_); };
-inline bool z_internal_check(const z_owned_shm_client_storage_t& this_) { return z_internal_shm_client_storage_check(&this_); };
-inline bool z_internal_check(const z_owned_shm_mut_t& this_) { return z_internal_shm_mut_check(&this_); };
-inline bool z_internal_check(const z_owned_shm_provider_t& this_) { return z_internal_shm_provider_check(&this_); };
 inline bool z_internal_check(const z_owned_slice_t& this_) { return z_internal_slice_check(&this_); };
-inline bool z_internal_check(const z_owned_source_info_t& this_) { return z_internal_source_info_check(&this_); };
 inline bool z_internal_check(const z_owned_string_array_t& this_) { return z_internal_string_array_check(&this_); };
 inline bool z_internal_check(const z_owned_string_t& this_) { return z_internal_string_check(&this_); };
 inline bool z_internal_check(const z_owned_subscriber_t& this_) { return z_internal_subscriber_check(&this_); };
 inline bool z_internal_check(const z_owned_task_t& this_) { return z_internal_task_check(&this_); };
 inline bool z_internal_check(const zc_owned_closure_log_t& this_) { return zc_internal_closure_log_check(&this_); };
-inline bool z_internal_check(const zc_owned_closure_matching_status_t& this_) { return zc_internal_closure_matching_status_check(&this_); };
-inline bool z_internal_check(const zc_owned_liveliness_token_t& this_) { return zc_internal_liveliness_token_check(&this_); };
-inline bool z_internal_check(const zc_owned_matching_listener_t& this_) { return zc_internal_matching_listener_check(&this_); };
-inline bool z_internal_check(const zc_owned_shm_client_list_t& this_) { return zc_internal_shm_client_list_check(&this_); };
-inline bool z_internal_check(const ze_owned_publication_cache_t& this_) { return ze_internal_publication_cache_check(&this_); };
-inline bool z_internal_check(const ze_owned_querying_subscriber_t& this_) { return ze_internal_querying_subscriber_check(&this_); };
 inline bool z_internal_check(const ze_owned_serializer_t& this_) { return ze_internal_serializer_check(&this_); };
 
 
@@ -1016,21 +720,13 @@ inline void z_call(const z_loaned_closure_reply_t* closure, z_loaned_reply_t* re
 inline void z_call(const z_loaned_closure_sample_t* closure, z_loaned_sample_t* sample) {
     z_closure_sample_call(closure, sample);
 };
-inline void z_call(const z_loaned_closure_zid_t* closure, const z_id_t* z_id) {
-    z_closure_zid_call(closure, z_id);
-};
-inline void z_call(const zc_loaned_closure_matching_status_t* closure, const zc_matching_status_t* mathing_status) {
-    zc_closure_matching_status_call(closure, mathing_status);
-};
 
 extern "C" using z_closure_drop_callback_t = void(void* context);
 extern "C" using z_closure_hello_callabck_t = void(z_loaned_hello_t *hello, void *context);
 extern "C" using z_closure_query_callabck_t = void(z_loaned_query_t *query, void *context);
 extern "C" using z_closure_reply_callabck_t = void(z_loaned_reply_t *reply, void *context);
 extern "C" using z_closure_sample_callabck_t = void(z_loaned_sample_t *sample, void *context);
-extern "C" using z_closure_zid_callabck_t = void(const z_id_t *z_id, void *context);
 extern "C" using zc_closure_log_callabck_t = void(zc_log_severity_t severity, const z_loaned_string_t *msg, void *context);
-extern "C" using zc_closure_matching_status_callabck_t = void(const zc_matching_status_t *matching_status, void *context);
 
 inline void z_closure(z_owned_closure_hello_t* this_, z_closure_hello_callabck_t* call,
     z_closure_drop_callback_t* drop, void* context) {
@@ -1048,17 +744,9 @@ inline void z_closure(z_owned_closure_sample_t* this_, z_closure_sample_callabck
     z_closure_drop_callback_t* drop, void* context) {
     z_closure_sample(this_, call, drop, context);
 };
-inline void z_closure(z_owned_closure_zid_t* this_, z_closure_zid_callabck_t* call,
-    z_closure_drop_callback_t* drop, void* context) {
-    z_closure_zid(this_, call, drop, context);
-};
 inline void z_closure(zc_owned_closure_log_t* this_, zc_closure_log_callabck_t* call,
     z_closure_drop_callback_t* drop, void* context) {
     zc_closure_log(this_, call, drop, context);
-};
-inline void z_closure(zc_owned_closure_matching_status_t* this_, zc_closure_matching_status_callabck_t* call,
-    z_closure_drop_callback_t* drop, void* context) {
-    zc_closure_matching_status(this_, call, drop, context);
 };
 
 
@@ -1129,12 +817,6 @@ inline void z_clone(z_owned_reply_err_t* dst, z_loaned_reply_err_t* this_) {
 inline void z_clone(z_owned_sample_t* dst, z_loaned_sample_t* this_) {
     z_sample_clone(dst, this_);
 };
-inline void z_clone(z_owned_shm_client_storage_t* this_, z_loaned_shm_client_storage_t* from) {
-    z_shm_client_storage_clone(this_, from);
-};
-inline void z_clone(z_owned_shm_t* out, z_loaned_shm_t* this_) {
-    z_shm_clone(out, this_);
-};
 inline void z_clone(z_owned_slice_t* dst, z_loaned_slice_t* this_) {
     z_slice_clone(dst, this_);
 };
@@ -1147,14 +829,10 @@ inline void z_clone(z_owned_string_t* dst, z_loaned_string_t* this_) {
 
 template<class T> struct z_loaned_to_owned_type_t {};
 template<class T> struct z_owned_to_loaned_type_t {};
-template<> struct z_loaned_to_owned_type_t<z_loaned_alloc_layout_t> { typedef z_owned_alloc_layout_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_alloc_layout_t> { typedef z_loaned_alloc_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_t> { typedef z_owned_bytes_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_t> { typedef z_loaned_bytes_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_writer_t> { typedef z_owned_bytes_writer_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_writer_t> { typedef z_loaned_bytes_writer_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_chunk_alloc_result_t> { typedef z_owned_chunk_alloc_result_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_chunk_alloc_result_t> { typedef z_loaned_chunk_alloc_result_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_hello_t> { typedef z_owned_closure_hello_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_hello_t> { typedef z_loaned_closure_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_query_t> { typedef z_owned_closure_query_t type; };
@@ -1163,8 +841,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_closure_reply_t> { typedef z
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_reply_t> { typedef z_loaned_closure_reply_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_sample_t> { typedef z_owned_closure_sample_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_sample_t> { typedef z_loaned_closure_sample_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_closure_zid_t> { typedef z_owned_closure_zid_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_closure_zid_t> { typedef z_loaned_closure_zid_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_condvar_t> { typedef z_owned_condvar_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_condvar_t> { typedef z_loaned_condvar_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_config_t> { typedef z_owned_config_t type; };
@@ -1181,8 +857,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_hello_t> { typedef z_owned_h
 template<> struct z_owned_to_loaned_type_t<z_owned_hello_t> { typedef z_loaned_hello_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_keyexpr_t> { typedef z_owned_keyexpr_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_keyexpr_t> { typedef z_loaned_keyexpr_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_memory_layout_t> { typedef z_owned_memory_layout_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_memory_layout_t> { typedef z_loaned_memory_layout_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_publisher_t> { typedef z_owned_publisher_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_publisher_t> { typedef z_loaned_publisher_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_query_t> { typedef z_owned_query_t type; };
@@ -1203,18 +877,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_sample_t> { typedef z_owned_
 template<> struct z_owned_to_loaned_type_t<z_owned_sample_t> { typedef z_loaned_sample_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_session_t> { typedef z_owned_session_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_session_t> { typedef z_loaned_session_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_client_storage_t> { typedef z_owned_shm_client_storage_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_client_storage_t> { typedef z_loaned_shm_client_storage_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_t> { typedef z_owned_shm_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_t> { typedef z_loaned_shm_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_mut_t> { typedef z_owned_shm_mut_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_mut_t> { typedef z_loaned_shm_mut_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_shm_provider_t> { typedef z_owned_shm_provider_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_shm_provider_t> { typedef z_loaned_shm_provider_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_slice_t> { typedef z_owned_slice_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_slice_t> { typedef z_loaned_slice_t type; };
-template<> struct z_loaned_to_owned_type_t<z_loaned_source_info_t> { typedef z_owned_source_info_t type; };
-template<> struct z_owned_to_loaned_type_t<z_owned_source_info_t> { typedef z_loaned_source_info_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_array_t> { typedef z_owned_string_array_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_string_array_t> { typedef z_loaned_string_array_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_string_t> { typedef z_owned_string_t type; };
@@ -1223,16 +887,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_subscriber_t> { typedef z_ow
 template<> struct z_owned_to_loaned_type_t<z_owned_subscriber_t> { typedef z_loaned_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_log_t> { typedef zc_owned_closure_log_t type; };
 template<> struct z_owned_to_loaned_type_t<zc_owned_closure_log_t> { typedef zc_loaned_closure_log_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_matching_status_t> { typedef zc_owned_closure_matching_status_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_closure_matching_status_t> { typedef zc_loaned_closure_matching_status_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_liveliness_token_t> { typedef zc_owned_liveliness_token_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_liveliness_token_t> { typedef zc_loaned_liveliness_token_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_shm_client_list_t> { typedef zc_owned_shm_client_list_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_shm_client_list_t> { typedef zc_loaned_shm_client_list_t type; };
-template<> struct z_loaned_to_owned_type_t<ze_loaned_publication_cache_t> { typedef ze_owned_publication_cache_t type; };
-template<> struct z_owned_to_loaned_type_t<ze_owned_publication_cache_t> { typedef ze_loaned_publication_cache_t type; };
-template<> struct z_loaned_to_owned_type_t<ze_loaned_querying_subscriber_t> { typedef ze_owned_querying_subscriber_t type; };
-template<> struct z_owned_to_loaned_type_t<ze_owned_querying_subscriber_t> { typedef ze_loaned_querying_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<ze_loaned_serializer_t> { typedef ze_owned_serializer_t type; };
 template<> struct z_owned_to_loaned_type_t<ze_owned_serializer_t> { typedef ze_loaned_serializer_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_mutex_t> { typedef z_owned_mutex_t type; };

--- a/src/liveliness.rs
+++ b/src/liveliness.rs
@@ -14,7 +14,12 @@
 
 use std::mem::MaybeUninit;
 
-use zenoh::{liveliness::LivelinessToken, Wait};
+use zenoh::{
+    handlers::Callback,
+    liveliness::{LivelinessSubscriberBuilder, LivelinessToken},
+    sample::Sample,
+    Wait,
+};
 
 use crate::{
     opaque_types::{zc_loaned_liveliness_token_t, zc_owned_liveliness_token_t},
@@ -145,6 +150,30 @@ pub extern "C" fn zc_liveliness_subscriber_options_default(
     this.write(zc_liveliness_subscriber_options_t { history: false });
 }
 
+fn _liveliness_declare_subscriber_inner<'a, 'b>(
+    session: &'a z_loaned_session_t,
+    key_expr: &'b z_loaned_keyexpr_t,
+    callback: &mut z_moved_closure_sample_t,
+    options: Option<&mut zc_liveliness_subscriber_options_t>,
+) -> LivelinessSubscriberBuilder<'a, 'b, Callback<Sample>> {
+    let session = session.as_rust_type_ref();
+    let key_expr = key_expr.as_rust_type_ref();
+    let callback = callback.take_rust_type();
+    let sub = session
+        .liveliness()
+        .declare_subscriber(key_expr)
+        .history(options.is_some_and(|o| o.history))
+        .callback(move |sample| {
+            let mut owned_sample = Some(sample);
+            z_closure_sample_call(z_closure_sample_loan(&callback), unsafe {
+                owned_sample
+                    .as_mut()
+                    .unwrap_unchecked()
+                    .as_loaned_c_type_mut()
+            })
+        });
+    sub
+}
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Declares a subscriber on liveliness tokens that intersect `key_expr`.
 ///
@@ -164,24 +193,8 @@ pub extern "C" fn zc_liveliness_declare_subscriber(
     options: Option<&mut zc_liveliness_subscriber_options_t>,
 ) -> result::z_result_t {
     let this = this.as_rust_type_mut_uninit();
-    let session = session.as_rust_type_ref();
-    let key_expr = key_expr.as_rust_type_ref();
-    let callback = callback.take_rust_type();
-    match session
-        .liveliness()
-        .declare_subscriber(key_expr)
-        .history(options.is_some_and(|o| o.history))
-        .callback(move |sample| {
-            let mut owned_sample = Some(sample);
-            z_closure_sample_call(z_closure_sample_loan(&callback), unsafe {
-                owned_sample
-                    .as_mut()
-                    .unwrap_unchecked()
-                    .as_loaned_c_type_mut()
-            })
-        })
-        .wait()
-    {
+    let subscriber = _liveliness_declare_subscriber_inner(session, key_expr, callback, options);
+    match subscriber.wait() {
         Ok(subscriber) => {
             this.write(Some(subscriber));
             result::Z_OK
@@ -189,6 +202,32 @@ pub extern "C" fn zc_liveliness_declare_subscriber(
         Err(e) => {
             tracing::error!("Failed to subscribe to liveliness: {e}");
             this.write(None);
+            result::Z_EGENERIC
+        }
+    }
+}
+
+/// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+/// @brief Declares a background subscriber on liveliness tokens that intersect `key_expr`. Subscriber callback will be called to process the messages,
+/// until the corresponding session is closed or dropped.
+/// @param session: The Zenoh session.
+/// @param key_expr: The key expression to subscribe to.
+/// @param callback: The callback function that will be called each time a liveliness token status is changed.
+/// @param options: The options to be passed to the liveliness subscriber declaration.
+///
+/// @return 0 in case of success, negative error values otherwise.
+#[no_mangle]
+pub extern "C" fn zc_liveliness_declare_background_subscriber(
+    session: &z_loaned_session_t,
+    key_expr: &z_loaned_keyexpr_t,
+    callback: &mut z_moved_closure_sample_t,
+    options: Option<&mut zc_liveliness_subscriber_options_t>,
+) -> result::z_result_t {
+    let subscriber = _liveliness_declare_subscriber_inner(session, key_expr, callback, options);
+    match subscriber.background().wait() {
+        Ok(_) => result::Z_OK,
+        Err(e) => {
+            tracing::error!("Failed to subscribe to liveliness: {e}");
             result::Z_EGENERIC
         }
     }

--- a/src/publication_cache.rs
+++ b/src/publication_cache.rs
@@ -139,23 +139,6 @@ pub extern "C" fn ze_internal_publication_cache_check(
 }
 
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
-/// @brief Undeclares and drops publication cache.
-/// @return 0 in case of success, negative error code otherwise.
-#[no_mangle]
-#[allow(clippy::missing_safety_doc)]
-pub extern "C" fn ze_undeclare_publication_cache(
-    this: &mut ze_moved_publication_cache_t,
-) -> result::z_result_t {
-    if let Some(p) = this.take_rust_type() {
-        if let Err(e) = p.undeclare().wait() {
-            tracing::error!("{}", e);
-            return result::Z_EGENERIC;
-        }
-    }
-    result::Z_OK
-}
-
-/// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Drops publication cache and resets it to its gravestone state.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -15,7 +15,10 @@
 use std::mem::MaybeUninit;
 
 #[cfg(feature = "unstable")]
-use zenoh::pubsub::MatchingListener;
+use zenoh::{
+    handlers::Callback,
+    pubsub::{MatchingListener, MatchingStatus},
+};
 use zenoh::{
     pubsub::Publisher,
     qos::{CongestionControl, Priority},
@@ -343,22 +346,10 @@ pub struct zc_matching_status_t {
 }
 
 #[cfg(feature = "unstable")]
-/// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
-/// @brief Constructs matching listener, registering a callback for notifying subscribers matching with a given publisher.
-///
-/// @param this_: An unitilized memory location where matching listener will be constructed. The matching listener will be automatically dropped when publisher is dropped.
-/// @param publisher: A publisher to associate with matching listener.
-/// @param callback: A closure that will be called every time the matching status of the publisher changes (If last subscriber, disconnects or when the first subscriber connects).
-///
-/// @return 0 in case of success, negative error code otherwise.
-#[no_mangle]
-#[allow(clippy::missing_safety_doc)]
-pub extern "C" fn zc_publisher_matching_listener_declare(
-    this: &mut MaybeUninit<zc_owned_matching_listener_t>,
-    publisher: &'static z_loaned_publisher_t,
+fn _publisher_matching_listener_declare_inner<'a, 'b>(
+    publisher: &'a z_loaned_publisher_t,
     callback: &mut zc_moved_closure_matching_status_t,
-) -> result::z_result_t {
-    let this = this.as_rust_type_mut_uninit();
+) -> zenoh::pubsub::MatchingListenerBuilder<'a, 'b, Callback<MatchingStatus>> {
     let publisher = publisher.as_rust_type_ref();
     let callback = callback.take_rust_type();
     let listener = publisher
@@ -368,14 +359,34 @@ pub extern "C" fn zc_publisher_matching_listener_declare(
                 matching: matching_status.matching_subscribers(),
             };
             zc_closure_matching_status_call(zc_closure_matching_status_loan(&callback), &status);
-        })
-        .wait();
-    match listener {
+        });
+    listener
+}
+
+#[cfg(feature = "unstable")]
+/// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+/// @brief Constructs matching listener, registering a callback for notifying subscribers matching with a given publisher.
+///
+/// @param this_: An unitilized memory location where matching listener will be constructed. The matching listener will be automatically dropped when publisher is dropped.
+/// @param publisher: A publisher to associate with matching listener.
+/// @param callback: A closure that will be called every time the matching status of the publisher changes (If last subscriber, disconnects or when the first subscriber connects).
+///
+/// @return 0 in case of success, negative error code otherwise.
+#[no_mangle]
+pub extern "C" fn zc_publisher_matching_listener_declare(
+    this: &mut MaybeUninit<zc_owned_matching_listener_t>,
+    publisher: &'static z_loaned_publisher_t,
+    callback: &mut zc_moved_closure_matching_status_t,
+) -> result::z_result_t {
+    let this = this.as_rust_type_mut_uninit();
+    let listener = _publisher_matching_listener_declare_inner(publisher, callback);
+    match listener.wait() {
         Ok(listener) => {
             this.write(Some(listener));
             result::Z_OK
         }
         Err(e) => {
+            this.write(None);
             tracing::error!("{}", e);
             result::Z_EGENERIC
         }
@@ -384,21 +395,26 @@ pub extern "C" fn zc_publisher_matching_listener_declare(
 
 #[cfg(feature = "unstable")]
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
-/// @brief Undeclares the given matching listener, droping and invalidating it.
+/// @brief Declares a matching listener, registering a callback for notifying subscribers matching with a given publisher.
+/// The callback will be run in the background until the corresponding publisher is dropped.
+///
+/// @param publisher: A publisher to associate with matching listener.
+/// @param callback: A closure that will be called every time the matching status of the publisher changes (If last subscriber, disconnects or when the first subscriber connects).
 ///
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-#[allow(clippy::missing_safety_doc)]
-pub extern "C" fn zc_publisher_matching_listener_undeclare(
-    this: &mut zc_moved_matching_listener_t,
+pub extern "C" fn zc_publisher_matching_listener_declare_background(
+    publisher: &'static z_loaned_publisher_t,
+    callback: &mut zc_moved_closure_matching_status_t,
 ) -> result::z_result_t {
-    if let Some(p) = this.take_rust_type() {
-        if let Err(e) = p.undeclare().wait() {
+    let listener = _publisher_matching_listener_declare_inner(publisher, callback);
+    match listener.background().wait() {
+        Ok(_) => result::Z_OK,
+        Err(e) => {
             tracing::error!("{}", e);
-            return result::Z_EGENERIC;
+            result::Z_EGENERIC
         }
     }
-    result::Z_OK
 }
 
 #[cfg(feature = "unstable")]
@@ -433,21 +449,6 @@ pub extern "C" fn zc_publisher_get_matching_status(
             result::Z_ENETWORK
         }
     }
-}
-
-#[no_mangle]
-#[allow(clippy::missing_safety_doc)]
-/// @brief Undeclares the given publisher, droping and invalidating it.
-///
-/// @return 0 in case of success, negative error code otherwise.
-pub extern "C" fn z_undeclare_publisher(this_: &mut z_moved_publisher_t) -> result::z_result_t {
-    if let Some(p) = this_.take_rust_type() {
-        if let Err(e) = p.undeclare().wait() {
-            tracing::error!("{}", e);
-            return result::Z_ENETWORK;
-        }
-    }
-    result::Z_OK
 }
 
 /// Frees memory and resets publisher to its gravestone state.

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -14,7 +14,7 @@
 
 use std::mem::MaybeUninit;
 
-use zenoh::{session::Session, Wait};
+use zenoh::{handlers::Callback, sample::Sample, session::Session, Wait};
 use zenoh_ext::*;
 
 use crate::{
@@ -88,26 +88,12 @@ pub extern "C" fn ze_querying_subscriber_options_default(
     });
 }
 
-/// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
-/// @brief Constructs and declares a querying subscriber for a given key expression.
-///
-/// @param this_: An uninitialized memory location where querying subscriber will be constructed.
-/// @param session: A Zenoh session.
-/// @param key_expr: A key expression to subscribe to.
-/// @param callback: The callback function that will be called each time a data matching the subscribed expression is received.
-/// @param options: Additional options for the querying subscriber.
-///
-/// @return 0 in case of success, negative error code otherwise.
-#[no_mangle]
-#[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn ze_declare_querying_subscriber(
-    this: &mut MaybeUninit<ze_owned_querying_subscriber_t>,
-    session: &'static z_loaned_session_t,
-    key_expr: &z_loaned_keyexpr_t,
+pub unsafe fn _declare_querying_subscriber_inner<'a, 'b>(
+    session: &'a z_loaned_session_t,
+    key_expr: &'b z_loaned_keyexpr_t,
     callback: &mut z_moved_closure_sample_t,
     options: Option<&mut ze_querying_subscriber_options_t>,
-) -> result::z_result_t {
-    let this = this.as_rust_type_mut_uninit();
+) -> QueryingSubscriberBuilder<'a, 'b, UserSpace, Callback<Sample>> {
     let session = session.as_rust_type_ref();
     let callback = callback.take_rust_type();
     let mut sub = session
@@ -141,14 +127,66 @@ pub unsafe extern "C" fn ze_declare_querying_subscriber(
                 .as_loaned_c_type_mut(),
         );
     });
+    sub
+}
+/// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+/// @brief Constructs and declares a querying subscriber for a given key expression.
+///
+/// @param this_: An uninitialized memory location where querying subscriber will be constructed.
+/// @param session: A Zenoh session.
+/// @param key_expr: A key expression to subscribe to.
+/// @param callback: The callback function that will be called each time a data matching the subscribed expression is received.
+/// @param options: Additional options for the querying subscriber.
+///
+/// @return 0 in case of success, negative error code otherwise.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn ze_declare_querying_subscriber(
+    this: &mut MaybeUninit<ze_owned_querying_subscriber_t>,
+    session: &'static z_loaned_session_t,
+    key_expr: &z_loaned_keyexpr_t,
+    callback: &mut z_moved_closure_sample_t,
+    options: Option<&mut ze_querying_subscriber_options_t>,
+) -> result::z_result_t {
+    let this = this.as_rust_type_mut_uninit();
+    let sub = _declare_querying_subscriber_inner(session, key_expr, callback, options);
     match sub.wait() {
         Ok(sub) => {
+            let session = session.as_rust_type_ref();
             this.write(Some((sub, session)));
             result::Z_OK
         }
         Err(e) => {
             tracing::debug!("{}", e);
             this.write(None);
+            result::Z_EGENERIC
+        }
+    }
+}
+
+/// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+/// @brief Declares a background querying subscriber for a given key expression. Subscriber callback will be called to process the messages,
+/// until the corresponding session is closed or dropped.
+///
+/// @param session: A Zenoh session.
+/// @param key_expr: A key expression to subscribe to.
+/// @param callback: The callback function that will be called each time a data matching the subscribed expression is received.
+/// @param options: Additional options for the querying subscriber.
+///
+/// @return 0 in case of success, negative error code otherwise.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn ze_declare_background_querying_subscriber(
+    session: &'static z_loaned_session_t,
+    key_expr: &z_loaned_keyexpr_t,
+    callback: &mut z_moved_closure_sample_t,
+    options: Option<&mut ze_querying_subscriber_options_t>,
+) -> result::z_result_t {
+    let sub = _declare_querying_subscriber_inner(session, key_expr, callback, options);
+    match sub.background().wait() {
+        Ok(_) => result::Z_OK,
+        Err(e) => {
+            tracing::debug!("{}", e);
             result::Z_EGENERIC
         }
     }
@@ -220,25 +258,7 @@ pub unsafe extern "C" fn ze_querying_subscriber_get(
 }
 
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
-/// @brief Undeclares the given querying subscriber, drops it and resets to a gravestone state.
-///
-/// @return 0 in case of success, negative error code otherwise.
-#[no_mangle]
-pub extern "C" fn ze_undeclare_querying_subscriber(
-    this_: &mut ze_moved_querying_subscriber_t,
-) -> result::z_result_t {
-    if let Some(s) = this_.take_rust_type() {
-        if let Err(e) = s.0.undeclare().wait() {
-            tracing::error!("{}", e);
-            return result::Z_EGENERIC;
-        }
-    }
-    result::Z_OK
-}
-
-/// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
-/// @brief Drops querying subscriber.
-/// The callback closure is not dropped, and thus the queries continue to be served until the corresponding session is closed.
+/// @brief Undeclares querying subscriber callback and resets it to its gravestone state.
 #[no_mangle]
 pub extern "C" fn ze_querying_subscriber_drop(this_: &mut ze_moved_querying_subscriber_t) {
     std::mem::drop(this_.take_rust_type())

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -14,7 +14,12 @@
 
 use std::mem::MaybeUninit;
 
-use zenoh::{pubsub::Subscriber, Wait};
+use zenoh::{
+    handlers::Callback,
+    pubsub::{Subscriber, SubscriberBuilder},
+    sample::Sample,
+    Wait,
+};
 
 pub use crate::opaque_types::{z_loaned_subscriber_t, z_moved_subscriber_t, z_owned_subscriber_t};
 use crate::{
@@ -59,25 +64,12 @@ pub extern "C" fn z_subscriber_options_default(this_: &mut MaybeUninit<z_subscri
     this_.write(z_subscriber_options_t { _0: 0 });
 }
 
-/// Constructs and declares a subscriber for a given key expression. Dropping subscriber
-///
-/// @param this_: An uninitialized location in memory, where subscriber will be constructed.
-/// @param session: The zenoh session.
-/// @param key_expr: The key expression to subscribe.
-/// @param callback: The callback function that will be called each time a data matching the subscribed expression is received.
-/// @param _options: The options to be passed to the subscriber declaration.
-///
-/// @return 0 in case of success, negative error code otherwise (in this case subscriber will be in its gravestone state).
-#[no_mangle]
-#[allow(clippy::missing_safety_doc)]
-pub extern "C" fn z_declare_subscriber(
-    this: &mut MaybeUninit<z_owned_subscriber_t>,
-    session: &z_loaned_session_t,
-    key_expr: &z_loaned_keyexpr_t,
+fn _declare_subscriber_inner<'a, 'b>(
+    session: &'a z_loaned_session_t,
+    key_expr: &'b z_loaned_keyexpr_t,
     callback: &mut z_moved_closure_sample_t,
     _options: Option<&mut z_subscriber_options_t>,
-) -> result::z_result_t {
-    let this = this.as_rust_type_mut_uninit();
+) -> SubscriberBuilder<'a, 'b, Callback<Sample>> {
     let session = session.as_rust_type_ref();
     let key_expr = key_expr.as_rust_type_ref();
     let callback = callback.take_rust_type();
@@ -92,6 +84,28 @@ pub extern "C" fn z_declare_subscriber(
                     .as_loaned_c_type_mut()
             })
         });
+    subscriber
+}
+
+/// Constructs and declares a subscriber for a given key expression. Dropping subscriber undeclares its callback.
+///
+/// @param this_: An uninitialized location in memory, where subscriber will be constructed.
+/// @param session: The zenoh session.
+/// @param key_expr: The key expression to subscribe.
+/// @param callback: The callback function that will be called each time a data matching the subscribed expression is received.
+/// @param _options: The options to be passed to the subscriber declaration.
+///
+/// @return 0 in case of success, negative error code otherwise (in this case subscriber will be in its gravestone state).
+#[no_mangle]
+pub extern "C" fn z_declare_subscriber(
+    this: &mut MaybeUninit<z_owned_subscriber_t>,
+    session: &z_loaned_session_t,
+    key_expr: &z_loaned_keyexpr_t,
+    callback: &mut z_moved_closure_sample_t,
+    _options: Option<&mut z_subscriber_options_t>,
+) -> result::z_result_t {
+    let this = this.as_rust_type_mut_uninit();
+    let subscriber = _declare_subscriber_inner(session, key_expr, callback, _options);
     match subscriber.wait() {
         Ok(sub) => {
             this.write(Some(sub));
@@ -100,6 +114,32 @@ pub extern "C" fn z_declare_subscriber(
         Err(e) => {
             tracing::error!("{}", e);
             this.write(None);
+            result::Z_EGENERIC
+        }
+    }
+}
+
+/// Constructs and declares a background subscriber. Subscriber callback will be called to process the messages,
+/// until the corresponding session is closed or dropped.
+///
+/// @param session: The zenoh session.
+/// @param key_expr: The key expression to subscribe.
+/// @param callback: The callback function that will be called each time a data matching the subscribed expression is received.
+/// @param _options: The options to be passed to the subscriber declaration.
+///
+/// @return 0 in case of success, negative error code otherwise.
+#[no_mangle]
+pub extern "C" fn z_declare_background_subscriber(
+    session: &z_loaned_session_t,
+    key_expr: &z_loaned_keyexpr_t,
+    callback: &mut z_moved_closure_sample_t,
+    _options: Option<&mut z_subscriber_options_t>,
+) -> result::z_result_t {
+    let subscriber = _declare_subscriber_inner(session, key_expr, callback, _options);
+    match subscriber.background().wait() {
+        Ok(_) => result::Z_OK,
+        Err(e) => {
+            tracing::error!("{}", e);
             result::Z_EGENERIC
         }
     }
@@ -115,23 +155,7 @@ pub extern "C" fn z_subscriber_keyexpr(subscriber: &z_loaned_subscriber_t) -> &z
         .as_loaned_c_type_ref()
 }
 
-/// Undeclares and drops subscriber.
-///
-/// @return 0 in case of success, negative error code otherwise.
-#[allow(clippy::missing_safety_doc)]
-#[no_mangle]
-pub extern "C" fn z_undeclare_subscriber(this_: &mut z_moved_subscriber_t) -> result::z_result_t {
-    if let Some(s) = this_.take_rust_type() {
-        if let Err(e) = s.undeclare().wait() {
-            tracing::error!("{}", e);
-            return result::Z_EGENERIC;
-        }
-    }
-    result::Z_OK
-}
-
-/// Drops subscriber and resets it to its gravestone state.
-/// The callback closure is not dropped and still keeps receiving and processing samples until the corresponding session is closed.
+/// Undeclares subscriber callback and resets it to its gravestone state.
 #[no_mangle]
 pub extern "C" fn z_subscriber_drop(this_: &mut z_moved_subscriber_t) {
     std::mem::drop(this_.take_rust_type())

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -305,8 +305,7 @@ int main(int argc, char **argv) {
     assert(_ret_int8 == 0);
     assert(!z_internal_check(_ret_expr));
 
-    _ret_int8 = z_undeclare_subscriber(z_move(_ret_sub));
-    assert(_ret_int8 == 0);
+    z_drop(z_move(_ret_sub));
 
     // TODO: test for pull subscriber
 
@@ -338,7 +337,7 @@ int main(int argc, char **argv) {
     assert(queries == 1);
     assert(replies == 1);
 
-    _ret_int8 = z_undeclare_queryable(z_move(qle));
+    z_drop(z_move(qle));
     assert(_ret_int8 == 0);
 
 #ifdef ZENOH_PICO

--- a/tests/z_api_double_drop_test.c
+++ b/tests/z_api_double_drop_test.c
@@ -47,9 +47,9 @@ void test_publisher() {
     z_owned_publisher_t pub;
     z_declare_publisher(&pub, z_loan(s), z_loan(keyexpr), NULL);
     assert(z_internal_check(pub));
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     assert(!z_internal_check(pub));
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     assert(!z_internal_check(pub));
     z_drop(z_move(s));
 }
@@ -90,9 +90,9 @@ void test_subscriber() {
     z_owned_subscriber_t sub;
     z_declare_subscriber(&sub, z_loan(s), z_loan(keyexpr), z_move(callback), NULL);
     assert(z_internal_check(sub));
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     assert(!z_internal_check(sub));
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     assert(!z_internal_check(sub));
     z_drop(z_move(s));
 }
@@ -112,9 +112,9 @@ void test_queryable() {
     z_owned_queryable_t queryable;
     z_declare_queryable(&queryable, z_loan(s), z_loan(keyexpr), z_move(callback), NULL);
     assert(z_internal_check(queryable));
-    z_undeclare_queryable(z_move(queryable));
+    z_drop(z_move(queryable));
     assert(!z_internal_check(queryable));
-    z_undeclare_queryable(z_move(queryable));
+    z_drop(z_move(queryable));
     assert(!z_internal_check(queryable));
     z_drop(z_move(s));
 }

--- a/tests/z_api_keyexpr_drop_test.c
+++ b/tests/z_api_keyexpr_drop_test.c
@@ -39,7 +39,7 @@ void test_publisher() {
     z_keyexpr_as_view_string(pub_ke, &pub_keyexpr);
     assert(strncmp(z_string_data(z_loan(pub_keyexpr)), "foo/bar", z_string_len(z_loan(pub_keyexpr))) ==
            0);  // Check that publisher keeps the correct keyexpr
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
 }
 
@@ -65,7 +65,7 @@ void test_subscriber() {
     z_keyexpr_as_view_string(sub_ke, &sub_keyexpr);
     assert(strncmp(z_string_data(z_loan(sub_keyexpr)), "foo/bar", z_string_len(z_loan(sub_keyexpr))) ==
            0);  // Check that subscriber keeps the correct keyexpr
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
 }
 

--- a/tests/z_int_pub_cache_query_sub_test.c
+++ b/tests/z_int_pub_cache_query_sub_test.c
@@ -85,7 +85,7 @@ int run_publisher() {
     SEM_WAIT(sem_sub);
 
     ze_undeclare_publication_cache(z_move(pub_cache));
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
 
     return 0;

--- a/tests/z_int_pub_sub_attachment_test.c
+++ b/tests/z_int_pub_sub_attachment_test.c
@@ -126,7 +126,7 @@ int run_publisher() {
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
 
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     return 0;
 }
@@ -190,7 +190,7 @@ int run_subscriber() {
     SEM_POST(sem);
     z_sleep_s(10);
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
 
     return -1;

--- a/tests/z_int_pub_sub_test.c
+++ b/tests/z_int_pub_sub_test.c
@@ -75,7 +75,7 @@ int run_publisher() {
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
 
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     return 0;
 }
@@ -164,7 +164,7 @@ int run_subscriber() {
     SEM_POST(sem);
     sleep(10);
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
 
     return -1;

--- a/tests/z_int_queryable_attachment_test.c
+++ b/tests/z_int_queryable_attachment_test.c
@@ -150,7 +150,7 @@ int run_queryable() {
     SEM_POST(sem);
     z_sleep_s(10);
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
     z_drop(z_move(s));
     return 0;
 }

--- a/tests/z_int_queryable_test.c
+++ b/tests/z_int_queryable_test.c
@@ -82,7 +82,7 @@ int run_queryable() {
     SEM_POST(sem);
     z_sleep_s(10);
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
     z_drop(z_move(s));
     return 0;
 }

--- a/tests/z_leak_pub_sub_test.c
+++ b/tests/z_leak_pub_sub_test.c
@@ -86,8 +86,8 @@ int main(int argc, char **argv) {
         z_sleep_s(1);
     }
 
-    z_undeclare_publisher(z_move(publisher));
-    z_undeclare_subscriber(z_move(subscriber));
+    z_drop(z_move(publisher));
+    z_drop(z_move(subscriber));
     z_drop(z_move(pub_session));
     z_drop(z_move(sub_session));
     z_drop(z_move(pub_keyexpr));

--- a/tests/z_leak_queryable_get_test.c
+++ b/tests/z_leak_queryable_get_test.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
     }
     assert(received_replies == 5);
 
-    z_undeclare_queryable(z_move(queryable));
+    z_drop(z_move(queryable));
     z_drop(z_move(get_session));
     z_drop(z_move(queryable_session));
     z_drop(z_move(queryable_keyexpr));


### PR DESCRIPTION
remove z_undeclare_subscriber/publisher/queryable/publication_cache/q…uerying_subscriber and zc_publisher_matching_listener_undeclare - since they had the same signature and effect as corresponding drop functions;

make z(e)_subscriber/publisher/queryable/querying_subscriber_drop and zc_publisher_matching_listener_drop automatically undeclare corresponding entities; add z(e)_declare_background_subscriber/queryable/querying_subscriber, zc_publisher_matching_listener_declare_background and  zc_liveliness_declare_background_subscriber functions, that do not return an entity, but rather register the corresponding callbacks until the session is closed/dropped;