### PR TITLE
make z_bytes_to_slice and z_bytes_to_string avoid making copy for non-fragmented non-shm data

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1311,7 +1311,7 @@ z_result_t z_bytes_to_owned_shm(const struct z_loaned_bytes_t *this_,
                                 struct z_owned_shm_t *dst);
 #endif
 /**
- * Converts data into an owned slice.
+ * @brief Gets data as an owned slice.
  *
  * @param this_: Data to convert.
  * @param dst: An uninitialized memory location where to construct a slice.
@@ -1320,7 +1320,7 @@ ZENOHC_API
 z_result_t z_bytes_to_slice(const struct z_loaned_bytes_t *this_,
                             struct z_owned_slice_t *dst);
 /**
- * Converts data into an owned non-null-terminated string.
+ * Gets data as an owned non-null-terminated string.
  *
  * @param this_: Data to convert.
  * @param dst: An uninitialized memory location where to construct a string.

--- a/tests/z_api_payload_test.c
+++ b/tests/z_api_payload_test.c
@@ -158,10 +158,10 @@ void test_slice(void) {
 
     assert(cnt == 0);
     z_drop(z_move(payload));
-    assert(cnt == 1);
 
     assert(!memcmp(data, z_slice_data(z_loan(out)), 10));
     z_slice_drop(z_slice_move(&out));
+    assert(cnt == 1);
 
     z_owned_bytes_t payload2;
     z_owned_slice_t s;


### PR DESCRIPTION
make z_bytes_to_slice and z_bytes_to_string avoid making copy for non-fragmented non-sim data