### PR TITLE
Fix liveliness timeout type

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -646,7 +646,7 @@ typedef struct z_liveliness_get_options_t {
   /**
    * The timeout for the liveliness query in milliseconds. 0 means default query timeout from zenoh configuration.
    */
-  uint32_t timeout_ms;
+  uint64_t timeout_ms;
 } z_liveliness_get_options_t;
 typedef struct z_moved_liveliness_token_t {
   struct z_owned_liveliness_token_t _this;

--- a/src/liveliness.rs
+++ b/src/liveliness.rs
@@ -228,7 +228,7 @@ pub extern "C" fn zc_liveliness_declare_background_subscriber(
 #[repr(C)]
 pub struct z_liveliness_get_options_t {
     /// The timeout for the liveliness query in milliseconds. 0 means default query timeout from zenoh configuration.
-    timeout_ms: u32,
+    timeout_ms: u64,
 }
 
 /// @brief Constructs default value `z_liveliness_get_options_t`.
@@ -266,7 +266,7 @@ pub extern "C" fn z_liveliness_get(
         })
     });
     if let Some(options) = options {
-        builder = builder.timeout(core::time::Duration::from_millis(options.timeout_ms as u64));
+        builder = builder.timeout(core::time::Duration::from_millis(options.timeout_ms));
     }
     match builder.wait() {
         Ok(()) => result::Z_OK,


### PR DESCRIPTION
In zenoh rust we have u64 timeout and other timeouts in zenoh-c also exposed as u64

Related PRs:
https://github.com/eclipse-zenoh/zenoh-cpp/pull/354
https://github.com/eclipse-zenoh/zenoh-pico/pull/845