### PR TITLE
Rename matching methods and types from `zc_*` to `z_*`

### DIFF
--- a/build-resources/opaque-types/src/lib.rs
+++ b/build-resources/opaque-types/src/lib.rs
@@ -272,7 +272,7 @@ get_opaque_type_data!(Publisher<'static>, z_loaned_publisher_t);
 ///
 /// A listener that sends notifications when the [`MatchingStatus`] of a publisher or querier changes.
 /// Dropping the corresponding publisher, also drops matching listener.
-get_opaque_type_data!(Option<MatchingListener<()>>, zc_owned_matching_listener_t);
+get_opaque_type_data!(Option<MatchingListener<()>>, z_owned_matching_listener_t);
 
 /// An owned Zenoh <a href="https://zenoh.io/docs/manual/abstractions/#subscriber"> subscriber </a>.
 ///

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -477,20 +477,20 @@ Matching
 
 Types
 -----
-.. doxygenstruct:: zc_owned_matching_listener_t
-.. doxygenstruct:: zc_owned_closure_matching_status_t
-.. doxygenstruct:: zc_matching_status_t
+.. doxygenstruct:: z_owned_matching_listener_t
+.. doxygenstruct:: z_owned_closure_matching_status_t
+.. doxygenstruct:: z_matching_status_t
     :members:
 
 Functions
 ---------
 
-.. doxygenfunction:: zc_matching_listener_drop
-.. doxygenfunction:: zc_undeclare_matching_listener
-.. doxygenfunction:: zc_closure_matching_status_drop
-.. doxygenfunction:: zc_closure_matching_status_loan
-.. doxygenfunction:: zc_closure_matching_status_call
-.. doxygenfunction:: zc_closure_matching_status
+.. doxygenfunction:: z_matching_listener_drop
+.. doxygenfunction:: z_undeclare_matching_listener
+.. doxygenfunction:: z_closure_matching_status_drop
+.. doxygenfunction:: z_closure_matching_status_loan
+.. doxygenfunction:: z_closure_matching_status_call
+.. doxygenfunction:: z_closure_matching_status
 
 
 Publication
@@ -540,9 +540,9 @@ Functions
 
 .. doxygenfunction:: z_reliability_default
 
-.. doxygenfunction:: zc_publisher_get_matching_status
-.. doxygenfunction:: zc_publisher_declare_matching_listener
-.. doxygenfunction:: zc_publisher_declare_background_matching_listener
+.. doxygenfunction:: z_publisher_get_matching_status
+.. doxygenfunction:: z_publisher_declare_matching_listener
+.. doxygenfunction:: z_publisher_declare_background_matching_listener
 
 Subscription
 ============
@@ -726,9 +726,9 @@ Functions
 .. doxygenfunction:: z_querier_id
 .. doxygenfunction:: z_querier_keyexpr
 .. doxygenfunction:: z_querier_get
-.. doxygenfunction:: zc_querier_get_matching_status
-.. doxygenfunction:: zc_querier_declare_matching_listener
-.. doxygenfunction:: zc_querier_declare_background_matching_listener
+.. doxygenfunction:: z_querier_get_matching_status
+.. doxygenfunction:: z_querier_declare_matching_listener
+.. doxygenfunction:: z_querier_declare_background_matching_listener
 
 .. doxygenfunction:: z_querier_options_default
 .. doxygenfunction:: z_querier_get_options_default

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -30,7 +30,7 @@ struct args_t {
 struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
 #if defined(Z_FEATURE_UNSTABLE_API)
-void matching_status_handler(const zc_matching_status_t* matching_status, void* arg) {
+void matching_status_handler(const z_matching_status_t* matching_status, void* arg) {
     if (matching_status->matching) {
         printf("Publisher has matching subscribers.\n");
     } else {
@@ -63,9 +63,9 @@ int main(int argc, char** argv) {
 
 #if defined(Z_FEATURE_UNSTABLE_API)
     if (args.add_matching_listener) {
-        zc_owned_closure_matching_status_t callback;
+        z_owned_closure_matching_status_t callback;
         z_closure(&callback, matching_status_handler, NULL, NULL);
-        zc_publisher_declare_background_matching_listener(z_loan(pub), z_move(callback));
+        z_publisher_declare_background_matching_listener(z_loan(pub), z_move(callback));
     }
 #endif
 

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -28,7 +28,7 @@ struct args_t {
 struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
 #if defined(Z_FEATURE_UNSTABLE_API)
-void matching_status_handler(const zc_matching_status_t* matching_status, void* arg) {
+void matching_status_handler(const z_matching_status_t* matching_status, void* arg) {
     if (matching_status->matching) {
         printf("Publisher has matching subscribers.\n");
     } else {
@@ -60,9 +60,9 @@ int main(int argc, char** argv) {
     }
 #if defined(Z_FEATURE_UNSTABLE_API)
     if (args.add_matching_listener) {
-        zc_owned_closure_matching_status_t callback;
+        z_owned_closure_matching_status_t callback;
         z_closure(&callback, matching_status_handler, NULL, NULL);
-        zc_publisher_declare_background_matching_listener(z_loan(pub), z_move(callback));
+        z_publisher_declare_background_matching_listener(z_loan(pub), z_move(callback));
     }
 #endif
 

--- a/examples/z_querier.c
+++ b/examples/z_querier.c
@@ -31,7 +31,7 @@ struct args_t {
 struct args_t parse_args(int argc, char** argv, z_owned_config_t* config);
 
 #if defined(Z_FEATURE_UNSTABLE_API)
-void matching_status_handler(const zc_matching_status_t* matching_status, void* arg) {
+void matching_status_handler(const z_matching_status_t* matching_status, void* arg) {
     if (matching_status->matching) {
         printf("Querier has matching queryables.\n");
     } else {
@@ -82,9 +82,9 @@ int main(int argc, char** argv) {
 
 #if defined(Z_FEATURE_UNSTABLE_API)
     if (args.add_matching_listener) {
-        zc_owned_closure_matching_status_t callback;
+        z_owned_closure_matching_status_t callback;
         z_closure(&callback, matching_status_handler, NULL, NULL);
-        zc_querier_declare_background_matching_listener(z_loan(querier), z_move(callback));
+        z_querier_declare_background_matching_listener(z_loan(querier), z_move(callback));
     }
 #endif
 

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -314,6 +314,40 @@ typedef struct z_moved_closure_hello_t {
   struct z_owned_closure_hello_t _this;
 } z_moved_closure_hello_t;
 /**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief A struct that indicates if there exist Subscribers matching the Publisher's key expression or Queryables matching Querier's key expression and target.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+typedef struct z_matching_status_t {
+  /**
+   * True if there exist matching Zenoh entities, false otherwise.
+   */
+  bool matching;
+} z_matching_status_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief A matching status-processing closure.
+ *
+ * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+typedef struct z_owned_closure_matching_status_t {
+  void *_context;
+  void (*_call)(const struct z_matching_status_t *matching_status, void *context);
+  void (*_drop)(void *context);
+} z_owned_closure_matching_status_t;
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Moved closure.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+typedef struct z_moved_closure_matching_status_t {
+  struct z_owned_closure_matching_status_t _this;
+} z_moved_closure_matching_status_t;
+#endif
+/**
  * @brief A query-processing closure.
  *
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
@@ -651,6 +685,9 @@ typedef struct z_liveliness_get_options_t {
 typedef struct z_moved_liveliness_token_t {
   struct z_owned_liveliness_token_t _this;
 } z_moved_liveliness_token_t;
+typedef struct z_moved_matching_listener_t {
+  struct z_owned_matching_listener_t _this;
+} z_moved_matching_listener_t;
 typedef struct z_moved_memory_layout_t {
   struct z_owned_memory_layout_t _this;
 } z_moved_memory_layout_t;
@@ -959,40 +996,6 @@ typedef struct zc_owned_closure_log_t {
 typedef struct zc_moved_closure_log_t {
   struct zc_owned_closure_log_t _this;
 } zc_moved_closure_log_t;
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief A struct that indicates if there exist Subscribers matching the Publisher's key expression or Queryables matching Querier's key expression and target.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-typedef struct zc_matching_status_t {
-  /**
-   * True if there exist matching Zenoh entities, false otherwise.
-   */
-  bool matching;
-} zc_matching_status_t;
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief A matching status-processing closure.
- *
- * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-typedef struct zc_owned_closure_matching_status_t {
-  void *_context;
-  void (*_call)(const struct zc_matching_status_t *matching_status, void *context);
-  void (*_drop)(void *context);
-} zc_owned_closure_matching_status_t;
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Moved closure.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-typedef struct zc_moved_closure_matching_status_t {
-  struct zc_owned_closure_matching_status_t _this;
-} zc_moved_closure_matching_status_t;
-#endif
 typedef struct zc_moved_concurrent_close_handle_t {
   struct zc_owned_concurrent_close_handle_t _this;
 } zc_moved_concurrent_close_handle_t;
@@ -1001,9 +1004,6 @@ typedef struct zc_internal_encoding_data_t {
   const uint8_t *schema_ptr;
   size_t schema_len;
 } zc_internal_encoding_data_t;
-typedef struct zc_moved_matching_listener_t {
-  struct zc_owned_matching_listener_t _this;
-} zc_moved_matching_listener_t;
 typedef struct zc_moved_shm_client_list_t {
   struct zc_owned_shm_client_list_t _this;
 } zc_moved_shm_client_list_t;
@@ -1863,6 +1863,54 @@ const struct z_loaned_closure_hello_t *z_closure_hello_loan(const struct z_owned
  */
 ZENOHC_API
 struct z_loaned_closure_hello_t *z_closure_hello_loan_mut(struct z_owned_closure_hello_t *closure);
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ *
+ * Closures are not guaranteed not to be called concurrently.
+ *
+ * It is guaranteed that:
+ *   - `call` will never be called once `drop` has started.
+ *   - `drop` will only be called **once**, and **after every** `call` has ended.
+ *   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+ * @brief Constructs closure.
+ * @param this_: uninitialized memory location where new closure will be constructed.
+ * @param call: a closure body.
+ * @param drop: an optional function to be called once on closure drop.
+ * @param context: closure context.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+void z_closure_matching_status(struct z_owned_closure_matching_status_t *this_,
+                               void (*call)(const struct z_matching_status_t *matching_status,
+                                            void *context),
+                               void (*drop)(void *context),
+                               void *context);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Calls the closure. Calling an uninitialized closure is a no-op.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+void z_closure_matching_status_call(const struct z_loaned_closure_matching_status_t *closure,
+                                    const struct z_matching_status_t *mathing_status);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Drops the closure, resetting it to its gravestone state. Droping an uninitialized closure is a no-op.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+void z_closure_matching_status_drop(struct z_moved_closure_matching_status_t *closure_);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Borrows closure.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+const struct z_loaned_closure_matching_status_t *z_closure_matching_status_loan(const struct z_owned_closure_matching_status_t *closure);
+#endif
 /**
  * @brief Constructs closure.
  *
@@ -2858,6 +2906,22 @@ ZENOHC_API bool z_internal_closure_hello_check(const struct z_owned_closure_hell
  */
 ZENOHC_API void z_internal_closure_hello_null(struct z_owned_closure_hello_t *this_);
 /**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+bool z_internal_closure_matching_status_check(const struct z_owned_closure_matching_status_t *this_);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Constructs a null value of 'z_owned_closure_matching_status_t' type
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+void z_internal_closure_matching_status_null(struct z_owned_closure_matching_status_t *this_);
+#endif
+/**
  * Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
  */
 ZENOHC_API bool z_internal_closure_query_check(const struct z_owned_closure_query_t *this_);
@@ -2964,6 +3028,22 @@ ZENOHC_API bool z_internal_liveliness_token_check(const struct z_owned_livelines
  * @brief Constructs liveliness token in its gravestone state.
  */
 ZENOHC_API void z_internal_liveliness_token_null(struct z_owned_liveliness_token_t *this_);
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Checks the matching listener is for the gravestone state
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+bool z_internal_matching_listener_check(const struct z_owned_matching_listener_t *this_);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Constructs an empty matching listener.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+void z_internal_matching_listener_null(struct z_owned_matching_listener_t *this_);
+#endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Returns ``true`` if `this` is valid.
@@ -3449,6 +3529,14 @@ ZENOHC_API void z_liveliness_token_options_default(struct z_liveliness_token_opt
 ZENOHC_API z_result_t z_liveliness_undeclare_token(struct z_moved_liveliness_token_t *this_);
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Undeclares the given matching listener, droping and invalidating it.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+void z_matching_listener_drop(struct z_moved_matching_listener_t *this_);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Deletes Memory Layout.
  */
 #if (defined(Z_FEATURE_SHARED_MEMORY) && defined(Z_FEATURE_UNSTABLE_API))
@@ -3559,6 +3647,37 @@ z_result_t z_posix_shm_provider_new(struct z_owned_shm_provider_t *this_,
  */
 ZENOHC_API enum z_priority_t z_priority_default(void);
 /**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Declares a matching listener, registering a callback for notifying subscribers matching with a given publisher.
+ * The callback will be run in the background until the corresponding publisher is dropped.
+ *
+ * @param publisher: A publisher to associate with matching listener.
+ * @param callback: A closure that will be called every time the matching status of the publisher changes (If last subscriber disconnects or when the first subscriber connects).
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+z_result_t z_publisher_declare_background_matching_listener(const struct z_loaned_publisher_t *publisher,
+                                                            struct z_moved_closure_matching_status_t *callback);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Constructs matching listener, registering a callback for notifying subscribers matching with a given publisher.
+ *
+ * @param publisher: A publisher to associate with matching listener.
+ * @param matching_listener: An uninitialized memory location where matching listener will be constructed. The matching listener's callback will be automatically dropped when the publisher is dropped.
+ * @param callback: A closure that will be called every time the matching status of the publisher changes (If last subscriber disconnects or when the first subscriber connects).
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+z_result_t z_publisher_declare_matching_listener(const struct z_loaned_publisher_t *publisher,
+                                                 struct z_owned_matching_listener_t *matching_listener,
+                                                 struct z_moved_closure_matching_status_t *callback);
+#endif
+/**
  * Sends a `DELETE` message onto the publisher's key expression.
  *
  * @return 0 in case of success, negative error code in case of failure.
@@ -3575,6 +3694,17 @@ ZENOHC_API void z_publisher_delete_options_default(struct z_publisher_delete_opt
  * This is equivalent to calling `z_undeclare_publisher()` and discarding its return value.
  */
 ZENOHC_API void z_publisher_drop(struct z_moved_publisher_t *this_);
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Gets publisher matching status - i.e. if there are any subscribers matching its key expression.
+ *
+ * @return 0 in case of success, negative error code otherwise (in this case matching_status is not updated).
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+z_result_t z_publisher_get_matching_status(const struct z_loaned_publisher_t *this_,
+                                           struct z_matching_status_t *matching_status);
+#endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Returns the ID of the publisher.
@@ -3642,6 +3772,37 @@ z_result_t z_put(const struct z_loaned_session_t *session,
 ZENOHC_API void z_put_options_default(struct z_put_options_t *this_);
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Declares a matching listener, registering a callback for notifying queryables matching the given querier key expression and target.
+ * The callback will be run in the background until the corresponding querier is dropped.
+ *
+ * @param querier: A querier to associate with matching listener.
+ * @param callback: A closure that will be called every time the matching status of the querier changes (If last queryable disconnects or when the first queryable connects).
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+#if (defined(Z_FEATURE_UNSTABLE_API) && defined(Z_FEATURE_UNSTABLE_API))
+ZENOHC_API
+z_result_t z_querier_declare_background_matching_listener(const struct z_loaned_querier_t *querier,
+                                                          struct z_moved_closure_matching_status_t *callback);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Constructs matching listener, registering a callback for notifying queryables matching with a given querier's key expression and target.
+ *
+ * @param querier: A querier to associate with matching listener.
+ * @param matching_listener: An uninitialized memory location where matching listener will be constructed. The matching listener's callback will be automatically dropped when the querier is dropped.
+ * @param callback: A closure that will be called every time the matching status of the querier changes (If last queryable disconnects or when the first queryable connects).
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+#if (defined(Z_FEATURE_UNSTABLE_API) && defined(Z_FEATURE_UNSTABLE_API))
+ZENOHC_API
+z_result_t z_querier_declare_matching_listener(const struct z_loaned_querier_t *querier,
+                                               struct z_owned_matching_listener_t *matching_listener,
+                                               struct z_moved_closure_matching_status_t *callback);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Frees memory and resets querier to its gravestone state.
  * This is equivalent to calling `z_undeclare_querier()` and discarding its return value.
  */
@@ -3667,6 +3828,17 @@ z_result_t z_querier_get(const struct z_loaned_querier_t *querier,
                          const char *parameters,
                          struct z_moved_closure_reply_t *callback,
                          struct z_querier_get_options_t *options);
+#endif
+/**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Gets querier matching status - i.e. if there are any queryables matching its key expression and target.
+ *
+ * @return 0 in case of success, negative error code otherwise (in this case matching_status is not updated).
+ */
+#if (defined(Z_FEATURE_UNSTABLE_API) && defined(Z_FEATURE_UNSTABLE_API))
+ZENOHC_API
+z_result_t z_querier_get_matching_status(const struct z_loaned_querier_t *this_,
+                                         struct z_matching_status_t *matching_status);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -4903,6 +5075,15 @@ ZENOHC_API
 z_result_t z_undeclare_keyexpr(const struct z_loaned_session_t *session,
                                struct z_moved_keyexpr_t *key_expr);
 /**
+ * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ * @brief Undeclares the given matching listener, droping and invalidating it.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+#if defined(Z_FEATURE_UNSTABLE_API)
+ZENOHC_API
+z_result_t z_undeclare_matching_listener(struct z_moved_matching_listener_t *this_);
+#endif
+/**
  * @brief Undeclares the given publisher.
  *
  * @return 0 in case of success, negative error code otherwise.
@@ -5134,54 +5315,6 @@ ZENOHC_API void zc_closure_log_drop(struct zc_moved_closure_log_t *closure_);
 ZENOHC_API
 const struct zc_loaned_closure_log_t *zc_closure_log_loan(const struct zc_owned_closure_log_t *closure);
 /**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- *
- * Closures are not guaranteed not to be called concurrently.
- *
- * It is guaranteed that:
- *   - `call` will never be called once `drop` has started.
- *   - `drop` will only be called **once**, and **after every** `call` has ended.
- *   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
- * @brief Constructs closure.
- * @param this_: uninitialized memory location where new closure will be constructed.
- * @param call: a closure body.
- * @param drop: an optional function to be called once on closure drop.
- * @param context: closure context.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-void zc_closure_matching_status(struct zc_owned_closure_matching_status_t *this_,
-                                void (*call)(const struct zc_matching_status_t *matching_status,
-                                             void *context),
-                                void (*drop)(void *context),
-                                void *context);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Calls the closure. Calling an uninitialized closure is a no-op.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-void zc_closure_matching_status_call(const struct zc_loaned_closure_matching_status_t *closure,
-                                     const struct zc_matching_status_t *mathing_status);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Drops the closure, resetting it to its gravestone state. Droping an uninitialized closure is a no-op.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-void zc_closure_matching_status_drop(struct zc_moved_closure_matching_status_t *closure_);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Borrows closure.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-const struct zc_loaned_closure_matching_status_t *zc_closure_matching_status_loan(const struct zc_owned_closure_matching_status_t *closure);
-#endif
-/**
  * @brief Drops the close handle. The concurrent close task will not be interrupted.
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
@@ -5289,22 +5422,6 @@ ZENOHC_API bool zc_internal_closure_log_check(const struct zc_owned_closure_log_
  */
 ZENOHC_API void zc_internal_closure_log_null(struct zc_owned_closure_log_t *this_);
 /**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-bool zc_internal_closure_matching_status_check(const struct zc_owned_closure_matching_status_t *this_);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Constructs a null value of 'zc_owned_closure_matching_status_t' type
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-void zc_internal_closure_matching_status_null(struct zc_owned_closure_matching_status_t *this_);
-#endif
-/**
  * @brief Returns ``true`` if concurrent close handle is valid, ``false`` if it is in gravestone state.
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
@@ -5323,22 +5440,6 @@ void zc_internal_encoding_from_data(struct z_owned_encoding_t *this_,
                                     struct zc_internal_encoding_data_t data);
 ZENOHC_API
 struct zc_internal_encoding_data_t zc_internal_encoding_get_data(const struct z_loaned_encoding_t *this_);
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Checks the matching listener is for the gravestone state
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-bool zc_internal_matching_listener_check(const struct zc_owned_matching_listener_t *this_);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Constructs an empty matching listener.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-void zc_internal_matching_listener_null(struct zc_owned_matching_listener_t *this_);
-#endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Returns ``true`` if `this` is valid.
@@ -5362,98 +5463,6 @@ void zc_internal_shm_client_list_null(struct zc_owned_shm_client_list_t *this_);
 #if defined(Z_FEATURE_UNSTABLE_API)
 ZENOHC_API
 enum zc_locality_t zc_locality_default(void);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Undeclares the given matching listener, droping and invalidating it.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-void zc_matching_listener_drop(struct zc_moved_matching_listener_t *this_);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Declares a matching listener, registering a callback for notifying subscribers matching with a given publisher.
- * The callback will be run in the background until the corresponding publisher is dropped.
- *
- * @param publisher: A publisher to associate with matching listener.
- * @param callback: A closure that will be called every time the matching status of the publisher changes (If last subscriber disconnects or when the first subscriber connects).
- *
- * @return 0 in case of success, negative error code otherwise.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-z_result_t zc_publisher_declare_background_matching_listener(const struct z_loaned_publisher_t *publisher,
-                                                             struct zc_moved_closure_matching_status_t *callback);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Constructs matching listener, registering a callback for notifying subscribers matching with a given publisher.
- *
- * @param publisher: A publisher to associate with matching listener.
- * @param matching_listener: An uninitialized memory location where matching listener will be constructed. The matching listener's callback will be automatically dropped when the publisher is dropped.
- * @param callback: A closure that will be called every time the matching status of the publisher changes (If last subscriber disconnects or when the first subscriber connects).
- *
- * @return 0 in case of success, negative error code otherwise.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-z_result_t zc_publisher_declare_matching_listener(const struct z_loaned_publisher_t *publisher,
-                                                  struct zc_owned_matching_listener_t *matching_listener,
-                                                  struct zc_moved_closure_matching_status_t *callback);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Gets publisher matching status - i.e. if there are any subscribers matching its key expression.
- *
- * @return 0 in case of success, negative error code otherwise (in this case matching_status is not updated).
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-z_result_t zc_publisher_get_matching_status(const struct z_loaned_publisher_t *this_,
-                                            struct zc_matching_status_t *matching_status);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Declares a matching listener, registering a callback for notifying queryables matching the given querier key expression and target.
- * The callback will be run in the background until the corresponding querier is dropped.
- *
- * @param querier: A querier to associate with matching listener.
- * @param callback: A closure that will be called every time the matching status of the querier changes (If last queryable disconnects or when the first queryable connects).
- *
- * @return 0 in case of success, negative error code otherwise.
- */
-#if (defined(Z_FEATURE_UNSTABLE_API) && defined(Z_FEATURE_UNSTABLE_API))
-ZENOHC_API
-z_result_t zc_querier_declare_background_matching_listener(const struct z_loaned_querier_t *querier,
-                                                           struct zc_moved_closure_matching_status_t *callback);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Constructs matching listener, registering a callback for notifying queryables matching with a given querier's key expression and target.
- *
- * @param querier: A querier to associate with matching listener.
- * @param matching_listener: An uninitialized memory location where matching listener will be constructed. The matching listener's callback will be automatically dropped when the querier is dropped.
- * @param callback: A closure that will be called every time the matching status of the querier changes (If last queryable disconnects or when the first queryable connects).
- *
- * @return 0 in case of success, negative error code otherwise.
- */
-#if (defined(Z_FEATURE_UNSTABLE_API) && defined(Z_FEATURE_UNSTABLE_API))
-ZENOHC_API
-z_result_t zc_querier_declare_matching_listener(const struct z_loaned_querier_t *querier,
-                                                struct zc_owned_matching_listener_t *matching_listener,
-                                                struct zc_moved_closure_matching_status_t *callback);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Gets querier matching status - i.e. if there are any queryables matching its key expression and target.
- *
- * @return 0 in case of success, negative error code otherwise (in this case matching_status is not updated).
- */
-#if (defined(Z_FEATURE_UNSTABLE_API) && defined(Z_FEATURE_UNSTABLE_API))
-ZENOHC_API
-z_result_t zc_querier_get_matching_status(const struct z_loaned_querier_t *this_,
-                                          struct zc_matching_status_t *matching_status);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5524,15 +5533,6 @@ ZENOHC_API
 void zc_try_init_log_from_env(void);
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
- * @brief Undeclares the given matching listener, droping and invalidating it.
- * @return 0 in case of success, negative error code otherwise.
- */
-#if defined(Z_FEATURE_UNSTABLE_API)
-ZENOHC_API
-z_result_t zc_undeclare_matching_listener(struct zc_moved_matching_listener_t *this_);
-#endif
-/**
- * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Constructs the default value for `ze_advanced_publisher_cache_options_t`.
  */
 #if defined(Z_FEATURE_UNSTABLE_API)
@@ -5552,7 +5552,7 @@ void ze_advanced_publisher_cache_options_default(struct ze_advanced_publisher_ca
 #if (defined(Z_FEATURE_UNSTABLE_API) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 z_result_t ze_advanced_publisher_declare_background_matching_listener(const struct ze_loaned_advanced_publisher_t *publisher,
-                                                                      struct zc_moved_closure_matching_status_t *callback);
+                                                                      struct z_moved_closure_matching_status_t *callback);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5567,8 +5567,8 @@ z_result_t ze_advanced_publisher_declare_background_matching_listener(const stru
 #if (defined(Z_FEATURE_UNSTABLE_API) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 z_result_t ze_advanced_publisher_declare_matching_listener(const struct ze_loaned_advanced_publisher_t *publisher,
-                                                           struct zc_owned_matching_listener_t *matching_listener,
-                                                           struct zc_moved_closure_matching_status_t *callback);
+                                                           struct z_owned_matching_listener_t *matching_listener,
+                                                           struct z_moved_closure_matching_status_t *callback);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -5607,7 +5607,7 @@ void ze_advanced_publisher_drop(struct ze_moved_advanced_publisher_t *this_);
 #if (defined(Z_FEATURE_UNSTABLE_API) && defined(Z_FEATURE_UNSTABLE_API))
 ZENOHC_API
 z_result_t ze_advanced_publisher_get_matching_status(const struct ze_loaned_advanced_publisher_t *this_,
-                                                     struct zc_matching_status_t *matching_status);
+                                                     struct z_matching_status_t *matching_status);
 #endif
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.

--- a/include/zenoh_macros.h
+++ b/include/zenoh_macros.h
@@ -9,6 +9,7 @@ static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return (z_move
 static inline z_moved_bytes_writer_t* z_bytes_writer_move(z_owned_bytes_writer_t* x) { return (z_moved_bytes_writer_t*)(x); }
 static inline z_moved_chunk_alloc_result_t* z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return (z_moved_chunk_alloc_result_t*)(x); }
 static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return (z_moved_closure_hello_t*)(x); }
+static inline z_moved_closure_matching_status_t* z_closure_matching_status_move(z_owned_closure_matching_status_t* x) { return (z_moved_closure_matching_status_t*)(x); }
 static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return (z_moved_closure_query_t*)(x); }
 static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return (z_moved_closure_reply_t*)(x); }
 static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return (z_moved_closure_sample_t*)(x); }
@@ -22,6 +23,7 @@ static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_
 static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return (z_moved_hello_t*)(x); }
 static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return (z_moved_keyexpr_t*)(x); }
 static inline z_moved_liveliness_token_t* z_liveliness_token_move(z_owned_liveliness_token_t* x) { return (z_moved_liveliness_token_t*)(x); }
+static inline z_moved_matching_listener_t* z_matching_listener_move(z_owned_matching_listener_t* x) { return (z_moved_matching_listener_t*)(x); }
 static inline z_moved_memory_layout_t* z_memory_layout_move(z_owned_memory_layout_t* x) { return (z_moved_memory_layout_t*)(x); }
 static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return (z_moved_mutex_t*)(x); }
 static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return (z_moved_publisher_t*)(x); }
@@ -47,9 +49,7 @@ static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return (z_m
 static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return (z_moved_subscriber_t*)(x); }
 static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return (z_moved_task_t*)(x); }
 static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return (zc_moved_closure_log_t*)(x); }
-static inline zc_moved_closure_matching_status_t* zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return (zc_moved_closure_matching_status_t*)(x); }
 static inline zc_moved_concurrent_close_handle_t* zc_concurrent_close_handle_move(zc_owned_concurrent_close_handle_t* x) { return (zc_moved_concurrent_close_handle_t*)(x); }
-static inline zc_moved_matching_listener_t* zc_matching_listener_move(zc_owned_matching_listener_t* x) { return (zc_moved_matching_listener_t*)(x); }
 static inline zc_moved_shm_client_list_t* zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return (zc_moved_shm_client_list_t*)(x); }
 static inline ze_moved_advanced_publisher_t* ze_advanced_publisher_move(ze_owned_advanced_publisher_t* x) { return (ze_moved_advanced_publisher_t*)(x); }
 static inline ze_moved_advanced_subscriber_t* ze_advanced_subscriber_move(ze_owned_advanced_subscriber_t* x) { return (ze_moved_advanced_subscriber_t*)(x); }
@@ -66,6 +66,7 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_bytes_t : z_bytes_loan, \
         z_owned_bytes_writer_t : z_bytes_writer_loan, \
         z_owned_closure_hello_t : z_closure_hello_loan, \
+        z_owned_closure_matching_status_t : z_closure_matching_status_loan, \
         z_owned_closure_query_t : z_closure_query_loan, \
         z_owned_closure_reply_t : z_closure_reply_loan, \
         z_owned_closure_sample_t : z_closure_sample_loan, \
@@ -104,7 +105,6 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_view_slice_t : z_view_slice_loan, \
         z_view_string_t : z_view_string_loan, \
         zc_owned_closure_log_t : zc_closure_log_loan, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_loan, \
         zc_owned_shm_client_list_t : zc_shm_client_list_loan, \
         ze_owned_advanced_publisher_t : ze_advanced_publisher_loan, \
         ze_owned_advanced_subscriber_t : ze_advanced_subscriber_loan, \
@@ -148,6 +148,7 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_moved_bytes_writer_t* : z_bytes_writer_drop, \
         z_moved_chunk_alloc_result_t* : z_chunk_alloc_result_drop, \
         z_moved_closure_hello_t* : z_closure_hello_drop, \
+        z_moved_closure_matching_status_t* : z_closure_matching_status_drop, \
         z_moved_closure_query_t* : z_closure_query_drop, \
         z_moved_closure_reply_t* : z_closure_reply_drop, \
         z_moved_closure_sample_t* : z_closure_sample_drop, \
@@ -161,6 +162,7 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_moved_hello_t* : z_hello_drop, \
         z_moved_keyexpr_t* : z_keyexpr_drop, \
         z_moved_liveliness_token_t* : z_liveliness_token_drop, \
+        z_moved_matching_listener_t* : z_matching_listener_drop, \
         z_moved_memory_layout_t* : z_memory_layout_drop, \
         z_moved_mutex_t* : z_mutex_drop, \
         z_moved_publisher_t* : z_publisher_drop, \
@@ -186,9 +188,7 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_moved_subscriber_t* : z_subscriber_drop, \
         z_moved_task_t* : z_task_drop, \
         zc_moved_closure_log_t* : zc_closure_log_drop, \
-        zc_moved_closure_matching_status_t* : zc_closure_matching_status_drop, \
         zc_moved_concurrent_close_handle_t* : zc_concurrent_close_handle_drop, \
-        zc_moved_matching_listener_t* : zc_matching_listener_drop, \
         zc_moved_shm_client_list_t* : zc_shm_client_list_drop, \
         ze_moved_advanced_publisher_t* : ze_advanced_publisher_drop, \
         ze_moved_advanced_subscriber_t* : ze_advanced_subscriber_drop, \
@@ -206,6 +206,7 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_bytes_writer_t : z_bytes_writer_move, \
         z_owned_chunk_alloc_result_t : z_chunk_alloc_result_move, \
         z_owned_closure_hello_t : z_closure_hello_move, \
+        z_owned_closure_matching_status_t : z_closure_matching_status_move, \
         z_owned_closure_query_t : z_closure_query_move, \
         z_owned_closure_reply_t : z_closure_reply_move, \
         z_owned_closure_sample_t : z_closure_sample_move, \
@@ -219,6 +220,7 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_hello_t : z_hello_move, \
         z_owned_keyexpr_t : z_keyexpr_move, \
         z_owned_liveliness_token_t : z_liveliness_token_move, \
+        z_owned_matching_listener_t : z_matching_listener_move, \
         z_owned_memory_layout_t : z_memory_layout_move, \
         z_owned_mutex_t : z_mutex_move, \
         z_owned_publisher_t : z_publisher_move, \
@@ -244,9 +246,7 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_subscriber_t : z_subscriber_move, \
         z_owned_task_t : z_task_move, \
         zc_owned_closure_log_t : zc_closure_log_move, \
-        zc_owned_closure_matching_status_t : zc_closure_matching_status_move, \
         zc_owned_concurrent_close_handle_t : zc_concurrent_close_handle_move, \
-        zc_owned_matching_listener_t : zc_matching_listener_move, \
         zc_owned_shm_client_list_t : zc_shm_client_list_move, \
         ze_owned_advanced_publisher_t : ze_advanced_publisher_move, \
         ze_owned_advanced_subscriber_t : ze_advanced_subscriber_move, \
@@ -264,6 +264,7 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_bytes_writer_t* : z_internal_bytes_writer_null, \
         z_owned_chunk_alloc_result_t* : z_internal_chunk_alloc_result_null, \
         z_owned_closure_hello_t* : z_internal_closure_hello_null, \
+        z_owned_closure_matching_status_t* : z_internal_closure_matching_status_null, \
         z_owned_closure_query_t* : z_internal_closure_query_null, \
         z_owned_closure_reply_t* : z_internal_closure_reply_null, \
         z_owned_closure_sample_t* : z_internal_closure_sample_null, \
@@ -277,6 +278,7 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_hello_t* : z_internal_hello_null, \
         z_owned_keyexpr_t* : z_internal_keyexpr_null, \
         z_owned_liveliness_token_t* : z_internal_liveliness_token_null, \
+        z_owned_matching_listener_t* : z_internal_matching_listener_null, \
         z_owned_memory_layout_t* : z_internal_memory_layout_null, \
         z_owned_mutex_t* : z_internal_mutex_null, \
         z_owned_publisher_t* : z_internal_publisher_null, \
@@ -302,9 +304,7 @@ static inline ze_moved_serializer_t* ze_serializer_move(ze_owned_serializer_t* x
         z_owned_subscriber_t* : z_internal_subscriber_null, \
         z_owned_task_t* : z_internal_task_null, \
         zc_owned_closure_log_t* : zc_internal_closure_log_null, \
-        zc_owned_closure_matching_status_t* : zc_internal_closure_matching_status_null, \
         zc_owned_concurrent_close_handle_t* : zc_internal_concurrent_close_handle_null, \
-        zc_owned_matching_listener_t* : zc_internal_matching_listener_null, \
         zc_owned_shm_client_list_t* : zc_internal_shm_client_list_null, \
         ze_owned_advanced_publisher_t* : ze_internal_advanced_publisher_null, \
         ze_owned_advanced_subscriber_t* : ze_internal_advanced_subscriber_null, \
@@ -320,6 +320,7 @@ static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *t
 static inline void z_bytes_writer_take(z_owned_bytes_writer_t* this_, z_moved_bytes_writer_t* x) { *this_ = x->_this; z_internal_bytes_writer_null(&x->_this); }
 static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) { *this_ = x->_this; z_internal_chunk_alloc_result_null(&x->_this); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_internal_closure_hello_null(&x->_this); }
+static inline void z_closure_matching_status_take(z_owned_closure_matching_status_t* closure_, z_moved_closure_matching_status_t* x) { *closure_ = x->_this; z_internal_closure_matching_status_null(&x->_this); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_internal_closure_query_null(&x->_this); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_internal_closure_reply_null(&x->_this); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_internal_closure_sample_null(&x->_this); }
@@ -333,6 +334,7 @@ static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* thi
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_internal_hello_null(&x->_this); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_internal_keyexpr_null(&x->_this); }
 static inline void z_liveliness_token_take(z_owned_liveliness_token_t* this_, z_moved_liveliness_token_t* x) { *this_ = x->_this; z_internal_liveliness_token_null(&x->_this); }
+static inline void z_matching_listener_take(z_owned_matching_listener_t* this_, z_moved_matching_listener_t* x) { *this_ = x->_this; z_internal_matching_listener_null(&x->_this); }
 static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) { *this_ = x->_this; z_internal_memory_layout_null(&x->_this); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_internal_mutex_null(&x->_this); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_internal_publisher_null(&x->_this); }
@@ -358,9 +360,7 @@ static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) {
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_internal_subscriber_null(&x->_this); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_internal_task_null(&x->_this); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_internal_closure_log_null(&x->_this); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) { *closure_ = x->_this; zc_internal_closure_matching_status_null(&x->_this); }
 static inline void zc_concurrent_close_handle_take(zc_owned_concurrent_close_handle_t* this_, zc_moved_concurrent_close_handle_t* x) { *this_ = x->_this; zc_internal_concurrent_close_handle_null(&x->_this); }
-static inline void zc_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) { *this_ = x->_this; zc_internal_matching_listener_null(&x->_this); }
 static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) { *this_ = x->_this; zc_internal_shm_client_list_null(&x->_this); }
 static inline void ze_advanced_publisher_take(ze_owned_advanced_publisher_t* this_, ze_moved_advanced_publisher_t* x) { *this_ = x->_this; ze_internal_advanced_publisher_null(&x->_this); }
 static inline void ze_advanced_subscriber_take(ze_owned_advanced_subscriber_t* this_, ze_moved_advanced_subscriber_t* x) { *this_ = x->_this; ze_internal_advanced_subscriber_null(&x->_this); }
@@ -378,6 +378,7 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_bytes_writer_t* : z_bytes_writer_take, \
         z_owned_chunk_alloc_result_t* : z_chunk_alloc_result_take, \
         z_owned_closure_hello_t* : z_closure_hello_take, \
+        z_owned_closure_matching_status_t* : z_closure_matching_status_take, \
         z_owned_closure_query_t* : z_closure_query_take, \
         z_owned_closure_reply_t* : z_closure_reply_take, \
         z_owned_closure_sample_t* : z_closure_sample_take, \
@@ -391,6 +392,7 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_hello_t* : z_hello_take, \
         z_owned_keyexpr_t* : z_keyexpr_take, \
         z_owned_liveliness_token_t* : z_liveliness_token_take, \
+        z_owned_matching_listener_t* : z_matching_listener_take, \
         z_owned_memory_layout_t* : z_memory_layout_take, \
         z_owned_mutex_t* : z_mutex_take, \
         z_owned_publisher_t* : z_publisher_take, \
@@ -416,9 +418,7 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_subscriber_t* : z_subscriber_take, \
         z_owned_task_t* : z_task_take, \
         zc_owned_closure_log_t* : zc_closure_log_take, \
-        zc_owned_closure_matching_status_t* : zc_closure_matching_status_take, \
         zc_owned_concurrent_close_handle_t* : zc_concurrent_close_handle_take, \
-        zc_owned_matching_listener_t* : zc_matching_listener_take, \
         zc_owned_shm_client_list_t* : zc_shm_client_list_take, \
         ze_owned_advanced_publisher_t* : ze_advanced_publisher_take, \
         ze_owned_advanced_subscriber_t* : ze_advanced_subscriber_take, \
@@ -436,6 +436,7 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_bytes_writer_t : z_internal_bytes_writer_check, \
         z_owned_chunk_alloc_result_t : z_internal_chunk_alloc_result_check, \
         z_owned_closure_hello_t : z_internal_closure_hello_check, \
+        z_owned_closure_matching_status_t : z_internal_closure_matching_status_check, \
         z_owned_closure_query_t : z_internal_closure_query_check, \
         z_owned_closure_reply_t : z_internal_closure_reply_check, \
         z_owned_closure_sample_t : z_internal_closure_sample_check, \
@@ -449,6 +450,7 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_hello_t : z_internal_hello_check, \
         z_owned_keyexpr_t : z_internal_keyexpr_check, \
         z_owned_liveliness_token_t : z_internal_liveliness_token_check, \
+        z_owned_matching_listener_t : z_internal_matching_listener_check, \
         z_owned_memory_layout_t : z_internal_memory_layout_check, \
         z_owned_mutex_t : z_internal_mutex_check, \
         z_owned_publisher_t : z_internal_publisher_check, \
@@ -474,9 +476,7 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
         z_owned_subscriber_t : z_internal_subscriber_check, \
         z_owned_task_t : z_internal_task_check, \
         zc_owned_closure_log_t : zc_internal_closure_log_check, \
-        zc_owned_closure_matching_status_t : zc_internal_closure_matching_status_check, \
         zc_owned_concurrent_close_handle_t : zc_internal_concurrent_close_handle_check, \
-        zc_owned_matching_listener_t : zc_internal_matching_listener_check, \
         zc_owned_shm_client_list_t : zc_internal_shm_client_list_check, \
         ze_owned_advanced_publisher_t : ze_internal_advanced_publisher_check, \
         ze_owned_advanced_subscriber_t : ze_internal_advanced_subscriber_check, \
@@ -490,33 +490,33 @@ static inline void ze_serializer_take(ze_owned_serializer_t* this_, ze_moved_ser
 #define z_call(closure, hello) \
     _Generic((closure), \
         const z_loaned_closure_hello_t* : z_closure_hello_call, \
+        const z_loaned_closure_matching_status_t* : z_closure_matching_status_call, \
         const z_loaned_closure_query_t* : z_closure_query_call, \
         const z_loaned_closure_reply_t* : z_closure_reply_call, \
         const z_loaned_closure_sample_t* : z_closure_sample_call, \
         const z_loaned_closure_zid_t* : z_closure_zid_call, \
-        const zc_loaned_closure_matching_status_t* : zc_closure_matching_status_call, \
         const ze_loaned_closure_miss_t* : ze_closure_miss_call \
     )(closure, hello)
 
 typedef void(*z_closure_drop_callback_t)(void *context);
 typedef void(*z_closure_hello_callback_t)(z_loaned_hello_t *hello, void *context);
+typedef void(*z_closure_matching_status_callback_t)(const z_matching_status_t *matching_status, void *context);
 typedef void(*z_closure_query_callback_t)(z_loaned_query_t *query, void *context);
 typedef void(*z_closure_reply_callback_t)(z_loaned_reply_t *reply, void *context);
 typedef void(*z_closure_sample_callback_t)(z_loaned_sample_t *sample, void *context);
 typedef void(*z_closure_zid_callback_t)(const z_id_t *z_id, void *context);
 typedef void(*zc_closure_log_callback_t)(zc_log_severity_t severity, const z_loaned_string_t *msg, void *context);
-typedef void(*zc_closure_matching_status_callback_t)(const zc_matching_status_t *matching_status, void *context);
 typedef void(*ze_closure_miss_callback_t)(const ze_miss_t *matching_status, void *context);
 
 #define z_closure(this_, call, drop, context) \
     _Generic((this_), \
         z_owned_closure_hello_t* : z_closure_hello, \
+        z_owned_closure_matching_status_t* : z_closure_matching_status, \
         z_owned_closure_query_t* : z_closure_query, \
         z_owned_closure_reply_t* : z_closure_reply, \
         z_owned_closure_sample_t* : z_closure_sample, \
         z_owned_closure_zid_t* : z_closure_zid, \
         zc_owned_closure_log_t* : zc_closure_log, \
-        zc_owned_closure_matching_status_t* : zc_closure_matching_status, \
         ze_owned_closure_miss_t* : ze_closure_miss \
     )(this_, call, drop, context)
 
@@ -565,6 +565,7 @@ static inline z_moved_bytes_t* z_bytes_move(z_owned_bytes_t* x) { return reinter
 static inline z_moved_bytes_writer_t* z_bytes_writer_move(z_owned_bytes_writer_t* x) { return reinterpret_cast<z_moved_bytes_writer_t*>(x); }
 static inline z_moved_chunk_alloc_result_t* z_chunk_alloc_result_move(z_owned_chunk_alloc_result_t* x) { return reinterpret_cast<z_moved_chunk_alloc_result_t*>(x); }
 static inline z_moved_closure_hello_t* z_closure_hello_move(z_owned_closure_hello_t* x) { return reinterpret_cast<z_moved_closure_hello_t*>(x); }
+static inline z_moved_closure_matching_status_t* z_closure_matching_status_move(z_owned_closure_matching_status_t* x) { return reinterpret_cast<z_moved_closure_matching_status_t*>(x); }
 static inline z_moved_closure_query_t* z_closure_query_move(z_owned_closure_query_t* x) { return reinterpret_cast<z_moved_closure_query_t*>(x); }
 static inline z_moved_closure_reply_t* z_closure_reply_move(z_owned_closure_reply_t* x) { return reinterpret_cast<z_moved_closure_reply_t*>(x); }
 static inline z_moved_closure_sample_t* z_closure_sample_move(z_owned_closure_sample_t* x) { return reinterpret_cast<z_moved_closure_sample_t*>(x); }
@@ -578,6 +579,7 @@ static inline z_moved_fifo_handler_sample_t* z_fifo_handler_sample_move(z_owned_
 static inline z_moved_hello_t* z_hello_move(z_owned_hello_t* x) { return reinterpret_cast<z_moved_hello_t*>(x); }
 static inline z_moved_keyexpr_t* z_keyexpr_move(z_owned_keyexpr_t* x) { return reinterpret_cast<z_moved_keyexpr_t*>(x); }
 static inline z_moved_liveliness_token_t* z_liveliness_token_move(z_owned_liveliness_token_t* x) { return reinterpret_cast<z_moved_liveliness_token_t*>(x); }
+static inline z_moved_matching_listener_t* z_matching_listener_move(z_owned_matching_listener_t* x) { return reinterpret_cast<z_moved_matching_listener_t*>(x); }
 static inline z_moved_memory_layout_t* z_memory_layout_move(z_owned_memory_layout_t* x) { return reinterpret_cast<z_moved_memory_layout_t*>(x); }
 static inline z_moved_mutex_t* z_mutex_move(z_owned_mutex_t* x) { return reinterpret_cast<z_moved_mutex_t*>(x); }
 static inline z_moved_publisher_t* z_publisher_move(z_owned_publisher_t* x) { return reinterpret_cast<z_moved_publisher_t*>(x); }
@@ -603,9 +605,7 @@ static inline z_moved_string_t* z_string_move(z_owned_string_t* x) { return rein
 static inline z_moved_subscriber_t* z_subscriber_move(z_owned_subscriber_t* x) { return reinterpret_cast<z_moved_subscriber_t*>(x); }
 static inline z_moved_task_t* z_task_move(z_owned_task_t* x) { return reinterpret_cast<z_moved_task_t*>(x); }
 static inline zc_moved_closure_log_t* zc_closure_log_move(zc_owned_closure_log_t* x) { return reinterpret_cast<zc_moved_closure_log_t*>(x); }
-static inline zc_moved_closure_matching_status_t* zc_closure_matching_status_move(zc_owned_closure_matching_status_t* x) { return reinterpret_cast<zc_moved_closure_matching_status_t*>(x); }
 static inline zc_moved_concurrent_close_handle_t* zc_concurrent_close_handle_move(zc_owned_concurrent_close_handle_t* x) { return reinterpret_cast<zc_moved_concurrent_close_handle_t*>(x); }
-static inline zc_moved_matching_listener_t* zc_matching_listener_move(zc_owned_matching_listener_t* x) { return reinterpret_cast<zc_moved_matching_listener_t*>(x); }
 static inline zc_moved_shm_client_list_t* zc_shm_client_list_move(zc_owned_shm_client_list_t* x) { return reinterpret_cast<zc_moved_shm_client_list_t*>(x); }
 static inline ze_moved_advanced_publisher_t* ze_advanced_publisher_move(ze_owned_advanced_publisher_t* x) { return reinterpret_cast<ze_moved_advanced_publisher_t*>(x); }
 static inline ze_moved_advanced_subscriber_t* ze_advanced_subscriber_move(ze_owned_advanced_subscriber_t* x) { return reinterpret_cast<ze_moved_advanced_subscriber_t*>(x); }
@@ -621,6 +621,7 @@ inline const z_loaned_alloc_layout_t* z_loan(const z_owned_alloc_layout_t& this_
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& this_) { return z_bytes_loan(&this_); };
 inline const z_loaned_bytes_writer_t* z_loan(const z_owned_bytes_writer_t& this_) { return z_bytes_writer_loan(&this_); };
 inline const z_loaned_closure_hello_t* z_loan(const z_owned_closure_hello_t& closure) { return z_closure_hello_loan(&closure); };
+inline const z_loaned_closure_matching_status_t* z_loan(const z_owned_closure_matching_status_t& closure) { return z_closure_matching_status_loan(&closure); };
 inline const z_loaned_closure_query_t* z_loan(const z_owned_closure_query_t& closure) { return z_closure_query_loan(&closure); };
 inline const z_loaned_closure_reply_t* z_loan(const z_owned_closure_reply_t& closure) { return z_closure_reply_loan(&closure); };
 inline const z_loaned_closure_sample_t* z_loan(const z_owned_closure_sample_t& closure) { return z_closure_sample_loan(&closure); };
@@ -659,7 +660,6 @@ inline const z_loaned_keyexpr_t* z_loan(const z_view_keyexpr_t& this_) { return 
 inline const z_loaned_slice_t* z_loan(const z_view_slice_t& this_) { return z_view_slice_loan(&this_); };
 inline const z_loaned_string_t* z_loan(const z_view_string_t& this_) { return z_view_string_loan(&this_); };
 inline const zc_loaned_closure_log_t* z_loan(const zc_owned_closure_log_t& closure) { return zc_closure_log_loan(&closure); };
-inline const zc_loaned_closure_matching_status_t* z_loan(const zc_owned_closure_matching_status_t& closure) { return zc_closure_matching_status_loan(&closure); };
 inline const zc_loaned_shm_client_list_t* z_loan(const zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_loan(&this_); };
 inline const ze_loaned_advanced_publisher_t* z_loan(const ze_owned_advanced_publisher_t& this_) { return ze_advanced_publisher_loan(&this_); };
 inline const ze_loaned_advanced_subscriber_t* z_loan(const ze_owned_advanced_subscriber_t& this_) { return ze_advanced_subscriber_loan(&this_); };
@@ -699,6 +699,7 @@ inline void z_drop(z_moved_bytes_t* this_) { z_bytes_drop(this_); };
 inline void z_drop(z_moved_bytes_writer_t* this_) { z_bytes_writer_drop(this_); };
 inline void z_drop(z_moved_chunk_alloc_result_t* this_) { z_chunk_alloc_result_drop(this_); };
 inline void z_drop(z_moved_closure_hello_t* this_) { z_closure_hello_drop(this_); };
+inline void z_drop(z_moved_closure_matching_status_t* closure_) { z_closure_matching_status_drop(closure_); };
 inline void z_drop(z_moved_closure_query_t* closure_) { z_closure_query_drop(closure_); };
 inline void z_drop(z_moved_closure_reply_t* closure_) { z_closure_reply_drop(closure_); };
 inline void z_drop(z_moved_closure_sample_t* closure_) { z_closure_sample_drop(closure_); };
@@ -712,6 +713,7 @@ inline void z_drop(z_moved_fifo_handler_sample_t* this_) { z_fifo_handler_sample
 inline void z_drop(z_moved_hello_t* this_) { z_hello_drop(this_); };
 inline void z_drop(z_moved_keyexpr_t* this_) { z_keyexpr_drop(this_); };
 inline void z_drop(z_moved_liveliness_token_t* this_) { z_liveliness_token_drop(this_); };
+inline void z_drop(z_moved_matching_listener_t* this_) { z_matching_listener_drop(this_); };
 inline void z_drop(z_moved_memory_layout_t* this_) { z_memory_layout_drop(this_); };
 inline void z_drop(z_moved_mutex_t* this_) { z_mutex_drop(this_); };
 inline void z_drop(z_moved_publisher_t* this_) { z_publisher_drop(this_); };
@@ -737,9 +739,7 @@ inline void z_drop(z_moved_string_t* this_) { z_string_drop(this_); };
 inline void z_drop(z_moved_subscriber_t* this_) { z_subscriber_drop(this_); };
 inline void z_drop(z_moved_task_t* this_) { z_task_drop(this_); };
 inline void z_drop(zc_moved_closure_log_t* closure_) { zc_closure_log_drop(closure_); };
-inline void z_drop(zc_moved_closure_matching_status_t* closure_) { zc_closure_matching_status_drop(closure_); };
 inline void z_drop(zc_moved_concurrent_close_handle_t* this_) { zc_concurrent_close_handle_drop(this_); };
-inline void z_drop(zc_moved_matching_listener_t* this_) { zc_matching_listener_drop(this_); };
 inline void z_drop(zc_moved_shm_client_list_t* this_) { zc_shm_client_list_drop(this_); };
 inline void z_drop(ze_moved_advanced_publisher_t* this_) { ze_advanced_publisher_drop(this_); };
 inline void z_drop(ze_moved_advanced_subscriber_t* this_) { ze_advanced_subscriber_drop(this_); };
@@ -755,6 +755,7 @@ inline z_moved_bytes_t* z_move(z_owned_bytes_t& this_) { return z_bytes_move(&th
 inline z_moved_bytes_writer_t* z_move(z_owned_bytes_writer_t& this_) { return z_bytes_writer_move(&this_); };
 inline z_moved_chunk_alloc_result_t* z_move(z_owned_chunk_alloc_result_t& this_) { return z_chunk_alloc_result_move(&this_); };
 inline z_moved_closure_hello_t* z_move(z_owned_closure_hello_t& this_) { return z_closure_hello_move(&this_); };
+inline z_moved_closure_matching_status_t* z_move(z_owned_closure_matching_status_t& closure_) { return z_closure_matching_status_move(&closure_); };
 inline z_moved_closure_query_t* z_move(z_owned_closure_query_t& closure_) { return z_closure_query_move(&closure_); };
 inline z_moved_closure_reply_t* z_move(z_owned_closure_reply_t& closure_) { return z_closure_reply_move(&closure_); };
 inline z_moved_closure_sample_t* z_move(z_owned_closure_sample_t& closure_) { return z_closure_sample_move(&closure_); };
@@ -768,6 +769,7 @@ inline z_moved_fifo_handler_sample_t* z_move(z_owned_fifo_handler_sample_t& this
 inline z_moved_hello_t* z_move(z_owned_hello_t& this_) { return z_hello_move(&this_); };
 inline z_moved_keyexpr_t* z_move(z_owned_keyexpr_t& this_) { return z_keyexpr_move(&this_); };
 inline z_moved_liveliness_token_t* z_move(z_owned_liveliness_token_t& this_) { return z_liveliness_token_move(&this_); };
+inline z_moved_matching_listener_t* z_move(z_owned_matching_listener_t& this_) { return z_matching_listener_move(&this_); };
 inline z_moved_memory_layout_t* z_move(z_owned_memory_layout_t& this_) { return z_memory_layout_move(&this_); };
 inline z_moved_mutex_t* z_move(z_owned_mutex_t& this_) { return z_mutex_move(&this_); };
 inline z_moved_publisher_t* z_move(z_owned_publisher_t& this_) { return z_publisher_move(&this_); };
@@ -793,9 +795,7 @@ inline z_moved_string_t* z_move(z_owned_string_t& this_) { return z_string_move(
 inline z_moved_subscriber_t* z_move(z_owned_subscriber_t& this_) { return z_subscriber_move(&this_); };
 inline z_moved_task_t* z_move(z_owned_task_t& this_) { return z_task_move(&this_); };
 inline zc_moved_closure_log_t* z_move(zc_owned_closure_log_t& closure_) { return zc_closure_log_move(&closure_); };
-inline zc_moved_closure_matching_status_t* z_move(zc_owned_closure_matching_status_t& closure_) { return zc_closure_matching_status_move(&closure_); };
 inline zc_moved_concurrent_close_handle_t* z_move(zc_owned_concurrent_close_handle_t& this_) { return zc_concurrent_close_handle_move(&this_); };
-inline zc_moved_matching_listener_t* z_move(zc_owned_matching_listener_t& this_) { return zc_matching_listener_move(&this_); };
 inline zc_moved_shm_client_list_t* z_move(zc_owned_shm_client_list_t& this_) { return zc_shm_client_list_move(&this_); };
 inline ze_moved_advanced_publisher_t* z_move(ze_owned_advanced_publisher_t& this_) { return ze_advanced_publisher_move(&this_); };
 inline ze_moved_advanced_subscriber_t* z_move(ze_owned_advanced_subscriber_t& this_) { return ze_advanced_subscriber_move(&this_); };
@@ -811,6 +811,7 @@ inline void z_internal_null(z_owned_bytes_t* this_) { z_internal_bytes_null(this
 inline void z_internal_null(z_owned_bytes_writer_t* this_) { z_internal_bytes_writer_null(this_); };
 inline void z_internal_null(z_owned_chunk_alloc_result_t* this_) { z_internal_chunk_alloc_result_null(this_); };
 inline void z_internal_null(z_owned_closure_hello_t* this_) { z_internal_closure_hello_null(this_); };
+inline void z_internal_null(z_owned_closure_matching_status_t* this_) { z_internal_closure_matching_status_null(this_); };
 inline void z_internal_null(z_owned_closure_query_t* this_) { z_internal_closure_query_null(this_); };
 inline void z_internal_null(z_owned_closure_reply_t* this_) { z_internal_closure_reply_null(this_); };
 inline void z_internal_null(z_owned_closure_sample_t* this_) { z_internal_closure_sample_null(this_); };
@@ -824,6 +825,7 @@ inline void z_internal_null(z_owned_fifo_handler_sample_t* this_) { z_internal_f
 inline void z_internal_null(z_owned_hello_t* this_) { z_internal_hello_null(this_); };
 inline void z_internal_null(z_owned_keyexpr_t* this_) { z_internal_keyexpr_null(this_); };
 inline void z_internal_null(z_owned_liveliness_token_t* this_) { z_internal_liveliness_token_null(this_); };
+inline void z_internal_null(z_owned_matching_listener_t* this_) { z_internal_matching_listener_null(this_); };
 inline void z_internal_null(z_owned_memory_layout_t* this_) { z_internal_memory_layout_null(this_); };
 inline void z_internal_null(z_owned_mutex_t* this_) { z_internal_mutex_null(this_); };
 inline void z_internal_null(z_owned_publisher_t* this_) { z_internal_publisher_null(this_); };
@@ -849,9 +851,7 @@ inline void z_internal_null(z_owned_string_t* this_) { z_internal_string_null(th
 inline void z_internal_null(z_owned_subscriber_t* this_) { z_internal_subscriber_null(this_); };
 inline void z_internal_null(z_owned_task_t* this_) { z_internal_task_null(this_); };
 inline void z_internal_null(zc_owned_closure_log_t* this_) { zc_internal_closure_log_null(this_); };
-inline void z_internal_null(zc_owned_closure_matching_status_t* this_) { zc_internal_closure_matching_status_null(this_); };
 inline void z_internal_null(zc_owned_concurrent_close_handle_t* this_) { zc_internal_concurrent_close_handle_null(this_); };
-inline void z_internal_null(zc_owned_matching_listener_t* this_) { zc_internal_matching_listener_null(this_); };
 inline void z_internal_null(zc_owned_shm_client_list_t* this_) { zc_internal_shm_client_list_null(this_); };
 inline void z_internal_null(ze_owned_advanced_publisher_t* this_) { ze_internal_advanced_publisher_null(this_); };
 inline void z_internal_null(ze_owned_advanced_subscriber_t* this_) { ze_internal_advanced_subscriber_null(this_); };
@@ -866,6 +866,7 @@ static inline void z_bytes_take(z_owned_bytes_t* this_, z_moved_bytes_t* x) { *t
 static inline void z_bytes_writer_take(z_owned_bytes_writer_t* this_, z_moved_bytes_writer_t* x) { *this_ = x->_this; z_internal_bytes_writer_null(&x->_this); }
 static inline void z_chunk_alloc_result_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_result_t* x) { *this_ = x->_this; z_internal_chunk_alloc_result_null(&x->_this); }
 static inline void z_closure_hello_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) { *this_ = x->_this; z_internal_closure_hello_null(&x->_this); }
+static inline void z_closure_matching_status_take(z_owned_closure_matching_status_t* closure_, z_moved_closure_matching_status_t* x) { *closure_ = x->_this; z_internal_closure_matching_status_null(&x->_this); }
 static inline void z_closure_query_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) { *closure_ = x->_this; z_internal_closure_query_null(&x->_this); }
 static inline void z_closure_reply_take(z_owned_closure_reply_t* closure_, z_moved_closure_reply_t* x) { *closure_ = x->_this; z_internal_closure_reply_null(&x->_this); }
 static inline void z_closure_sample_take(z_owned_closure_sample_t* closure_, z_moved_closure_sample_t* x) { *closure_ = x->_this; z_internal_closure_sample_null(&x->_this); }
@@ -879,6 +880,7 @@ static inline void z_fifo_handler_sample_take(z_owned_fifo_handler_sample_t* thi
 static inline void z_hello_take(z_owned_hello_t* this_, z_moved_hello_t* x) { *this_ = x->_this; z_internal_hello_null(&x->_this); }
 static inline void z_keyexpr_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) { *this_ = x->_this; z_internal_keyexpr_null(&x->_this); }
 static inline void z_liveliness_token_take(z_owned_liveliness_token_t* this_, z_moved_liveliness_token_t* x) { *this_ = x->_this; z_internal_liveliness_token_null(&x->_this); }
+static inline void z_matching_listener_take(z_owned_matching_listener_t* this_, z_moved_matching_listener_t* x) { *this_ = x->_this; z_internal_matching_listener_null(&x->_this); }
 static inline void z_memory_layout_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) { *this_ = x->_this; z_internal_memory_layout_null(&x->_this); }
 static inline void z_mutex_take(z_owned_mutex_t* this_, z_moved_mutex_t* x) { *this_ = x->_this; z_internal_mutex_null(&x->_this); }
 static inline void z_publisher_take(z_owned_publisher_t* this_, z_moved_publisher_t* x) { *this_ = x->_this; z_internal_publisher_null(&x->_this); }
@@ -904,9 +906,7 @@ static inline void z_string_take(z_owned_string_t* this_, z_moved_string_t* x) {
 static inline void z_subscriber_take(z_owned_subscriber_t* this_, z_moved_subscriber_t* x) { *this_ = x->_this; z_internal_subscriber_null(&x->_this); }
 static inline void z_task_take(z_owned_task_t* this_, z_moved_task_t* x) { *this_ = x->_this; z_internal_task_null(&x->_this); }
 static inline void zc_closure_log_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) { *closure_ = x->_this; zc_internal_closure_log_null(&x->_this); }
-static inline void zc_closure_matching_status_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) { *closure_ = x->_this; zc_internal_closure_matching_status_null(&x->_this); }
 static inline void zc_concurrent_close_handle_take(zc_owned_concurrent_close_handle_t* this_, zc_moved_concurrent_close_handle_t* x) { *this_ = x->_this; zc_internal_concurrent_close_handle_null(&x->_this); }
-static inline void zc_matching_listener_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) { *this_ = x->_this; zc_internal_matching_listener_null(&x->_this); }
 static inline void zc_shm_client_list_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) { *this_ = x->_this; zc_internal_shm_client_list_null(&x->_this); }
 static inline void ze_advanced_publisher_take(ze_owned_advanced_publisher_t* this_, ze_moved_advanced_publisher_t* x) { *this_ = x->_this; ze_internal_advanced_publisher_null(&x->_this); }
 static inline void ze_advanced_subscriber_take(ze_owned_advanced_subscriber_t* this_, ze_moved_advanced_subscriber_t* x) { *this_ = x->_this; ze_internal_advanced_subscriber_null(&x->_this); }
@@ -932,6 +932,9 @@ inline void z_take(z_owned_chunk_alloc_result_t* this_, z_moved_chunk_alloc_resu
 };
 inline void z_take(z_owned_closure_hello_t* this_, z_moved_closure_hello_t* x) {
     z_closure_hello_take(this_, x);
+};
+inline void z_take(z_owned_closure_matching_status_t* closure_, z_moved_closure_matching_status_t* x) {
+    z_closure_matching_status_take(closure_, x);
 };
 inline void z_take(z_owned_closure_query_t* closure_, z_moved_closure_query_t* x) {
     z_closure_query_take(closure_, x);
@@ -971,6 +974,9 @@ inline void z_take(z_owned_keyexpr_t* this_, z_moved_keyexpr_t* x) {
 };
 inline void z_take(z_owned_liveliness_token_t* this_, z_moved_liveliness_token_t* x) {
     z_liveliness_token_take(this_, x);
+};
+inline void z_take(z_owned_matching_listener_t* this_, z_moved_matching_listener_t* x) {
+    z_matching_listener_take(this_, x);
 };
 inline void z_take(z_owned_memory_layout_t* this_, z_moved_memory_layout_t* x) {
     z_memory_layout_take(this_, x);
@@ -1047,14 +1053,8 @@ inline void z_take(z_owned_task_t* this_, z_moved_task_t* x) {
 inline void z_take(zc_owned_closure_log_t* closure_, zc_moved_closure_log_t* x) {
     zc_closure_log_take(closure_, x);
 };
-inline void z_take(zc_owned_closure_matching_status_t* closure_, zc_moved_closure_matching_status_t* x) {
-    zc_closure_matching_status_take(closure_, x);
-};
 inline void z_take(zc_owned_concurrent_close_handle_t* this_, zc_moved_concurrent_close_handle_t* x) {
     zc_concurrent_close_handle_take(this_, x);
-};
-inline void z_take(zc_owned_matching_listener_t* this_, zc_moved_matching_listener_t* x) {
-    zc_matching_listener_take(this_, x);
 };
 inline void z_take(zc_owned_shm_client_list_t* this_, zc_moved_shm_client_list_t* x) {
     zc_shm_client_list_take(this_, x);
@@ -1087,6 +1087,7 @@ inline bool z_internal_check(const z_owned_bytes_t& this_) { return z_internal_b
 inline bool z_internal_check(const z_owned_bytes_writer_t& this_) { return z_internal_bytes_writer_check(&this_); };
 inline bool z_internal_check(const z_owned_chunk_alloc_result_t& this_) { return z_internal_chunk_alloc_result_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_hello_t& this_) { return z_internal_closure_hello_check(&this_); };
+inline bool z_internal_check(const z_owned_closure_matching_status_t& this_) { return z_internal_closure_matching_status_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_query_t& this_) { return z_internal_closure_query_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_reply_t& this_) { return z_internal_closure_reply_check(&this_); };
 inline bool z_internal_check(const z_owned_closure_sample_t& this_) { return z_internal_closure_sample_check(&this_); };
@@ -1100,6 +1101,7 @@ inline bool z_internal_check(const z_owned_fifo_handler_sample_t& this_) { retur
 inline bool z_internal_check(const z_owned_hello_t& this_) { return z_internal_hello_check(&this_); };
 inline bool z_internal_check(const z_owned_keyexpr_t& this_) { return z_internal_keyexpr_check(&this_); };
 inline bool z_internal_check(const z_owned_liveliness_token_t& this_) { return z_internal_liveliness_token_check(&this_); };
+inline bool z_internal_check(const z_owned_matching_listener_t& this_) { return z_internal_matching_listener_check(&this_); };
 inline bool z_internal_check(const z_owned_memory_layout_t& this_) { return z_internal_memory_layout_check(&this_); };
 inline bool z_internal_check(const z_owned_mutex_t& this_) { return z_internal_mutex_check(&this_); };
 inline bool z_internal_check(const z_owned_publisher_t& this_) { return z_internal_publisher_check(&this_); };
@@ -1125,9 +1127,7 @@ inline bool z_internal_check(const z_owned_string_t& this_) { return z_internal_
 inline bool z_internal_check(const z_owned_subscriber_t& this_) { return z_internal_subscriber_check(&this_); };
 inline bool z_internal_check(const z_owned_task_t& this_) { return z_internal_task_check(&this_); };
 inline bool z_internal_check(const zc_owned_closure_log_t& this_) { return zc_internal_closure_log_check(&this_); };
-inline bool z_internal_check(const zc_owned_closure_matching_status_t& this_) { return zc_internal_closure_matching_status_check(&this_); };
 inline bool z_internal_check(const zc_owned_concurrent_close_handle_t& this_) { return zc_internal_concurrent_close_handle_check(&this_); };
-inline bool z_internal_check(const zc_owned_matching_listener_t& this_) { return zc_internal_matching_listener_check(&this_); };
 inline bool z_internal_check(const zc_owned_shm_client_list_t& this_) { return zc_internal_shm_client_list_check(&this_); };
 inline bool z_internal_check(const ze_owned_advanced_publisher_t& this_) { return ze_internal_advanced_publisher_check(&this_); };
 inline bool z_internal_check(const ze_owned_advanced_subscriber_t& this_) { return ze_internal_advanced_subscriber_check(&this_); };
@@ -1141,6 +1141,9 @@ inline bool z_internal_check(const ze_owned_serializer_t& this_) { return ze_int
 inline void z_call(const z_loaned_closure_hello_t* closure, z_loaned_hello_t* hello) {
     z_closure_hello_call(closure, hello);
 };
+inline void z_call(const z_loaned_closure_matching_status_t* closure, const z_matching_status_t* mathing_status) {
+    z_closure_matching_status_call(closure, mathing_status);
+};
 inline void z_call(const z_loaned_closure_query_t* closure, z_loaned_query_t* query) {
     z_closure_query_call(closure, query);
 };
@@ -1153,26 +1156,27 @@ inline void z_call(const z_loaned_closure_sample_t* closure, z_loaned_sample_t* 
 inline void z_call(const z_loaned_closure_zid_t* closure, const z_id_t* z_id) {
     z_closure_zid_call(closure, z_id);
 };
-inline void z_call(const zc_loaned_closure_matching_status_t* closure, const zc_matching_status_t* mathing_status) {
-    zc_closure_matching_status_call(closure, mathing_status);
-};
 inline void z_call(const ze_loaned_closure_miss_t* closure, const ze_miss_t* mathing_status) {
     ze_closure_miss_call(closure, mathing_status);
 };
 
 extern "C" using z_closure_drop_callback_t = void(void* context);
 extern "C" using z_closure_hello_callback_t = void(z_loaned_hello_t *hello, void *context);
+extern "C" using z_closure_matching_status_callback_t = void(const z_matching_status_t *matching_status, void *context);
 extern "C" using z_closure_query_callback_t = void(z_loaned_query_t *query, void *context);
 extern "C" using z_closure_reply_callback_t = void(z_loaned_reply_t *reply, void *context);
 extern "C" using z_closure_sample_callback_t = void(z_loaned_sample_t *sample, void *context);
 extern "C" using z_closure_zid_callback_t = void(const z_id_t *z_id, void *context);
 extern "C" using zc_closure_log_callback_t = void(zc_log_severity_t severity, const z_loaned_string_t *msg, void *context);
-extern "C" using zc_closure_matching_status_callback_t = void(const zc_matching_status_t *matching_status, void *context);
 extern "C" using ze_closure_miss_callback_t = void(const ze_miss_t *matching_status, void *context);
 
 inline void z_closure(z_owned_closure_hello_t* this_, z_closure_hello_callback_t* call,
     z_closure_drop_callback_t* drop, void* context) {
     z_closure_hello(this_, call, drop, context);
+};
+inline void z_closure(z_owned_closure_matching_status_t* this_, z_closure_matching_status_callback_t* call,
+    z_closure_drop_callback_t* drop, void* context) {
+    z_closure_matching_status(this_, call, drop, context);
 };
 inline void z_closure(z_owned_closure_query_t* this_, z_closure_query_callback_t* call,
     z_closure_drop_callback_t* drop, void* context) {
@@ -1193,10 +1197,6 @@ inline void z_closure(z_owned_closure_zid_t* this_, z_closure_zid_callback_t* ca
 inline void z_closure(zc_owned_closure_log_t* this_, zc_closure_log_callback_t* call,
     z_closure_drop_callback_t* drop, void* context) {
     zc_closure_log(this_, call, drop, context);
-};
-inline void z_closure(zc_owned_closure_matching_status_t* this_, zc_closure_matching_status_callback_t* call,
-    z_closure_drop_callback_t* drop, void* context) {
-    zc_closure_matching_status(this_, call, drop, context);
 };
 inline void z_closure(ze_owned_closure_miss_t* this_, ze_closure_miss_callback_t* call,
     z_closure_drop_callback_t* drop, void* context) {
@@ -1297,6 +1297,8 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_bytes_writer_t> { typedef z_
 template<> struct z_owned_to_loaned_type_t<z_owned_bytes_writer_t> { typedef z_loaned_bytes_writer_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_hello_t> { typedef z_owned_closure_hello_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_hello_t> { typedef z_loaned_closure_hello_t type; };
+template<> struct z_loaned_to_owned_type_t<z_loaned_closure_matching_status_t> { typedef z_owned_closure_matching_status_t type; };
+template<> struct z_owned_to_loaned_type_t<z_owned_closure_matching_status_t> { typedef z_loaned_closure_matching_status_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_query_t> { typedef z_owned_closure_query_t type; };
 template<> struct z_owned_to_loaned_type_t<z_owned_closure_query_t> { typedef z_loaned_closure_query_t type; };
 template<> struct z_loaned_to_owned_type_t<z_loaned_closure_reply_t> { typedef z_owned_closure_reply_t type; };
@@ -1367,8 +1369,6 @@ template<> struct z_loaned_to_owned_type_t<z_loaned_subscriber_t> { typedef z_ow
 template<> struct z_owned_to_loaned_type_t<z_owned_subscriber_t> { typedef z_loaned_subscriber_t type; };
 template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_log_t> { typedef zc_owned_closure_log_t type; };
 template<> struct z_owned_to_loaned_type_t<zc_owned_closure_log_t> { typedef zc_loaned_closure_log_t type; };
-template<> struct z_loaned_to_owned_type_t<zc_loaned_closure_matching_status_t> { typedef zc_owned_closure_matching_status_t type; };
-template<> struct z_owned_to_loaned_type_t<zc_owned_closure_matching_status_t> { typedef zc_loaned_closure_matching_status_t type; };
 template<> struct z_loaned_to_owned_type_t<zc_loaned_shm_client_list_t> { typedef zc_owned_shm_client_list_t type; };
 template<> struct z_owned_to_loaned_type_t<zc_owned_shm_client_list_t> { typedef zc_loaned_shm_client_list_t type; };
 template<> struct z_loaned_to_owned_type_t<ze_loaned_advanced_publisher_t> { typedef ze_owned_advanced_publisher_t type; };

--- a/splitguide.yaml
+++ b/splitguide.yaml
@@ -57,7 +57,7 @@ zenoh_opaque.h:
   - z_timestamp_t!
   - z_owned_publisher_t!
   - z_loaned_publisher_t!
-  - zc_owned_matching_listener_t!#unstable
+  - z_owned_matching_listener_t!#unstable
   - z_owned_subscriber_t!
   - z_loaned_subscriber_t!
   - z_owned_liveliness_token_t!
@@ -76,7 +76,7 @@ zenoh_opaque.h:
   - z_loaned_closure_sample_t!
   - z_loaned_closure_zid_t!
   - zc_loaned_closure_log_t!
-  - zc_loaned_closure_matching_status_t!#unstable
+  - z_loaned_closure_matching_status_t!#unstable
   - z_owned_shm_client_t!#shared-memory#unstable
   - zc_owned_shm_client_list_t!#shared-memory#unstable
   - zc_loaned_shm_client_list_t!#shared-memory#unstable

--- a/src/closures/matching_status_closure.rs
+++ b/src/closures/matching_status_closure.rs
@@ -17,42 +17,42 @@ use libc::c_void;
 
 use crate::{
     transmute::{LoanedCTypeRef, OwnedCTypeRef, TakeRustType},
-    zc_matching_status_t,
+    z_matching_status_t,
 };
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief A matching status-processing closure.
 ///
 /// A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
 #[repr(C)]
-pub struct zc_owned_closure_matching_status_t {
+pub struct z_owned_closure_matching_status_t {
     _context: *mut c_void,
-    _call: Option<extern "C" fn(matching_status: &zc_matching_status_t, context: *mut c_void)>,
+    _call: Option<extern "C" fn(matching_status: &z_matching_status_t, context: *mut c_void)>,
     _drop: Option<extern "C" fn(context: *mut c_void)>,
 }
 
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Loaned closure.
 #[repr(C)]
-pub struct zc_loaned_closure_matching_status_t {
+pub struct z_loaned_closure_matching_status_t {
     _0: [usize; 3],
 }
 
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Moved closure.
 #[repr(C)]
-pub struct zc_moved_closure_matching_status_t {
-    _this: zc_owned_closure_matching_status_t,
+pub struct z_moved_closure_matching_status_t {
+    _this: z_owned_closure_matching_status_t,
 }
 
 decl_c_type!(
-    owned(zc_owned_closure_matching_status_t),
-    loaned(zc_loaned_closure_matching_status_t),
-    moved(zc_moved_closure_matching_status_t),
+    owned(z_owned_closure_matching_status_t),
+    loaned(z_loaned_closure_matching_status_t),
+    moved(z_moved_closure_matching_status_t),
 );
 
-impl Default for zc_owned_closure_matching_status_t {
+impl Default for z_owned_closure_matching_status_t {
     fn default() -> Self {
-        zc_owned_closure_matching_status_t {
+        z_owned_closure_matching_status_t {
             _context: std::ptr::null_mut(),
             _call: None,
             _drop: None,
@@ -60,14 +60,14 @@ impl Default for zc_owned_closure_matching_status_t {
     }
 }
 
-impl zc_owned_closure_matching_status_t {
+impl z_owned_closure_matching_status_t {
     pub fn is_empty(&self) -> bool {
         self._call.is_none() && self._drop.is_none() && self._context.is_null()
     }
 }
-unsafe impl Send for zc_owned_closure_matching_status_t {}
-unsafe impl Sync for zc_owned_closure_matching_status_t {}
-impl Drop for zc_owned_closure_matching_status_t {
+unsafe impl Send for z_owned_closure_matching_status_t {}
+unsafe impl Sync for z_owned_closure_matching_status_t {}
+impl Drop for z_owned_closure_matching_status_t {
     fn drop(&mut self) {
         if let Some(drop) = self._drop {
             drop(self._context)
@@ -75,20 +75,20 @@ impl Drop for zc_owned_closure_matching_status_t {
     }
 }
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
-/// @brief Constructs a null value of 'zc_owned_closure_matching_status_t' type
+/// @brief Constructs a null value of 'z_owned_closure_matching_status_t' type
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn zc_internal_closure_matching_status_null(
-    this: *mut MaybeUninit<zc_owned_closure_matching_status_t>,
+pub unsafe extern "C" fn z_internal_closure_matching_status_null(
+    this: *mut MaybeUninit<z_owned_closure_matching_status_t>,
 ) {
-    (*this).write(zc_owned_closure_matching_status_t::default());
+    (*this).write(z_owned_closure_matching_status_t::default());
 }
 
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Returns ``true`` if closure is valid, ``false`` if it is in gravestone state.
 #[no_mangle]
-pub extern "C" fn zc_internal_closure_matching_status_check(
-    this: &zc_owned_closure_matching_status_t,
+pub extern "C" fn z_internal_closure_matching_status_check(
+    this: &z_owned_closure_matching_status_t,
 ) -> bool {
     !this.is_empty()
 }
@@ -96,9 +96,9 @@ pub extern "C" fn zc_internal_closure_matching_status_check(
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Calls the closure. Calling an uninitialized closure is a no-op.
 #[no_mangle]
-pub extern "C" fn zc_closure_matching_status_call(
-    closure: &zc_loaned_closure_matching_status_t,
-    mathing_status: &zc_matching_status_t,
+pub extern "C" fn z_closure_matching_status_call(
+    closure: &z_loaned_closure_matching_status_t,
+    mathing_status: &z_matching_status_t,
 ) {
     let closure = closure.as_owned_c_type_ref();
     match closure._call {
@@ -112,17 +112,15 @@ pub extern "C" fn zc_closure_matching_status_call(
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Drops the closure, resetting it to its gravestone state. Droping an uninitialized closure is a no-op.
 #[no_mangle]
-pub extern "C" fn zc_closure_matching_status_drop(
-    closure_: &mut zc_moved_closure_matching_status_t,
-) {
+pub extern "C" fn z_closure_matching_status_drop(closure_: &mut z_moved_closure_matching_status_t) {
     let _ = closure_.take_rust_type();
 }
 
-impl<F: Fn(&zc_matching_status_t)> From<F> for zc_owned_closure_matching_status_t {
+impl<F: Fn(&z_matching_status_t)> From<F> for z_owned_closure_matching_status_t {
     fn from(f: F) -> Self {
         let this = Box::into_raw(Box::new(f)) as _;
-        extern "C" fn call<F: Fn(&zc_matching_status_t)>(
-            response: &zc_matching_status_t,
+        extern "C" fn call<F: Fn(&z_matching_status_t)>(
+            response: &z_matching_status_t,
             this: *mut c_void,
         ) {
             let this = unsafe { &*(this as *const F) };
@@ -131,7 +129,7 @@ impl<F: Fn(&zc_matching_status_t)> From<F> for zc_owned_closure_matching_status_
         extern "C" fn drop<F>(this: *mut c_void) {
             std::mem::drop(unsafe { Box::from_raw(this as *mut F) })
         }
-        zc_owned_closure_matching_status_t {
+        z_owned_closure_matching_status_t {
             _context: this,
             _call: Some(call::<F>),
             _drop: Some(drop::<F>),
@@ -142,9 +140,9 @@ impl<F: Fn(&zc_matching_status_t)> From<F> for zc_owned_closure_matching_status_
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Borrows closure.
 #[no_mangle]
-pub extern "C" fn zc_closure_matching_status_loan(
-    closure: &zc_owned_closure_matching_status_t,
-) -> &zc_loaned_closure_matching_status_t {
+pub extern "C" fn z_closure_matching_status_loan(
+    closure: &z_owned_closure_matching_status_t,
+) -> &z_loaned_closure_matching_status_t {
     closure.as_loaned_c_type_ref()
 }
 
@@ -162,13 +160,13 @@ pub extern "C" fn zc_closure_matching_status_loan(
 /// @param drop: an optional function to be called once on closure drop.
 /// @param context: closure context.
 #[no_mangle]
-pub extern "C" fn zc_closure_matching_status(
-    this: &mut MaybeUninit<zc_owned_closure_matching_status_t>,
-    call: Option<extern "C" fn(matching_status: &zc_matching_status_t, context: *mut c_void)>,
+pub extern "C" fn z_closure_matching_status(
+    this: &mut MaybeUninit<z_owned_closure_matching_status_t>,
+    call: Option<extern "C" fn(matching_status: &z_matching_status_t, context: *mut c_void)>,
     drop: Option<extern "C" fn(context: *mut c_void)>,
     context: *mut c_void,
 ) {
-    this.write(zc_owned_closure_matching_status_t {
+    this.write(z_owned_closure_matching_status_t {
         _context: context,
         _call: call,
         _drop: drop,

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -16,20 +16,20 @@ use std::mem::MaybeUninit;
 
 use zenoh::{matching::MatchingListener, Wait};
 
-pub use crate::opaque_types::{zc_moved_matching_listener_t, zc_owned_matching_listener_t};
+pub use crate::opaque_types::{z_moved_matching_listener_t, z_owned_matching_listener_t};
 use crate::{
     result,
     transmute::{RustTypeRef, RustTypeRefUninit, TakeRustType},
 };
 decl_c_type!(
-    owned(zc_owned_matching_listener_t, option MatchingListener<()>),
+    owned(z_owned_matching_listener_t, option MatchingListener<()>),
 );
 
 #[no_mangle]
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Constructs an empty matching listener.
-pub extern "C" fn zc_internal_matching_listener_null(
-    this_: &mut MaybeUninit<zc_owned_matching_listener_t>,
+pub extern "C" fn z_internal_matching_listener_null(
+    this_: &mut MaybeUninit<z_owned_matching_listener_t>,
 ) {
     this_.as_rust_type_mut_uninit().write(None);
 }
@@ -37,9 +37,7 @@ pub extern "C" fn zc_internal_matching_listener_null(
 #[no_mangle]
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 /// @brief Checks the matching listener is for the gravestone state
-pub extern "C" fn zc_internal_matching_listener_check(
-    this_: &zc_owned_matching_listener_t,
-) -> bool {
+pub extern "C" fn z_internal_matching_listener_check(this_: &z_owned_matching_listener_t) -> bool {
     this_.as_rust_type_ref().is_some()
 }
 
@@ -47,7 +45,7 @@ pub extern "C" fn zc_internal_matching_listener_check(
 /// @brief A struct that indicates if there exist Subscribers matching the Publisher's key expression or Queryables matching Querier's key expression and target.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-pub struct zc_matching_status_t {
+pub struct z_matching_status_t {
     /// True if there exist matching Zenoh entities, false otherwise.
     pub matching: bool,
 }
@@ -56,7 +54,7 @@ pub struct zc_matching_status_t {
 /// @brief Undeclares the given matching listener, droping and invalidating it.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn zc_matching_listener_drop(this: &mut zc_moved_matching_listener_t) {
+pub extern "C" fn z_matching_listener_drop(this: &mut z_moved_matching_listener_t) {
     std::mem::drop(this.take_rust_type())
 }
 
@@ -65,8 +63,8 @@ pub extern "C" fn zc_matching_listener_drop(this: &mut zc_moved_matching_listene
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn zc_undeclare_matching_listener(
-    this: &mut zc_moved_matching_listener_t,
+pub extern "C" fn z_undeclare_matching_listener(
+    this: &mut z_moved_matching_listener_t,
 ) -> result::z_result_t {
     if let Some(m) = this.take_rust_type() {
         if let Err(e) = m.undeclare().wait() {

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -25,7 +25,7 @@ use zenoh::{
 };
 
 #[cfg(feature = "unstable")]
-use crate::zc_moved_closure_matching_status_t;
+use crate::z_moved_closure_matching_status_t;
 use crate::{
     result::{self},
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
@@ -34,12 +34,12 @@ use crate::{
 };
 #[cfg(feature = "unstable")]
 use crate::{
-    transmute::IntoCType, z_entity_global_id_t, z_reliability_default, z_reliability_t,
-    zc_closure_matching_status_call, zc_closure_matching_status_loan, zc_locality_default,
+    transmute::IntoCType, z_closure_matching_status_call, z_closure_matching_status_loan,
+    z_entity_global_id_t, z_reliability_default, z_reliability_t, zc_locality_default,
     zc_locality_t,
 };
 #[cfg(feature = "unstable")]
-use crate::{z_moved_source_info_t, zc_matching_status_t, zc_owned_matching_listener_t};
+use crate::{z_matching_status_t, z_moved_source_info_t, z_owned_matching_listener_t};
 /// Options passed to the `z_declare_publisher()` function.
 #[repr(C)]
 pub struct z_publisher_options_t {
@@ -343,17 +343,17 @@ pub extern "C" fn z_publisher_keyexpr(publisher: &z_loaned_publisher_t) -> &z_lo
 #[cfg(feature = "unstable")]
 fn _publisher_matching_listener_declare_inner<'a>(
     publisher: &'a z_loaned_publisher_t,
-    callback: &mut zc_moved_closure_matching_status_t,
+    callback: &mut z_moved_closure_matching_status_t,
 ) -> zenoh::matching::MatchingListenerBuilder<'a, Callback<MatchingStatus>> {
     let publisher = publisher.as_rust_type_ref();
     let callback = callback.take_rust_type();
     let listener = publisher
         .matching_listener()
         .callback_mut(move |matching_status| {
-            let status = zc_matching_status_t {
+            let status = z_matching_status_t {
                 matching: matching_status.matching(),
             };
-            zc_closure_matching_status_call(zc_closure_matching_status_loan(&callback), &status);
+            z_closure_matching_status_call(z_closure_matching_status_loan(&callback), &status);
         });
     listener
 }
@@ -368,10 +368,10 @@ fn _publisher_matching_listener_declare_inner<'a>(
 ///
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn zc_publisher_declare_matching_listener(
+pub extern "C" fn z_publisher_declare_matching_listener(
     publisher: &'static z_loaned_publisher_t,
-    matching_listener: &mut MaybeUninit<zc_owned_matching_listener_t>,
-    callback: &mut zc_moved_closure_matching_status_t,
+    matching_listener: &mut MaybeUninit<z_owned_matching_listener_t>,
+    callback: &mut z_moved_closure_matching_status_t,
 ) -> result::z_result_t {
     let this = matching_listener.as_rust_type_mut_uninit();
     let listener = _publisher_matching_listener_declare_inner(publisher, callback);
@@ -398,9 +398,9 @@ pub extern "C" fn zc_publisher_declare_matching_listener(
 ///
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn zc_publisher_declare_background_matching_listener(
+pub extern "C" fn z_publisher_declare_background_matching_listener(
     publisher: &'static z_loaned_publisher_t,
-    callback: &mut zc_moved_closure_matching_status_t,
+    callback: &mut z_moved_closure_matching_status_t,
 ) -> result::z_result_t {
     let listener = _publisher_matching_listener_declare_inner(publisher, callback);
     match listener.background().wait() {
@@ -419,13 +419,13 @@ pub extern "C" fn zc_publisher_declare_background_matching_listener(
 /// @return 0 in case of success, negative error code otherwise (in this case matching_status is not updated).
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn zc_publisher_get_matching_status(
+pub extern "C" fn z_publisher_get_matching_status(
     this: &'static z_loaned_publisher_t,
-    matching_status: &mut MaybeUninit<zc_matching_status_t>,
+    matching_status: &mut MaybeUninit<z_matching_status_t>,
 ) -> result::z_result_t {
     match this.as_rust_type_ref().matching_status().wait() {
         Ok(s) => {
-            matching_status.write(zc_matching_status_t {
+            matching_status.write(z_matching_status_t {
                 matching: s.matching(),
             });
             result::Z_OK

--- a/src/querier.rs
+++ b/src/querier.rs
@@ -34,10 +34,10 @@ use crate::{
 };
 #[cfg(feature = "unstable")]
 use crate::{
-    transmute::IntoCType, z_entity_global_id_t, z_moved_source_info_t,
-    zc_closure_matching_status_call, zc_closure_matching_status_loan, zc_locality_default,
-    zc_locality_t, zc_matching_status_t, zc_moved_closure_matching_status_t,
-    zc_owned_matching_listener_t, zc_reply_keyexpr_default, zc_reply_keyexpr_t,
+    transmute::IntoCType, z_closure_matching_status_call, z_closure_matching_status_loan,
+    z_entity_global_id_t, z_matching_status_t, z_moved_closure_matching_status_t,
+    z_moved_source_info_t, z_owned_matching_listener_t, zc_locality_default, zc_locality_t,
+    zc_reply_keyexpr_default, zc_reply_keyexpr_t,
 };
 
 /// @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
@@ -295,17 +295,17 @@ pub extern "C" fn z_querier_keyexpr(querier: &z_loaned_querier_t) -> &z_loaned_k
 #[cfg(feature = "unstable")]
 fn _querier_matching_listener_declare_inner<'a>(
     querier: &'a z_loaned_querier_t,
-    callback: &mut zc_moved_closure_matching_status_t,
+    callback: &mut z_moved_closure_matching_status_t,
 ) -> zenoh::matching::MatchingListenerBuilder<'a, Callback<MatchingStatus>> {
     let querier = querier.as_rust_type_ref();
     let callback = callback.take_rust_type();
     let listener = querier
         .matching_listener()
         .callback_mut(move |matching_status| {
-            let status = zc_matching_status_t {
+            let status = z_matching_status_t {
                 matching: matching_status.matching(),
             };
-            zc_closure_matching_status_call(zc_closure_matching_status_loan(&callback), &status);
+            z_closure_matching_status_call(z_closure_matching_status_loan(&callback), &status);
         });
     listener
 }
@@ -320,10 +320,10 @@ fn _querier_matching_listener_declare_inner<'a>(
 ///
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn zc_querier_declare_matching_listener(
+pub extern "C" fn z_querier_declare_matching_listener(
     querier: &'static z_loaned_querier_t,
-    matching_listener: &mut MaybeUninit<zc_owned_matching_listener_t>,
-    callback: &mut zc_moved_closure_matching_status_t,
+    matching_listener: &mut MaybeUninit<z_owned_matching_listener_t>,
+    callback: &mut z_moved_closure_matching_status_t,
 ) -> result::z_result_t {
     let this = matching_listener.as_rust_type_mut_uninit();
     let listener = _querier_matching_listener_declare_inner(querier, callback);
@@ -350,9 +350,9 @@ pub extern "C" fn zc_querier_declare_matching_listener(
 ///
 /// @return 0 in case of success, negative error code otherwise.
 #[no_mangle]
-pub extern "C" fn zc_querier_declare_background_matching_listener(
+pub extern "C" fn z_querier_declare_background_matching_listener(
     querier: &'static z_loaned_querier_t,
-    callback: &mut zc_moved_closure_matching_status_t,
+    callback: &mut z_moved_closure_matching_status_t,
 ) -> result::z_result_t {
     let listener = _querier_matching_listener_declare_inner(querier, callback);
     match listener.background().wait() {
@@ -371,13 +371,13 @@ pub extern "C" fn zc_querier_declare_background_matching_listener(
 /// @return 0 in case of success, negative error code otherwise (in this case matching_status is not updated).
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub extern "C" fn zc_querier_get_matching_status(
+pub extern "C" fn z_querier_get_matching_status(
     this: &'static z_loaned_querier_t,
-    matching_status: &mut MaybeUninit<zc_matching_status_t>,
+    matching_status: &mut MaybeUninit<z_matching_status_t>,
 ) -> result::z_result_t {
     match this.as_rust_type_ref().matching_status().wait() {
         Ok(s) => {
-            matching_status.write(zc_matching_status_t {
+            matching_status.write(z_matching_status_t {
                 matching: s.matching(),
             });
             result::Z_OK


### PR DESCRIPTION
Rename matching methods and types from `zc_*` to `z_*` because it was already implemented in Zenoh Pico