### PR TITLE
support for advanced pubs default recovery option without last sample miss detection

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -988,6 +988,8 @@ Types
     :members:
 .. doxygenstruct:: ze_advanced_subscriber_recovery_options_t
     :members:
+.. doxygenstruct:: ze_advanced_subscriber_last_sample_miss_detection_options_t
+    :members: 
 .. doxygenstruct:: ze_advanced_subscriber_options_t
     :members:
 
@@ -1007,6 +1009,7 @@ Functions
 
 .. doxygenfunction:: ze_advanced_subscriber_history_options_default
 .. doxygenfunction:: ze_advanced_subscriber_recovery_options_default
+.. doxygenfunction:: ze_advanced_subscriber_last_sample_miss_detection_options_default
 .. doxygenfunction:: ze_advanced_subscriber_options_default
 
 Publication Cache (deprecated)

--- a/examples/z_advanced_sub.c
+++ b/examples/z_advanced_sub.c
@@ -67,8 +67,10 @@ int main(int argc, char** argv) {
     ze_advanced_subscriber_history_options_default(&sub_opts.history);  // or sub_opts.history.is_enabled = true;
     sub_opts.history.detect_late_publishers = true;
     ze_advanced_subscriber_recovery_options_default(&sub_opts.recovery);  // or sub_opts.recovery.is_enabled = true;
+    ze_advanced_subscriber_last_sample_miss_detection_options_default(&sub_opts.recovery.last_sample_miss_detection);
+    // or sub_opts.recovery.last_sample_miss_detection.is_enabled = true;
     // use publisher heartbeats by default, otherwise enable periodic queries as follows:
-    // sub_opts.recovery.periodic_queries_period_ms = 1000;
+    // sub_opts.recovery.last_sample_miss_detection.periodic_queries_period_ms = 1000;
     sub_opts.subscriber_detection = true;
 
     z_owned_closure_sample_t callback;

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1058,13 +1058,13 @@ typedef struct ze_moved_advanced_publisher_t {
 #if defined(Z_FEATURE_UNSTABLE_API)
 typedef struct ze_advanced_publisher_sample_miss_detection_options_t {
   /**
-   * Must be set to ``true``, to enable sample miss_detection.
+   * Must be set to ``true``, to enable sample miss detection.
    */
   bool is_enabled;
   /**
    * If different from zero, the publisher will send heartbeats with the specified period, which
-   * can be used by Advanced Subscribers for missed sample detection (if recovery with zero query period is enabled).
-   * Otherwise, missed samples will be retransmitted based on Advanced Subscribers periodic queries.
+   * can be used by Advanced Subscribers for last sample(s) miss detection (if last sample miss detection with zero query period is enabled).
+   * Otherwise, missed samples will be retransmitted based on Advanced Subscriber queries.
    */
   uint64_t heartbeat_period_ms;
 } ze_advanced_publisher_sample_miss_detection_options_t;
@@ -1084,7 +1084,7 @@ typedef struct ze_advanced_publisher_options_t {
    */
   struct ze_advanced_publisher_cache_options_t cache;
   /**
-   * Settings allowing matching Subscribers to detect lost samples and optionally ask for retransimission.
+   * Settings to allow matching Subscribers to detect lost samples and optionally ask for retransimission.
    *
    * Retransmission can only be done if cache is enabled.
    */
@@ -1191,6 +1191,27 @@ typedef struct ze_advanced_subscriber_history_options_t {
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Settings for detection of the last sample(s) miss by Advanced Subscriber.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+typedef struct ze_advanced_subscriber_last_sample_miss_detection_options_t {
+  /**
+   * Must be set to ``true``, to enable the last sample(s) miss detection.
+   */
+  bool is_enabled;
+  /**
+   * Period for queries for not yet received Samples.
+   *
+   * These queries allow to retrieve the last Sample(s) if the last Sample(s) is/are lost.
+   * So it is useful for sporadic publications but useless for periodic publications
+   * with a period smaller or equal to this period. If set to 0, the last sample(s) miss detection will be performed
+   * based on publisher's heartbeat if the latter is enabled.
+   */
+  uint64_t periodic_queries_period_ms;
+} ze_advanced_subscriber_last_sample_miss_detection_options_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Settings for recovering lost messages for Advanced Subscriber.
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
@@ -1200,14 +1221,11 @@ typedef struct ze_advanced_subscriber_recovery_options_t {
    */
   bool is_enabled;
   /**
-   * Period for queries for not yet received Samples.
-   *
-   * These queries allow to retrieve the last Sample(s) if the last Sample(s) is/are lost.
-   * So it is useful for sporadic publications but useless for periodic publications
-   * with a period smaller or equal to this period. If set to 0, the missed samples will be retrieved
-   * based on publisher's heartbeat.
+   * Setting for detecting last sample(s) miss.
+   * Note that it does not affect intermediate sample miss detection/retrieval (which is performed automatically as long as recovery is enabled).
+   * If this option is disabled, subscriber will be unable to detect/request retransmission of missed sample until it receives a more recent one from the same publisher.
    */
-  uint64_t periodic_queries_period_ms;
+  struct ze_advanced_subscriber_last_sample_miss_detection_options_t last_sample_miss_detection;
 } ze_advanced_subscriber_recovery_options_t;
 #endif
 /**
@@ -5763,6 +5781,14 @@ struct z_entity_global_id_t ze_advanced_subscriber_id(const struct ze_loaned_adv
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
 const struct z_loaned_keyexpr_t *ze_advanced_subscriber_keyexpr(const struct ze_loaned_advanced_subscriber_t *subscriber);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Constructs the default value for `ze_advanced_subscriber_last_sample_miss_detection_options_t`.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+void ze_advanced_subscriber_last_sample_miss_detection_options_default(struct ze_advanced_subscriber_last_sample_miss_detection_options_t *this_);
 #endif
 /**
  * Borrows subscriber.

--- a/src/advanced_publisher.rs
+++ b/src/advanced_publisher.rs
@@ -87,11 +87,11 @@ impl From<&ze_advanced_publisher_cache_options_t> for CacheConfig {
 /// @brief Settings for sample miss detection on Advanced Publisher.
 #[repr(C)]
 pub struct ze_advanced_publisher_sample_miss_detection_options_t {
-    /// Must be set to ``true``, to enable sample miss_detection.
+    /// Must be set to ``true``, to enable sample miss detection.
     pub is_enabled: bool,
     /// If different from zero, the publisher will send heartbeats with the specified period, which
-    /// can be used by Advanced Subscribers for missed sample detection (if recovery with zero query period is enabled).
-    /// Otherwise, missed samples will be retransmitted based on Advanced Subscribers periodic queries.
+    /// can be used by Advanced Subscribers for last sample(s) miss detection (if last sample miss detection with zero query period is enabled).
+    /// Otherwise, missed samples will be retransmitted based on Advanced Subscriber queries.
     pub heartbeat_period_ms: u64,
 }
 
@@ -131,7 +131,7 @@ pub struct ze_advanced_publisher_options_t {
     pub publisher_options: z_publisher_options_t,
     /// Publisher cache settings.
     pub cache: ze_advanced_publisher_cache_options_t,
-    /// Settings allowing matching Subscribers to detect lost samples and optionally ask for retransimission.
+    /// Settings to allow matching Subscribers to detect lost samples and optionally ask for retransimission.
     ///
     /// Retransmission can only be done if cache is enabled.
     pub sample_miss_detection: ze_advanced_publisher_sample_miss_detection_options_t,

--- a/tests/z_int_advanced_pub_sub_test.c
+++ b/tests/z_int_advanced_pub_sub_test.c
@@ -54,7 +54,7 @@ int run_publisher() {
     ze_advanced_publisher_cache_options_default(&pub_opts.cache);
     pub_opts.cache.max_samples = values_count;
     pub_opts.publisher_detection = true;
-    pub_opts.sample_miss_detection.is_enabled = true;  // periodic queries are expected by default
+    pub_opts.sample_miss_detection.is_enabled = true;  // heartbeats are disabled by default
 
     if (ze_declare_advanced_publisher(z_loan(s), &pub, z_loan(ke), &pub_opts) < 0) {
         printf("Unable to declare AdvancedPublisher for key expression!\n");
@@ -143,7 +143,8 @@ int run_subscriber() {
     sub_opts.history.detect_late_publishers = true;
 
     ze_advanced_subscriber_recovery_options_default(&sub_opts.recovery);
-    sub_opts.recovery.periodic_queries_period_ms = 1000;
+    ze_advanced_subscriber_last_sample_miss_detection_options_default(&sub_opts.recovery.last_sample_miss_detection);
+    sub_opts.recovery.last_sample_miss_detection.periodic_queries_period_ms = 1000;
     sub_opts.subscriber_detection = true;
 
     z_owned_closure_sample_t callback;


### PR DESCRIPTION
support for default recovery option without last sample miss detection (i.e. without heartbeat nor periodic queries from subscriber's side)