### PR TITLE
refactor: remove unnecessary copy in examples

### DIFF
--- a/examples/z_bytes.c
+++ b/examples/z_bytes.c
@@ -200,9 +200,9 @@ int main(void) {
     {
         /// fill z_bytes with some data
         z_owned_bytes_t b1, b2, b3;
-        z_bytes_copy_from_str(&b1, "abc");
-        z_bytes_copy_from_str(&b2, "def");
-        z_bytes_copy_from_str(&b3, "hij");
+        z_bytes_from_str(&b1, "abc", NULL, NULL);
+        z_bytes_from_str(&b2, "def", NULL, NULL);
+        z_bytes_from_str(&b3, "hij", NULL, NULL);
         z_owned_bytes_writer_t writer;
         z_bytes_writer_empty(&writer);
         z_bytes_writer_append(z_loan_mut(writer), z_move(b1));

--- a/examples/z_bytes.c
+++ b/examples/z_bytes.c
@@ -200,9 +200,9 @@ int main(void) {
     {
         /// fill z_bytes with some data
         z_owned_bytes_t b1, b2, b3;
-        z_bytes_from_str(&b1, "abc", NULL, NULL);
-        z_bytes_from_str(&b2, "def", NULL, NULL);
-        z_bytes_from_str(&b3, "hij", NULL, NULL);
+        z_bytes_from_static_str(&b1, "abc");
+        z_bytes_from_static_str(&b2, "def");
+        z_bytes_from_static_str(&b3, "hij");
         z_owned_bytes_writer_t writer;
         z_bytes_writer_empty(&writer);
         z_bytes_writer_append(z_loan_mut(writer), z_move(b1));

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
         z_publisher_put_options_default(&options);
 
         z_owned_bytes_t payload;
-        z_bytes_copy_from_str(&payload, buf);
+        z_bytes_from_str(&payload, buf, NULL, NULL);
 
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
         z_publisher_put_options_default(&options);
 
         z_owned_bytes_t payload;
-        z_bytes_from_str(&payload, buf, NULL, NULL);
+        z_bytes_copy_from_str(&payload, buf);
 
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }


### PR DESCRIPTION
Users take the examples as a reference and learn how to construct a `z_owned_bytes` properly. After browsing the example codes, I propose removing unnecessary `copy` in some cases while retaining a few for scenario comparisons.