### PR TITLE
Add CI for checking markdown format.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,15 @@ jobs:
           cmake -DCMAKE_TOOLCHAIN_FILE="../ci/toolchains/TC-x86_64-pc-windows-gnu.cmake" -DZENOHC_BUILD_WITH_SHARED_MEMORY=ON -DZENOHC_BUILD_WITH_UNSTABLE_API=ON ..
           cmake --build . --target examples
 
+  markdown_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          config: '.markdownlint.yaml'
+          globs: '**/README.md'
+
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are
@@ -239,7 +248,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, cross-compile-mac-os, cross-compile-ubuntu, markdown_lint]
     if: always()
     steps:
       - name: Check whether all jobs pass

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+{
+  "MD013": false, # Line length limitation
+  "MD033": false, # Enable Inline HTML
+  "MD041": false, # Allow first line heading
+  "MD045": false, # Allow Images have no alternate text
+}

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ cmake ../zenoh-c/examples -DCMAKE_INSTALL_PREFIX=~/.local
 ```
 
 ## Documentation
+
 Zenoh-c API documentation is available on [Read the Docs](https://zenoh-c.readthedocs.io/en/latest/index.html).
 
 It can be built manually by performing the following steps:
@@ -186,6 +187,7 @@ sphinx-build -b html . _build/html
 ```
 
 ## Cross-Compilation
+
 Cross-compilation can be performed using standard cmake approach as described in [[cmake-toolchains](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html)].
 
 In addition the following project-specific options might need to be set for cross-compilation:
@@ -217,6 +219,7 @@ and release files will be located at
 `/path/to/zenoh-c/target/x86_64-pc-windows-gnu/release`
 
 > :warning: **WARNING** :warning: : Perhaps additional efforts are necessary, that will depend of your environment.
+
 ## Rust Version
 
 The Rust version we use is defined in [rust-toolchain.toml](rust-toolchain.toml), which is `1.75.0`.
@@ -233,6 +236,7 @@ cmake ../zenoh-c -DZENOHC_CARGO_CHANNEL="+1.75.0"
 It's necessary sometimes to build zenoh-c library with set of features different from default. For example: enable TCP and UDP only. This can be done by changing `ZENOHC_CARGO_FLAGS` parameter for cmake (notice ";" instead of space due to cmake peculiarities)
 
 Available features can be found in [Cargo.toml](./Cargo.toml)
+
 ```bash
 cmake ../zenoh-c -DZENOHC_CARGO_FLAGS="--no-default-features;--features=transport_tcp,transport_udp"
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 zenoh-c API documentation is available on [Read the Docs](https://zenoh-c.readthedocs.io/en/latest/index.html).
 
 -------------------------------
+
 ## How to build it
 
 ```bash


### PR DESCRIPTION
As https://github.com/eclipse-zenoh/zenoh/issues/1666, fix the README.md format and update CI.