### PR TITLE
impose utf-8 correctness check when serializing strings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -128,6 +128,7 @@ Functions
 .. doxygenfunction:: ze_serialize_buf
 .. doxygenfunction:: ze_serialize_string
 .. doxygenfunction:: ze_serialize_str
+.. doxygenfunction:: ze_serialize_substr
 .. doxygenfunction:: ze_serialize_uint8
 .. doxygenfunction:: ze_serialize_uint16
 .. doxygenfunction:: ze_serialize_uint32
@@ -177,6 +178,7 @@ Functions
 .. doxygenfunction:: ze_serializer_serialize_buf
 .. doxygenfunction:: ze_serializer_serialize_string
 .. doxygenfunction:: ze_serializer_serialize_str
+.. doxygenfunction:: ze_serializer_serialize_substr
 .. doxygenfunction:: ze_serializer_serialize_uint8
 .. doxygenfunction:: ze_serializer_serialize_uint16
 .. doxygenfunction:: ze_serializer_serialize_uint32

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1311,7 +1311,7 @@ z_result_t z_bytes_to_string(const struct z_loaned_bytes_t *this_,
  * This allows to compose a serialized data out of multiple `z_owned_bytes_t` that may point to different memory regions.
  * Said in other terms, it allows to create a linear view on different memory regions without copy.
  *
- * @return 0 in case of success, negative error code otherwise
+ * @return 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API
 z_result_t z_bytes_writer_append(struct z_loaned_bytes_writer_t *this_,
@@ -5013,7 +5013,7 @@ ZENOHC_API
 z_result_t ze_deserialize_slice(const struct z_loaned_bytes_t *this_,
                                 struct z_owned_slice_t *slice);
 /**
- * @brief Deserializes into a string.
+ * @brief Deserializes into a UTF-8 string.
  */
 ZENOHC_API
 z_result_t ze_deserialize_string(const struct z_loaned_bytes_t *this_,
@@ -5255,72 +5255,90 @@ void ze_querying_subscriber_options_default(struct ze_querying_subscriber_option
 /**
  * @brief Serializes a bool.
  */
-ZENOHC_API void ze_serialize_bool(struct z_owned_bytes_t *this_, bool val);
+ZENOHC_API z_result_t ze_serialize_bool(struct z_owned_bytes_t *this_, bool val);
 /**
  * @brief Serializes a data from buffer by.
  * @param this_: An uninitialized location in memory where `z_owned_bytes_t` is to be constructed.
  * @param data: A pointer to the buffer containing data.
  * @param len: Length of the buffer.
  */
-ZENOHC_API void ze_serialize_buf(struct z_owned_bytes_t *this_, const uint8_t *data, size_t len);
+ZENOHC_API
+z_result_t ze_serialize_buf(struct z_owned_bytes_t *this_,
+                            const uint8_t *data,
+                            size_t len);
 /**
  * @brief Serializes a double.
  */
-ZENOHC_API void ze_serialize_double(struct z_owned_bytes_t *this_, double val);
+ZENOHC_API z_result_t ze_serialize_double(struct z_owned_bytes_t *this_, double val);
 /**
  * @brief Serializes a float.
  */
-ZENOHC_API void ze_serialize_float(struct z_owned_bytes_t *this_, float val);
+ZENOHC_API z_result_t ze_serialize_float(struct z_owned_bytes_t *this_, float val);
 /**
  * @brief Serializes a signed integer.
  */
-ZENOHC_API void ze_serialize_int16(struct z_owned_bytes_t *this_, int16_t val);
+ZENOHC_API z_result_t ze_serialize_int16(struct z_owned_bytes_t *this_, int16_t val);
 /**
  * @brief Serializes a signed integer.
  */
-ZENOHC_API void ze_serialize_int32(struct z_owned_bytes_t *this_, int32_t val);
+ZENOHC_API z_result_t ze_serialize_int32(struct z_owned_bytes_t *this_, int32_t val);
 /**
  * @brief Serializes a signed integer.
  */
-ZENOHC_API void ze_serialize_int64(struct z_owned_bytes_t *this_, int64_t val);
+ZENOHC_API z_result_t ze_serialize_int64(struct z_owned_bytes_t *this_, int64_t val);
 /**
  * @brief Serializes a signed integer.
  */
-ZENOHC_API void ze_serialize_int8(struct z_owned_bytes_t *this_, int8_t val);
+ZENOHC_API z_result_t ze_serialize_int8(struct z_owned_bytes_t *this_, int8_t val);
 /**
  * @brief Serializes a slice.
  */
 ZENOHC_API
-void ze_serialize_slice(struct z_owned_bytes_t *this_,
-                        const struct z_loaned_slice_t *slice);
+z_result_t ze_serialize_slice(struct z_owned_bytes_t *this_,
+                              const struct z_loaned_slice_t *slice);
 /**
  * @brief Serializes a null-terminated string.
+ * The string should be a valid UTF-8.
  * @param this_: An uninitialized location in memory where `z_owned_bytes_t` is to be constructed.
  * @param str: a pointer to the null-terminated string.
  */
-ZENOHC_API void ze_serialize_str(struct z_owned_bytes_t *this_, const char *str);
+ZENOHC_API z_result_t ze_serialize_str(struct z_owned_bytes_t *this_, const char *str);
 /**
  * @brief Serializes a string.
+ * The string should be a valid UTF-8.
+ * @param this_: An uninitialized location in memory where `z_owned_bytes_t` is to be constructed.
+ * @param str: a string to serialize.
  */
 ZENOHC_API
-void ze_serialize_string(struct z_owned_bytes_t *this_,
-                         const struct z_loaned_string_t *str);
+z_result_t ze_serialize_string(struct z_owned_bytes_t *this_,
+                               const struct z_loaned_string_t *str);
+/**
+ * @brief Serializes a substring.
+ * The substring should be a valid UTF-8.
+ * @param this_: An uninitialized location in memory where `z_owned_bytes_t` is to be constructed.
+ * @param start: a pointer to the the start of the substring.
+ * @param len: the length of the substring.
+ */
+ZENOHC_API
+z_result_t ze_serialize_substr(struct z_owned_bytes_t *this_,
+                               const char *start,
+                               size_t len);
 /**
  * @brief Serializes an unsigned integer.
  */
-ZENOHC_API void ze_serialize_uint16(struct z_owned_bytes_t *this_, uint16_t val);
+ZENOHC_API z_result_t ze_serialize_uint16(struct z_owned_bytes_t *this_, uint16_t val);
 /**
  * @brief Serializes an unsigned integer.
  */
-ZENOHC_API void ze_serialize_uint32(struct z_owned_bytes_t *this_, uint32_t val);
+ZENOHC_API z_result_t ze_serialize_uint32(struct z_owned_bytes_t *this_, uint32_t val);
 /**
  * @brief Serializes an unsigned integer.
  */
-ZENOHC_API void ze_serialize_uint64(struct z_owned_bytes_t *this_, uint64_t val);
+ZENOHC_API z_result_t ze_serialize_uint64(struct z_owned_bytes_t *this_, uint64_t val);
 /**
  * @brief Serializes an unsigned integer.
  */
-ZENOHC_API void ze_serialize_uint8(struct z_owned_bytes_t *this_, uint8_t val);
+ZENOHC_API z_result_t ze_serialize_uint8(struct z_owned_bytes_t *this_, uint8_t val);
 /**
  * @brief Drops `this_`, resetting it to gravestone value.
  */
@@ -5352,7 +5370,7 @@ struct ze_loaned_serializer_t *ze_serializer_loan_mut(struct ze_owned_serializer
 /**
  * @brief Serializes a bool.
  */
-ZENOHC_API void ze_serializer_serialize_bool(struct ze_loaned_serializer_t *this_, bool val);
+ZENOHC_API z_result_t ze_serializer_serialize_bool(struct ze_loaned_serializer_t *this_, bool val);
 /**
  * @brief Serializes a data from buffer.
  * @param this_: A serializer instance.
@@ -5360,73 +5378,108 @@ ZENOHC_API void ze_serializer_serialize_bool(struct ze_loaned_serializer_t *this
  * @param len: Length of the buffer.
  */
 ZENOHC_API
-void ze_serializer_serialize_buf(struct ze_loaned_serializer_t *this_,
-                                 const uint8_t *data,
-                                 size_t len);
+z_result_t ze_serializer_serialize_buf(struct ze_loaned_serializer_t *this_,
+                                       const uint8_t *data,
+                                       size_t len);
 /**
  * @brief Serializes a double.
  */
-ZENOHC_API void ze_serializer_serialize_double(struct ze_loaned_serializer_t *this_, double val);
+ZENOHC_API
+z_result_t ze_serializer_serialize_double(struct ze_loaned_serializer_t *this_,
+                                          double val);
 /**
  * @brief Serializes a float.
  */
-ZENOHC_API void ze_serializer_serialize_float(struct ze_loaned_serializer_t *this_, float val);
+ZENOHC_API
+z_result_t ze_serializer_serialize_float(struct ze_loaned_serializer_t *this_,
+                                         float val);
 /**
  * @brief Serializes a signed integer.
  */
-ZENOHC_API void ze_serializer_serialize_int16(struct ze_loaned_serializer_t *this_, int16_t val);
+ZENOHC_API
+z_result_t ze_serializer_serialize_int16(struct ze_loaned_serializer_t *this_,
+                                         int16_t val);
 /**
  * @brief Serializes a signed integer.
  */
-ZENOHC_API void ze_serializer_serialize_int32(struct ze_loaned_serializer_t *this_, int32_t val);
+ZENOHC_API
+z_result_t ze_serializer_serialize_int32(struct ze_loaned_serializer_t *this_,
+                                         int32_t val);
 /**
  * @brief Serializes a signed integer.
  */
-ZENOHC_API void ze_serializer_serialize_int64(struct ze_loaned_serializer_t *this_, int64_t val);
+ZENOHC_API
+z_result_t ze_serializer_serialize_int64(struct ze_loaned_serializer_t *this_,
+                                         int64_t val);
 /**
  * @brief Serializes a signed integer.
  */
-ZENOHC_API void ze_serializer_serialize_int8(struct ze_loaned_serializer_t *this_, int8_t val);
+ZENOHC_API
+z_result_t ze_serializer_serialize_int8(struct ze_loaned_serializer_t *this_,
+                                        int8_t val);
 /**
  * @brief Initiates serialization of a sequence of multiple elements.
  * @param this_: A serializer instance.
  * @param len: Length of the sequence. Could be read during deserialization using `ze_deserializer_deserialize_sequence_length`.
  */
 ZENOHC_API
-void ze_serializer_serialize_sequence_length(struct ze_loaned_serializer_t *this_,
-                                             size_t len);
+z_result_t ze_serializer_serialize_sequence_length(struct ze_loaned_serializer_t *this_,
+                                                   size_t len);
 /**
  * @brief Serializes a slice.
  */
 ZENOHC_API
-void ze_serializer_serialize_slice(struct ze_loaned_serializer_t *this_,
-                                   const struct z_loaned_slice_t *slice);
+z_result_t ze_serializer_serialize_slice(struct ze_loaned_serializer_t *this_,
+                                         const struct z_loaned_slice_t *slice);
 /**
  * @brief Serializes a null-terminated string.
- */
-ZENOHC_API void ze_serializer_serialize_str(struct ze_loaned_serializer_t *this_, const char *str);
-/**
- * @brief Serializes a string.
+ * The string should be a valid UTF-8.
+ * @return 0 in case of success, negative error code otherwise.
  */
 ZENOHC_API
-void ze_serializer_serialize_string(struct ze_loaned_serializer_t *this_,
-                                    const struct z_loaned_string_t *str);
+z_result_t ze_serializer_serialize_str(struct ze_loaned_serializer_t *this_,
+                                       const char *str);
+/**
+ * @brief Serializes a string.
+ * The string should be a valid UTF-8.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+ZENOHC_API
+z_result_t ze_serializer_serialize_string(struct ze_loaned_serializer_t *this_,
+                                          const struct z_loaned_string_t *str);
+/**
+ * @brief Serializes a substring of specified length.
+ * The subsstring should be a valid UTF-8.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+ZENOHC_API
+z_result_t ze_serializer_serialize_substr(struct ze_loaned_serializer_t *this_,
+                                          const char *start,
+                                          size_t len);
 /**
  * @brief Serializes an unsigned integer.
  */
-ZENOHC_API void ze_serializer_serialize_uint16(struct ze_loaned_serializer_t *this_, uint16_t val);
+ZENOHC_API
+z_result_t ze_serializer_serialize_uint16(struct ze_loaned_serializer_t *this_,
+                                          uint16_t val);
 /**
  * @brief Serializes an unsigned integer.
  */
-ZENOHC_API void ze_serializer_serialize_uint32(struct ze_loaned_serializer_t *this_, uint32_t val);
+ZENOHC_API
+z_result_t ze_serializer_serialize_uint32(struct ze_loaned_serializer_t *this_,
+                                          uint32_t val);
 /**
  * @brief Serializes an unsigned integer.
  */
-ZENOHC_API void ze_serializer_serialize_uint64(struct ze_loaned_serializer_t *this_, uint64_t val);
+ZENOHC_API
+z_result_t ze_serializer_serialize_uint64(struct ze_loaned_serializer_t *this_,
+                                          uint64_t val);
 /**
  * @brief Serializes an unsigned integer.
  */
-ZENOHC_API void ze_serializer_serialize_uint8(struct ze_loaned_serializer_t *this_, uint8_t val);
+ZENOHC_API
+z_result_t ze_serializer_serialize_uint8(struct ze_loaned_serializer_t *this_,
+                                         uint8_t val);
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Undeclares publication cache.

--- a/include/zenoh_concrete.h
+++ b/include/zenoh_concrete.h
@@ -33,6 +33,7 @@
 #define Z_EUNAVAILABLE -6
 #define Z_EDESERIALIZE -7
 #define Z_ESESSION_CLOSED -8
+#define Z_EUTF8 -9
 #define Z_EBUSY_MUTEX -16
 #define Z_EINVAL_MUTEX -22
 #define Z_EAGAIN_MUTEX -11

--- a/src/result.rs
+++ b/src/result.rs
@@ -26,6 +26,7 @@ pub const Z_ENULL: z_result_t = -5;
 pub const Z_EUNAVAILABLE: z_result_t = -6;
 pub const Z_EDESERIALIZE: z_result_t = -7;
 pub const Z_ESESSION_CLOSED: z_result_t = -8;
+pub const Z_EUTF8: z_result_t = -9;
 // negative pthread error codes (due to convention to return negative values on error)
 pub const Z_EBUSY_MUTEX: z_result_t = -16;
 pub const Z_EINVAL_MUTEX: z_result_t = -22;

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -12,9 +12,11 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use core::str;
 use std::{mem::MaybeUninit, slice::from_raw_parts};
 
 use libc::strlen;
+use zenoh::bytes::ZBytes;
 use zenoh_ext::{
     z_deserialize, z_serialize, Deserialize, Serialize, VarInt, ZDeserializer, ZSerializer,
 };
@@ -127,68 +129,112 @@ where
 
 /// @brief Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn ze_serialize_uint8(this_: &mut MaybeUninit<z_owned_bytes_t>, val: u8) {
+pub extern "C" fn ze_serialize_uint8(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: u8,
+) -> z_result_t {
     ze_serialize_arithmetic::<u8>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn ze_serialize_uint16(this_: &mut MaybeUninit<z_owned_bytes_t>, val: u16) {
+pub extern "C" fn ze_serialize_uint16(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: u16,
+) -> z_result_t {
     ze_serialize_arithmetic::<u16>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn ze_serialize_uint32(this_: &mut MaybeUninit<z_owned_bytes_t>, val: u32) {
+pub extern "C" fn ze_serialize_uint32(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: u32,
+) -> z_result_t {
     ze_serialize_arithmetic::<u32>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn ze_serialize_uint64(this_: &mut MaybeUninit<z_owned_bytes_t>, val: u64) {
+pub extern "C" fn ze_serialize_uint64(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: u64,
+) -> z_result_t {
     ze_serialize_arithmetic::<u64>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn ze_serialize_int8(this_: &mut MaybeUninit<z_owned_bytes_t>, val: i8) {
+pub extern "C" fn ze_serialize_int8(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: i8,
+) -> z_result_t {
     ze_serialize_arithmetic::<i8>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn ze_serialize_int16(this_: &mut MaybeUninit<z_owned_bytes_t>, val: i16) {
+pub extern "C" fn ze_serialize_int16(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: i16,
+) -> z_result_t {
     ze_serialize_arithmetic::<i16>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn ze_serialize_int32(this_: &mut MaybeUninit<z_owned_bytes_t>, val: i32) {
+pub extern "C" fn ze_serialize_int32(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: i32,
+) -> z_result_t {
     ze_serialize_arithmetic::<i32>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn ze_serialize_int64(this_: &mut MaybeUninit<z_owned_bytes_t>, val: i64) {
+pub extern "C" fn ze_serialize_int64(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: i64,
+) -> z_result_t {
     ze_serialize_arithmetic::<i64>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a float.
 #[no_mangle]
-pub extern "C" fn ze_serialize_float(this_: &mut MaybeUninit<z_owned_bytes_t>, val: f32) {
+pub extern "C" fn ze_serialize_float(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: f32,
+) -> z_result_t {
     ze_serialize_arithmetic::<f32>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a double.
 #[no_mangle]
-pub extern "C" fn ze_serialize_double(this_: &mut MaybeUninit<z_owned_bytes_t>, val: f64) {
+pub extern "C" fn ze_serialize_double(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: f64,
+) -> z_result_t {
     ze_serialize_arithmetic::<f64>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a bool.
 #[no_mangle]
-pub extern "C" fn ze_serialize_bool(this_: &mut MaybeUninit<z_owned_bytes_t>, val: bool) {
+pub extern "C" fn ze_serialize_bool(
+    this_: &mut MaybeUninit<z_owned_bytes_t>,
+    val: bool,
+) -> z_result_t {
     ze_serialize_arithmetic::<bool>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Deserializes into an unsigned integer.
@@ -274,9 +320,10 @@ pub extern "C" fn ze_deserialize_bool(this: &z_loaned_bytes_t, dst: &mut bool) -
 pub extern "C" fn ze_serialize_slice(
     this: &mut MaybeUninit<z_owned_bytes_t>,
     slice: &z_loaned_slice_t,
-) {
+) -> z_result_t {
     let cslice = slice.as_rust_type_ref().slice();
     this.as_rust_type_mut_uninit().write(z_serialize(cslice));
+    result::Z_OK
 }
 
 /// @brief Serializes a data from buffer by.
@@ -289,9 +336,10 @@ pub extern "C" fn ze_serialize_buf(
     this: &mut MaybeUninit<z_owned_bytes_t>,
     data: *const u8,
     len: usize,
-) {
+) -> z_result_t {
     let slice = unsafe { from_raw_parts(data, len) };
     this.as_rust_type_mut_uninit().write(z_serialize(slice));
+    result::Z_OK
 }
 
 /// @brief Deserializes into a slice.
@@ -318,17 +366,56 @@ pub extern "C" fn ze_deserialize_slice(
 }
 
 /// @brief Serializes a string.
+/// The string should be a valid UTF-8.
+/// @param this_: An uninitialized location in memory where `z_owned_bytes_t` is to be constructed.
+/// @param str: a string to serialize.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub extern "C" fn ze_serialize_string(
     this: &mut MaybeUninit<z_owned_bytes_t>,
     str: &z_loaned_string_t,
-) {
-    let cslice = str.as_rust_type_ref().slice();
-    this.as_rust_type_mut_uninit().write(z_serialize(cslice));
+) -> z_result_t {
+    match str::from_utf8(str.as_rust_type_ref().slice()) {
+        Ok(s) => {
+            this.as_rust_type_mut_uninit().write(z_serialize(s));
+            result::Z_OK
+        }
+        Err(e) => {
+            tracing::error!("{}", e);
+            this.as_rust_type_mut_uninit().write(ZBytes::new());
+            result::Z_EUTF8
+        }
+    }
+}
+
+/// @brief Serializes a substring.
+/// The substring should be a valid UTF-8.
+/// @param this_: An uninitialized location in memory where `z_owned_bytes_t` is to be constructed.
+/// @param start: a pointer to the the start of the substring.
+/// @param len: the length of the substring.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn ze_serialize_substr(
+    this: &mut MaybeUninit<z_owned_bytes_t>,
+    start: *const libc::c_char,
+    len: usize,
+) -> z_result_t {
+    let slice = unsafe { from_raw_parts(start as *const u8, len) };
+    match str::from_utf8(slice) {
+        Ok(s) => {
+            this.as_rust_type_mut_uninit().write(z_serialize(s));
+            result::Z_OK
+        }
+        Err(e) => {
+            tracing::error!("{}", e);
+            this.as_rust_type_mut_uninit().write(ZBytes::new());
+            result::Z_EUTF8
+        }
+    }
 }
 
 /// @brief Serializes a null-terminated string.
+/// The string should be a valid UTF-8.
 /// @param this_: An uninitialized location in memory where `z_owned_bytes_t` is to be constructed.
 /// @param str: a pointer to the null-terminated string.
 #[no_mangle]
@@ -336,12 +423,11 @@ pub extern "C" fn ze_serialize_string(
 pub unsafe extern "C" fn ze_serialize_str(
     this: &mut MaybeUninit<z_owned_bytes_t>,
     str: *const libc::c_char,
-) {
-    let slice = unsafe { from_raw_parts(str as *const u8, strlen(str)) };
-    this.as_rust_type_mut_uninit().write(z_serialize(slice));
+) -> z_result_t {
+    unsafe { ze_serialize_substr(this, str, strlen(str)) }
 }
 
-/// @brief Deserializes into a string.
+/// @brief Deserializes into a UTF-8 string.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ze_deserialize_string(
@@ -405,68 +491,112 @@ where
 
 /// @brief Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn ze_serializer_serialize_uint8(this_: &mut ze_loaned_serializer_t, val: u8) {
+pub extern "C" fn ze_serializer_serialize_uint8(
+    this_: &mut ze_loaned_serializer_t,
+    val: u8,
+) -> z_result_t {
     ze_serializer_serialize_arithmetic::<u8>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn ze_serializer_serialize_uint16(this_: &mut ze_loaned_serializer_t, val: u16) {
+pub extern "C" fn ze_serializer_serialize_uint16(
+    this_: &mut ze_loaned_serializer_t,
+    val: u16,
+) -> z_result_t {
     ze_serializer_serialize_arithmetic::<u16>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn ze_serializer_serialize_uint32(this_: &mut ze_loaned_serializer_t, val: u32) {
+pub extern "C" fn ze_serializer_serialize_uint32(
+    this_: &mut ze_loaned_serializer_t,
+    val: u32,
+) -> z_result_t {
     ze_serializer_serialize_arithmetic::<u32>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes an unsigned integer.
 #[no_mangle]
-pub extern "C" fn ze_serializer_serialize_uint64(this_: &mut ze_loaned_serializer_t, val: u64) {
+pub extern "C" fn ze_serializer_serialize_uint64(
+    this_: &mut ze_loaned_serializer_t,
+    val: u64,
+) -> z_result_t {
     ze_serializer_serialize_arithmetic::<u64>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn ze_serializer_serialize_int8(this_: &mut ze_loaned_serializer_t, val: i8) {
+pub extern "C" fn ze_serializer_serialize_int8(
+    this_: &mut ze_loaned_serializer_t,
+    val: i8,
+) -> z_result_t {
     ze_serializer_serialize_arithmetic::<i8>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn ze_serializer_serialize_int16(this_: &mut ze_loaned_serializer_t, val: i16) {
+pub extern "C" fn ze_serializer_serialize_int16(
+    this_: &mut ze_loaned_serializer_t,
+    val: i16,
+) -> z_result_t {
     ze_serializer_serialize_arithmetic::<i16>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn ze_serializer_serialize_int32(this_: &mut ze_loaned_serializer_t, val: i32) {
+pub extern "C" fn ze_serializer_serialize_int32(
+    this_: &mut ze_loaned_serializer_t,
+    val: i32,
+) -> z_result_t {
     ze_serializer_serialize_arithmetic::<i32>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a signed integer.
 #[no_mangle]
-pub extern "C" fn ze_serializer_serialize_int64(this_: &mut ze_loaned_serializer_t, val: i64) {
+pub extern "C" fn ze_serializer_serialize_int64(
+    this_: &mut ze_loaned_serializer_t,
+    val: i64,
+) -> z_result_t {
     ze_serializer_serialize_arithmetic::<i64>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a float.
 #[no_mangle]
-pub extern "C" fn ze_serializer_serialize_float(this_: &mut ze_loaned_serializer_t, val: f32) {
+pub extern "C" fn ze_serializer_serialize_float(
+    this_: &mut ze_loaned_serializer_t,
+    val: f32,
+) -> z_result_t {
     ze_serializer_serialize_arithmetic::<f32>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a double.
 #[no_mangle]
-pub extern "C" fn ze_serializer_serialize_double(this_: &mut ze_loaned_serializer_t, val: f64) {
+pub extern "C" fn ze_serializer_serialize_double(
+    this_: &mut ze_loaned_serializer_t,
+    val: f64,
+) -> z_result_t {
     ze_serializer_serialize_arithmetic::<f64>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Serializes a bool.
 #[no_mangle]
-pub extern "C" fn ze_serializer_serialize_bool(this_: &mut ze_loaned_serializer_t, val: bool) {
+pub extern "C" fn ze_serializer_serialize_bool(
+    this_: &mut ze_loaned_serializer_t,
+    val: bool,
+) -> z_result_t {
     ze_serializer_serialize_arithmetic::<bool>(this_, &val);
+    result::Z_OK
 }
 
 /// @brief Deserializes into an unsigned integer.
@@ -584,9 +714,10 @@ pub extern "C" fn ze_deserializer_deserialize_bool(
 pub extern "C" fn ze_serializer_serialize_slice(
     this: &mut ze_loaned_serializer_t,
     slice: &z_loaned_slice_t,
-) {
+) -> z_result_t {
     let cslice = slice.as_rust_type_ref().slice();
     this.as_rust_type_mut().serialize(cslice);
+    result::Z_OK
 }
 
 /// @brief Serializes a data from buffer.
@@ -598,9 +729,10 @@ pub extern "C" fn ze_serializer_serialize_buf(
     this: &mut ze_loaned_serializer_t,
     data: *const u8,
     len: usize,
-) {
+) -> z_result_t {
     let slice = unsafe { from_raw_parts(data, len) };
     this.as_rust_type_mut().serialize(slice);
+    result::Z_OK
 }
 
 /// @brief Deserializes into a slice.
@@ -625,23 +757,56 @@ pub extern "C" fn ze_deserializer_deserialize_slice(
 }
 
 /// @brief Serializes a string.
+/// The string should be a valid UTF-8.
+/// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
 pub extern "C" fn ze_serializer_serialize_string(
     this: &mut ze_loaned_serializer_t,
     str: &z_loaned_string_t,
-) {
-    let cslice = str.as_rust_type_ref().slice();
-    this.as_rust_type_mut().serialize(cslice);
+) -> z_result_t {
+    match str::from_utf8(str.as_rust_type_ref().slice()) {
+        Ok(s) => {
+            this.as_rust_type_mut().serialize(s);
+            result::Z_OK
+        }
+        Err(e) => {
+            tracing::error!("{}", e);
+            result::Z_EUTF8
+        }
+    }
+}
+
+/// @brief Serializes a substring of specified length.
+/// The subsstring should be a valid UTF-8.
+/// @return 0 in case of success, negative error code otherwise.
+#[no_mangle]
+pub extern "C" fn ze_serializer_serialize_substr(
+    this: &mut ze_loaned_serializer_t,
+    start: *const libc::c_char,
+    len: usize,
+) -> z_result_t {
+    let slice = unsafe { from_raw_parts(start as *const u8, len) };
+    match str::from_utf8(slice) {
+        Ok(s) => {
+            this.as_rust_type_mut().serialize(s);
+            result::Z_OK
+        }
+        Err(e) => {
+            tracing::error!("{}", e);
+            result::Z_EUTF8
+        }
+    }
 }
 
 /// @brief Serializes a null-terminated string.
+/// The string should be a valid UTF-8.
+/// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
 pub extern "C" fn ze_serializer_serialize_str(
     this: &mut ze_loaned_serializer_t,
     str: *const libc::c_char,
-) {
-    let slice = unsafe { from_raw_parts(str as *const u8, strlen(str)) };
-    this.as_rust_type_mut().serialize(slice);
+) -> z_result_t {
+    ze_serializer_serialize_substr(this, str, unsafe { strlen(str) })
 }
 
 /// @brief Deserializes into a string.
@@ -670,8 +835,9 @@ pub extern "C" fn ze_deserializer_deserialize_string(
 pub extern "C" fn ze_serializer_serialize_sequence_length(
     this: &mut ze_loaned_serializer_t,
     len: usize,
-) {
+) -> z_result_t {
     this.as_rust_type_mut().serialize(VarInt::<usize>(len));
+    result::Z_OK
 }
 
 /// @brief Initiates deserialization of a sequence of multiple elements.

--- a/src/zbytes.rs
+++ b/src/zbytes.rs
@@ -685,7 +685,7 @@ unsafe extern "C" fn z_bytes_writer_write_all(
 /// This allows to compose a serialized data out of multiple `z_owned_bytes_t` that may point to different memory regions.
 /// Said in other terms, it allows to create a linear view on different memory regions without copy.
 ///
-/// @return 0 in case of success, negative error code otherwise
+/// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
 extern "C" fn z_bytes_writer_append(
     this: &mut z_loaned_bytes_writer_t,


### PR DESCRIPTION
impose utf-8 correctness check when serializing strings;
add serialization functions for substrings;
make all serialization functions fallible;