### PR TITLE
to_loaned_shm -> as_loaned_shm 

### DIFF
--- a/examples/z_queryable_shm.c
+++ b/examples/z_queryable_shm.c
@@ -32,7 +32,7 @@ void query_handler(z_loaned_query_t *query, void *context) {
     const z_loaned_bytes_t *payload = z_query_payload(query);
     if (payload != NULL && z_bytes_len(payload) > 0) {
         const z_loaned_shm_t *shm = NULL;
-        char *payload_type = z_bytes_to_loaned_shm(payload, &shm) == Z_OK ? "SHM" : "RAW";
+        char *payload_type = z_bytes_as_loaned_shm(payload, &shm) == Z_OK ? "SHM" : "RAW";
 
         z_owned_string_t payload_string;
         z_bytes_to_string(payload, &payload_string);

--- a/examples/z_sub_shm.c
+++ b/examples/z_sub_shm.c
@@ -37,7 +37,7 @@ void data_handler(z_loaned_sample_t *sample, void *arg) {
     char *payload_type = "RAW";
     {
         const z_loaned_shm_t *shm = NULL;
-        if (z_bytes_to_loaned_shm(z_sample_payload(sample), &shm) == Z_OK) {
+        if (z_bytes_as_loaned_shm(z_sample_payload(sample), &shm) == Z_OK) {
             payload_type = "SHM";
         }
     }

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1056,6 +1056,18 @@ z_result_t z_alloc_layout_threadsafe_alloc_gc_defrag_async(struct z_buf_alloc_re
                                                                                    struct z_buf_alloc_result_t*));
 #endif
 /**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Converts data into a loaned SHM buffer.
+ *
+ * @param this_: Data to convert.
+ * @param dst: An uninitialized memory location where to construct an SHM buffer.
+ */
+#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
+ZENOHC_API
+z_result_t z_bytes_as_loaned_shm(const struct z_loaned_bytes_t *this_,
+                                 const struct z_loaned_shm_t **dst);
+#endif
+/**
  * Constructs an owned shallow copy of data in provided uninitialized memory location.
  */
 ZENOHC_API void z_bytes_clone(struct z_owned_bytes_t *dst, const struct z_loaned_bytes_t *this_);
@@ -1246,18 +1258,6 @@ ZENOHC_API int64_t z_bytes_reader_tell(struct z_bytes_reader_t *this_);
 ZENOHC_API
 bool z_bytes_slice_iterator_next(struct z_bytes_slice_iterator_t *this_,
                                  struct z_view_slice_t *slice);
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Converts data into a loaned SHM buffer.
- *
- * @param this_: Data to convert.
- * @param dst: An uninitialized memory location where to construct an SHM buffer.
- */
-#if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
-ZENOHC_API
-z_result_t z_bytes_to_loaned_shm(const struct z_loaned_bytes_t *this_,
-                                 const struct z_loaned_shm_t **dst);
-#endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Converts data into a mutably loaned SHM buffer.

--- a/src/zbytes.rs
+++ b/src/zbytes.rs
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn z_bytes_to_owned_shm(
 /// @param dst: An uninitialized memory location where to construct an SHM buffer.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_bytes_to_loaned_shm(
+pub unsafe extern "C" fn z_bytes_as_loaned_shm(
     this: &'static z_loaned_bytes_t,
     dst: &'static mut MaybeUninit<&'static z_loaned_shm_t>,
 ) -> z_result_t {


### PR DESCRIPTION
rename `to_loaned_shm` -> `as_loaned_shm`  to prevent any possible misleading

[closes #809]