### PR TITLE
rename zc_liveliness_token_(un)declare according to the rest api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -827,8 +827,8 @@ Functions
 .. doxygenfunction:: zc_liveliness_subscriber_declare_background
 .. doxygenfunction:: zc_liveliness_get
 
-.. doxygenfunction:: zc_liveliness_declare_token
-.. doxygenfunction:: zc_liveliness_undeclare_token
+.. doxygenfunction:: zc_liveliness_token_declare
+.. doxygenfunction:: zc_liveliness_token_undeclare
 .. doxygenfunction:: zc_liveliness_token_loan
 .. doxygenfunction:: zc_liveliness_token_drop
 

--- a/examples/z_liveliness.c
+++ b/examples/z_liveliness.c
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
 
     printf("Declaring liveliness token '%s'...\n", args.keyexpr);
     zc_owned_liveliness_token_t token;
-    if (zc_liveliness_declare_token(&token, z_loan(s), z_loan(keyexpr), NULL) < 0) {
+    if (zc_liveliness_token_declare(&token, z_loan(s), z_loan(keyexpr), NULL) < 0) {
         printf("Unable to create liveliness token!\n");
         exit(-1);
     }

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -969,7 +969,7 @@ typedef struct zc_moved_closure_matching_status_t {
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief The options for `zc_liveliness_declare_token()`.
+ * @brief The options for `zc_liveliness_token_declare()`.
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 typedef struct zc_liveliness_declaration_options_t {
@@ -4691,25 +4691,6 @@ void zc_liveliness_declaration_options_default(struct zc_liveliness_declaration_
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Constructs and declares a liveliness token on the network.
- *
- * Liveliness token subscribers on an intersecting key expression will receive a PUT sample when connectivity
- * is achieved, and a DELETE sample if it's lost.
- *
- * @param this_: An uninitialized memory location where liveliness token will be constructed.
- * @param session: A Zenos session to declare the liveliness token.
- * @param key_expr: A keyexpr to declare a liveliess token for.
- * @param _options: Liveliness token declaration properties.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-z_result_t zc_liveliness_declare_token(struct zc_owned_liveliness_token_t *this_,
-                                       const struct z_loaned_session_t *session,
-                                       const struct z_loaned_keyexpr_t *key_expr,
-                                       const struct zc_liveliness_declaration_options_t *_options);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Queries liveliness tokens currently on the network with a key expression intersecting with `key_expr`.
  *
  * @param session: The Zenoh session.
@@ -4780,6 +4761,25 @@ void zc_liveliness_subscriber_options_default(struct zc_liveliness_subscriber_op
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Constructs and declares a liveliness token on the network.
+ *
+ * Liveliness token subscribers on an intersecting key expression will receive a PUT sample when connectivity
+ * is achieved, and a DELETE sample if it's lost.
+ *
+ * @param this_: An uninitialized memory location where liveliness token will be constructed.
+ * @param session: A Zenos session to declare the liveliness token.
+ * @param key_expr: A keyexpr to declare a liveliess token for.
+ * @param _options: Liveliness token declaration properties.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+z_result_t zc_liveliness_token_declare(struct zc_owned_liveliness_token_t *this_,
+                                       const struct z_loaned_session_t *session,
+                                       const struct z_loaned_keyexpr_t *key_expr,
+                                       const struct zc_liveliness_declaration_options_t *_options);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Undeclares liveliness token, frees memory and resets it to a gravestone state.
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
@@ -4800,7 +4800,7 @@ const struct zc_loaned_liveliness_token_t *zc_liveliness_token_loan(const struct
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
-z_result_t zc_liveliness_undeclare_token(struct zc_moved_liveliness_token_t *this_);
+z_result_t zc_liveliness_token_undeclare(struct zc_moved_liveliness_token_t *this_);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.

--- a/src/liveliness.rs
+++ b/src/liveliness.rs
@@ -58,7 +58,7 @@ pub extern "C" fn zc_liveliness_token_drop(this_: &mut zc_moved_liveliness_token
 }
 
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
-/// @brief The options for `zc_liveliness_declare_token()`.
+/// @brief The options for `zc_liveliness_token_declare()`.
 #[repr(C)]
 pub struct zc_liveliness_declaration_options_t {
     _dummy: u8,
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn zc_liveliness_token_loan(
 /// @param key_expr: A keyexpr to declare a liveliess token for.
 /// @param _options: Liveliness token declaration properties.
 #[no_mangle]
-pub extern "C" fn zc_liveliness_declare_token(
+pub extern "C" fn zc_liveliness_token_declare(
     this: &mut MaybeUninit<zc_owned_liveliness_token_t>,
     session: &z_loaned_session_t,
     key_expr: &z_loaned_keyexpr_t,
@@ -122,7 +122,7 @@ pub extern "C" fn zc_liveliness_declare_token(
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Destroys a liveliness token, notifying subscribers of its destruction.
 #[no_mangle]
-pub extern "C" fn zc_liveliness_undeclare_token(
+pub extern "C" fn zc_liveliness_token_undeclare(
     this: &mut zc_moved_liveliness_token_t,
 ) -> result::z_result_t {
     if let Some(token) = this.take_rust_type() {

--- a/tests/z_api_liveliness.c
+++ b/tests/z_api_liveliness.c
@@ -75,21 +75,21 @@ void test_liveliness_sub() {
 
     z_sleep_s(1);
     zc_owned_liveliness_token_t t1, t2;
-    zc_liveliness_declare_token(&t1, z_loan(s1), z_loan(k1), NULL);
-    zc_liveliness_declare_token(&t2, z_loan(s1), z_loan(k2), NULL);
+    zc_liveliness_token_declare(&t1, z_loan(s1), z_loan(k1), NULL);
+    zc_liveliness_token_declare(&t2, z_loan(s1), z_loan(k2), NULL);
 
     z_sleep_s(1);
 
     assert(context.token1_put);
     assert(context.token2_put);
 
-    zc_liveliness_undeclare_token(z_move(t1));
+    zc_liveliness_token_undeclare(z_move(t1));
     z_sleep_s(1);
 
     assert(context.token1_drop);
     assert(!context.token2_drop);
 
-    zc_liveliness_undeclare_token(z_move(t2));
+    zc_liveliness_token_undeclare(z_move(t2));
     z_sleep_s(1);
     assert(context.token2_drop);
 }
@@ -110,7 +110,7 @@ void test_liveliness_get() {
 
     z_sleep_s(1);
     zc_owned_liveliness_token_t t1;
-    zc_liveliness_declare_token(&t1, z_loan(s1), z_loan(k1), NULL);
+    zc_liveliness_token_declare(&t1, z_loan(s1), z_loan(k1), NULL);
     z_sleep_s(1);
 
     z_owned_fifo_handler_reply_t handler;


### PR DESCRIPTION
rename zc_liveliness_token_(un)declare according to the rest api