### PR TITLE
Add deprecation allowance for builder.rs

### DIFF
--- a/build-resources/opaque-types/src/lib.rs
+++ b/build-resources/opaque-types/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(unused_doc_comments)]
 #![allow(dead_code)]
+#![allow(deprecated)]
 use core::ffi::c_void;
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
 use std::sync::Arc;


### PR DESCRIPTION
technical library opaque-types for builder.rs should work with deprecated API