### PR TITLE
add possibility to get contiguous view of z_bytes data when it is not fragmented

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -280,6 +280,7 @@ Types
 .. doxygenstruct:: z_bytes_reader_t
 .. doxygenstruct:: z_owned_bytes_writer_t
 .. doxygenstruct:: z_loaned_bytes_writer_t
+.. doxygenstruct:: z_bytes_slice_iterator_t
 
 Functions
 ^^^^^^^^^
@@ -302,6 +303,10 @@ Functions
 .. doxygenfunction:: z_bytes_loan
 .. doxygenfunction:: z_bytes_loan_mut
 .. doxygenfunction:: z_bytes_drop
+
+.. doxygenfunction:: z_bytes_get_slice_iterator
+.. doxygenfunction:: z_bytes_slice_iterator_next
+.. doxygenfunction:: z_bytes_get_contiguous_view
 
 .. doxygenfunction:: z_bytes_get_reader
 .. doxygenfunction:: z_bytes_reader_read

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1541,6 +1541,7 @@ z_result_t z_bytes_from_str(struct z_owned_bytes_t *this_,
  */
 ZENOHC_API void z_bytes_from_string(struct z_owned_bytes_t *this_, struct z_moved_string_t *s);
 /**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * Attempts to get a contiguous view to the underlying bytes.
  * This is only possible if data is not fragmented, otherwise the function will fail.
  * In case of fragmented data, consider using `z_bytes_get_slice_iterator()`.
@@ -1549,9 +1550,11 @@ ZENOHC_API void z_bytes_from_string(struct z_owned_bytes_t *this_, struct z_move
  * @param view: An uninitialized memory location where a contiguous view on data will be constructed.
  * @return  ​0​ upon success, negative error code otherwise.
  */
+#if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
 z_result_t z_bytes_get_contiguous_view(const struct z_loaned_bytes_t *this_,
                                        struct z_view_slice_t *view);
+#endif
 /**
  * Returns a reader for the data.
  *

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1541,6 +1541,18 @@ z_result_t z_bytes_from_str(struct z_owned_bytes_t *this_,
  */
 ZENOHC_API void z_bytes_from_string(struct z_owned_bytes_t *this_, struct z_moved_string_t *s);
 /**
+ * Attempts to get a contiguous view to the underlying bytes.
+ * This is only possible if data is not fragmented, otherwise the function will fail.
+ * In case of fragmented data, consider using `z_bytes_get_slice_iterator()`.
+ *
+ * @param this_: An instance of Zenoh data.
+ * @param view: An uninitialized memory location where a contiguous view on data will be constructed.
+ * @return  ​0​ upon success, negative error code otherwise.
+ */
+ZENOHC_API
+z_result_t z_bytes_get_contiguous_view(const struct z_loaned_bytes_t *this_,
+                                       struct z_view_slice_t *view);
+/**
  * Returns a reader for the data.
  *
  * The `data` should outlive the reader.

--- a/src/zbytes.rs
+++ b/src/zbytes.rs
@@ -479,6 +479,8 @@ pub extern "C" fn z_bytes_slice_iterator_next(
     }
 }
 
+#[cfg(feature = "unstable")]
+/// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// Attempts to get a contiguous view to the underlying bytes.
 /// This is only possible if data is not fragmented, otherwise the function will fail.
 /// In case of fragmented data, consider using `z_bytes_get_slice_iterator()`.

--- a/tests/z_api_payload_test.c
+++ b/tests/z_api_payload_test.c
@@ -234,10 +234,12 @@ void test_slices(void) {
     z_bytes_copy_from_buf(&payload, data, 10);
     assert(check_slice(z_loan(payload), data, 10));
 
+#if defined(Z_FEATURE_UNSTABLE_API)
     z_view_slice_t view;
     assert(z_bytes_get_contiguous_view(z_loan(payload), &view) == Z_OK);
     assert(z_slice_len(z_loan(view)) == 10);
     assert(memcmp(data, z_slice_data(z_loan(view)), 10) == 0);
+#endif
 
     z_drop(z_move(payload));
 
@@ -252,7 +254,9 @@ void test_slices(void) {
     }
     z_bytes_writer_finish(z_move(writer), &payload);
     assert(check_slice(z_loan(payload), data, 10));
+#if defined(Z_FEATURE_UNSTABLE_API)
     assert(z_bytes_get_contiguous_view(z_loan(payload), &view) != Z_OK);
+#endif
     z_drop(z_move(payload));
 }
 


### PR DESCRIPTION
add z_bytes_get_contiguous_view function;