### PR TITLE
Fix clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y musl-tools
           sudo apt-get install -y gcc-arm-linux-gnueabi
           sudo apt-get install -y gcc-arm-linux-gnueabihf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,9 +2908,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "tracing",
  "uhlc",
@@ -3935,12 +3935,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 
 [[package]]
 name = "zenoh-config"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "json5",
  "num_cpus",
@@ -3963,7 +3963,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "aes",
  "hmac",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "getrandom",
  "hashbrown 0.14.5",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "flume",
@@ -4065,7 +4065,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-serial"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "tokio",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixpipe"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-vsock"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "libc",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4264,7 +4264,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "git-version",
  "libloading",
@@ -4280,7 +4280,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "const_format",
  "rand",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "anyhow",
 ]
@@ -4302,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "event-listener 5.3.1",
  "futures",
@@ -4352,7 +4352,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "futures",
  "tokio",
@@ -4365,7 +4365,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -4399,7 +4399,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "const_format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,148 +133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand 2.1.1",
- "futures-lite 2.3.0",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-io 2.3.4",
- "async-lock 3.4.0",
- "blocking",
- "futures-lite 2.3.0",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.27",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
-]
-
-[[package]]
-name = "async-io"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
-dependencies = [
- "async-lock 3.4.0",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.3.0",
- "parking",
- "polling 3.7.3",
- "rustix 0.38.37",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener 5.3.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 1.13.0",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,12 +142,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -372,19 +224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel 2.3.1",
- "async-task",
- "futures-io",
- "futures-lite 2.3.0",
- "piper",
 ]
 
 [[package]]
@@ -805,12 +644,6 @@ checksum = "b6aff27af350e7b53e82aac3e5ab6389abd8f280640ac034508dff0608c4c7e5"
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
@@ -818,25 +651,6 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
-dependencies = [
- "event-listener 5.3.1",
- "pin-project-lite",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -953,34 +767,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
-dependencies = [
- "fastrand 2.1.1",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,18 +857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,12 +892,6 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -1262,17 +1030,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnetwork"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,15 +1112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,12 +1160,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
@@ -1437,9 +1179,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lz4_flex"
@@ -1921,17 +1660,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand 2.1.1",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,37 +1713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
-version = "3.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.4.0",
- "pin-project-lite",
- "rustix 0.38.37",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,7 +1757,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.7",
+ "socket2",
  "thiserror 1.0.63",
  "tokio",
  "tracing",
@@ -2092,7 +1789,7 @@ checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
- "socket2 0.5.7",
+ "socket2",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2309,20 +2006,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno 0.3.9",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
@@ -2330,7 +2013,7 @@ dependencies = [
  "bitflags 2.6.0",
  "errno 0.3.9",
  "libc",
- "linux-raw-sys 0.4.14",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -2728,16 +2411,6 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
@@ -2891,9 +2564,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
- "fastrand 2.1.1",
+ "fastrand",
  "once_cell",
- "rustix 0.38.37",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -3055,7 +2728,7 @@ dependencies = [
  "libc",
  "mio 1.0.2",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -3421,12 +3094,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "value-bag"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,12 +3114,6 @@ dependencies = [
  "libc",
  "nix 0.27.1",
 ]
-
-[[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -3497,18 +3158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3536,16 +3185,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
-
-[[package]]
-name = "web-sys"
-version = "0.3.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "webpki-roots"
@@ -3858,7 +3497,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3895,7 +3534,6 @@ dependencies = [
 name = "zenoh-c"
 version = "1.2.1"
 dependencies = [
- "async-std",
  "cbindgen",
  "chrono",
  "const_format",
@@ -4113,7 +3751,7 @@ version = "1.2.1"
 source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4136,7 +3774,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-webpki",
  "secrecy",
- "socket2 0.5.7",
+ "socket2",
  "time",
  "tls-listener",
  "tokio",
@@ -4159,7 +3797,7 @@ version = "1.2.1"
 source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4341,7 +3979,7 @@ name = "zenoh-sync"
 version = "1.2.1"
 source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "futures",
  "tokio",
  "zenoh-buffers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ default = [
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-async-std = "=1.12.0"
 chrono = "0.4.37"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
@@ -75,7 +74,7 @@ tokio = "*"
 unwrap-infallible = "0.1.5"
 const_format = "0.2.32"
 zenoh = { version = "1.2.1", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features = ["internal"] }
-zenoh-ext = { version = "1.2.1", git = "https://github.com/eclipse-zenoh/zenoh.git", features=["internal"], default-features = false, branch = "main" }
+zenoh-ext = { version = "1.2.1", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features=["internal"] }
 zenoh-runtime = { version = "1.2.1", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-util = { version = "1.2.1", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 flume = "*"

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -63,7 +63,6 @@ default = [
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-async-std = "=1.12.0"
 chrono = "0.4.37"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
@@ -75,7 +74,7 @@ tokio = "*"
 unwrap-infallible = "0.1.5"
 const_format = "0.2.32"
 zenoh = { version = "1.2.1", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features = ["internal"] }
-zenoh-ext = { version = "1.2.1", git = "https://github.com/eclipse-zenoh/zenoh.git", features=["internal"], branch = "main", default-features = false }
+zenoh-ext = { version = "1.2.1", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features=["internal"] }
 zenoh-runtime = { version = "1.2.1", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-util = { version = "1.2.1", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 flume = "*"

--- a/build-resources/opaque-types/Cargo.lock
+++ b/build-resources/opaque-types/Cargo.lock
@@ -3306,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "tracing",
  "uhlc",
@@ -3374,12 +3374,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 
 [[package]]
 name = "zenoh-config"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "json5",
  "num_cpus",
@@ -3402,7 +3402,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "aes",
  "hmac",
@@ -3426,7 +3426,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3445,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "getrandom",
  "hashbrown 0.14.5",
@@ -3460,7 +3460,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "flume",
@@ -3504,7 +3504,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3531,7 +3531,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-serial"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3566,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3595,7 +3595,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixpipe"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -3636,7 +3636,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -3654,7 +3654,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-vsock"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "libc",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "git-version",
  "libloading",
@@ -3719,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "const_format",
  "rand",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "anyhow",
 ]
@@ -3741,7 +3741,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "lazy_static",
  "ron",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "event-listener",
  "futures",
@@ -3791,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "futures",
  "tokio",
@@ -3804,7 +3804,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.2.1"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#2311334ebb82378e341d350a08d0667169c7f211"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4b035b769f301efe72bb5797e37b841ab406d1cc"
 dependencies = [
  "async-trait",
  "const_format",

--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1842,6 +1842,7 @@ ZENOHC_API void z_close_options_default(struct z_close_options_t *this_);
  *   - `call` will never be called once `drop` has started.
  *   - `drop` will only be called **once**, and **after every** `call` has ended.
  *   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+ *
  * @param this_: uninitialized memory location where new closure will be constructed.
  * @param call: a closure body.
  * @param drop: an optional function to be called once on closure drop.
@@ -1881,6 +1882,7 @@ struct z_loaned_closure_hello_t *z_closure_hello_loan_mut(struct z_owned_closure
  *   - `call` will never be called once `drop` has started.
  *   - `drop` will only be called **once**, and **after every** `call` has ended.
  *   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+ *
  * @brief Constructs closure.
  * @param this_: uninitialized memory location where new closure will be constructed.
  * @param call: a closure body.
@@ -1929,6 +1931,7 @@ const struct z_loaned_closure_matching_status_t *z_closure_matching_status_loan(
  *   - `call` will never be called once `drop` has started.
  *   - `drop` will only be called **once**, and **after every** `call` has ended.
  *   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+ *
  * @param this_: uninitialized memory location where new closure will be constructed.
  * @param call: a closure body.
  * @param drop: an optional function to be called once on closure drop.
@@ -1968,6 +1971,7 @@ struct z_loaned_closure_query_t *z_closure_query_loan_mut(struct z_owned_closure
  *   - `call` will never be called once `drop` has started.
  *   - `drop` will only be called **once**, and **after every** `call` has ended.
  *   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+ *
  * @param this_: uninitialized memory location where new closure will be constructed.
  * @param call: a closure body.
  * @param drop: an optional function to be called once on closure drop.
@@ -2008,6 +2012,7 @@ struct z_loaned_closure_reply_t *z_closure_reply_loan_mut(struct z_owned_closure
  *   - `call` will never be called once `drop` has started.
  *   - `drop` will only be called **once**, and **after every** `call` has ended.
  *   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+ *
  * @param this_: uninitialized memory location where new closure will be constructed.
  * @param call: a closure body.
  * @param drop: an optional function to be called once on closure drop.
@@ -2047,6 +2052,7 @@ struct z_loaned_closure_sample_t *z_closure_sample_loan_mut(struct z_owned_closu
  *   - `call` will never be called once `drop` has started.
  *   - `drop` will only be called **once**, and **after every** `call` has ended.
  *   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+ *
  * @param this_: uninitialized memory location where new closure will be constructed.
  * @param call: a closure body.
  * @param drop: an optional function to be called once on closure drop.
@@ -5315,6 +5321,7 @@ z_result_t z_whatami_to_view_string(enum z_whatami_t whatami,
  * There is no ideal signal to trigger this cleanup, so by default, zenoh triggers it in the following moments:
  * - first POSIX SHM segment creation
  * - process exit via exit() call or return from maint function
+ *
  * It is OK to additionally trigger this function at any time, but be aware that this can be costly.
  *
  * For non-linux platforms this function currently does nothing
@@ -5332,6 +5339,7 @@ void zc_cleanup_orphaned_shm_segments(void);
  *   - `call` will never be called once `drop` has started.
  *   - `drop` will only be called **once**, and **after every** `call` has ended.
  *   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+ *
  * @param this_: uninitialized memory location where new closure will be constructed.
  * @param call: a closure body.
  * @param drop: an optional function to be called once on closure drop.
@@ -5865,6 +5873,7 @@ void ze_advanced_subscriber_recovery_options_default(struct ze_advanced_subscrib
  *   - `call` will never be called once `drop` has started.
  *   - `drop` will only be called **once**, and **after every** `call` has ended.
  *   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+ *
  * @brief Constructs closure.
  * @param this_: uninitialized memory location where new closure will be constructed.
  * @param call: a closure body.

--- a/src/closures/hello_closure.rs
+++ b/src/closures/hello_closure.rs
@@ -152,6 +152,7 @@ pub extern "C" fn z_closure_hello_loan_mut(
 ///   - `call` will never be called once `drop` has started.
 ///   - `drop` will only be called **once**, and **after every** `call` has ended.
 ///   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+///
 /// @param this_: uninitialized memory location where new closure will be constructed.
 /// @param call: a closure body.
 /// @param drop: an optional function to be called once on closure drop.

--- a/src/closures/log_closure.rs
+++ b/src/closures/log_closure.rs
@@ -187,6 +187,7 @@ pub extern "C" fn zc_closure_log_loan(
 ///   - `call` will never be called once `drop` has started.
 ///   - `drop` will only be called **once**, and **after every** `call` has ended.
 ///   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+///
 /// @param this_: uninitialized memory location where new closure will be constructed.
 /// @param call: a closure body.
 /// @param drop: an optional function to be called once on closure drop.

--- a/src/closures/matching_status_closure.rs
+++ b/src/closures/matching_status_closure.rs
@@ -154,6 +154,7 @@ pub extern "C" fn z_closure_matching_status_loan(
 ///   - `call` will never be called once `drop` has started.
 ///   - `drop` will only be called **once**, and **after every** `call` has ended.
 ///   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+///
 /// @brief Constructs closure.
 /// @param this_: uninitialized memory location where new closure will be constructed.
 /// @param call: a closure body.

--- a/src/closures/miss_closure.rs
+++ b/src/closures/miss_closure.rs
@@ -149,6 +149,7 @@ pub extern "C" fn ze_closure_miss_loan(
 ///   - `call` will never be called once `drop` has started.
 ///   - `drop` will only be called **once**, and **after every** `call` has ended.
 ///   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+///
 /// @brief Constructs closure.
 /// @param this_: uninitialized memory location where new closure will be constructed.
 /// @param call: a closure body.

--- a/src/closures/query_closure.rs
+++ b/src/closures/query_closure.rs
@@ -150,6 +150,7 @@ pub extern "C" fn z_closure_query_loan_mut(
 ///   - `call` will never be called once `drop` has started.
 ///   - `drop` will only be called **once**, and **after every** `call` has ended.
 ///   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+///
 /// @param this_: uninitialized memory location where new closure will be constructed.
 /// @param call: a closure body.
 /// @param drop: an optional function to be called once on closure drop.

--- a/src/closures/reply_closure.rs
+++ b/src/closures/reply_closure.rs
@@ -154,6 +154,7 @@ pub extern "C" fn z_closure_reply_loan_mut(
 ///   - `call` will never be called once `drop` has started.
 ///   - `drop` will only be called **once**, and **after every** `call` has ended.
 ///   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+///
 /// @param this_: uninitialized memory location where new closure will be constructed.
 /// @param call: a closure body.
 /// @param drop: an optional function to be called once on closure drop.

--- a/src/closures/sample_closure.rs
+++ b/src/closures/sample_closure.rs
@@ -152,6 +152,7 @@ pub extern "C" fn z_closure_sample_loan_mut(
 ///   - `call` will never be called once `drop` has started.
 ///   - `drop` will only be called **once**, and **after every** `call` has ended.
 ///   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+///
 /// @param this_: uninitialized memory location where new closure will be constructed.
 /// @param call: a closure body.
 /// @param drop: an optional function to be called once on closure drop.

--- a/src/closures/zenohid_closure.rs
+++ b/src/closures/zenohid_closure.rs
@@ -147,6 +147,7 @@ pub extern "C" fn z_closure_zid_loan_mut(
 ///   - `call` will never be called once `drop` has started.
 ///   - `drop` will only be called **once**, and **after every** `call` has ended.
 ///   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+///
 /// @param this_: uninitialized memory location where new closure will be constructed.
 /// @param call: a closure body.
 /// @param drop: an optional function to be called once on closure drop.

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,7 +73,7 @@ decl_c_type!(
 
 /// Borrows config.
 #[no_mangle]
-pub extern "C" fn z_config_loan(this_: &'static z_owned_config_t) -> &z_loaned_config_t {
+pub extern "C" fn z_config_loan(this_: &'static z_owned_config_t) -> &'static z_loaned_config_t {
     let this = this_.as_rust_type_ref();
     let this = unsafe { this.as_ref().unwrap_unchecked() };
     this.as_loaned_c_type_ref()

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -136,7 +136,7 @@ pub unsafe extern "C" fn z_encoding_to_string(
     out_str: &mut MaybeUninit<z_owned_string_t>,
 ) {
     let s: Cow<'static, str> = this.as_rust_type_ref().into();
-    z_string_copy_from_substr(out_str, s.as_bytes().as_ptr() as _, s.as_bytes().len());
+    z_string_copy_from_substr(out_str, s.as_bytes().as_ptr() as _, s.len());
 }
 
 /// Returns a loaned default `z_loaned_encoding_t`.

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -449,13 +449,7 @@ pub unsafe extern "C" fn z_keyexpr_as_view_string(
     out_string: &mut MaybeUninit<z_view_string_t>,
 ) {
     let this = this.as_rust_type_ref();
-    unsafe {
-        z_view_string_from_substr(
-            out_string,
-            this.as_bytes().as_ptr() as _,
-            this.len(),
-        )
-    };
+    unsafe { z_view_string_from_substr(out_string, this.as_bytes().as_ptr() as _, this.len()) };
 }
 
 /// Constructs and declares a key expression on the network. This reduces key key expression to a numerical id,

--- a/src/keyexpr.rs
+++ b/src/keyexpr.rs
@@ -72,7 +72,7 @@ fn keyexpr_create_inner(
         if should_auto_canonize {
             name.canonize();
         }
-        return keyexpr::new(name).map(|k| k.into());
+        keyexpr::new(name).map(|k| k.into())
     }
 }
 
@@ -453,7 +453,7 @@ pub unsafe extern "C" fn z_keyexpr_as_view_string(
         z_view_string_from_substr(
             out_string,
             this.as_bytes().as_ptr() as _,
-            this.as_bytes().len(),
+            this.len(),
         )
     };
 }

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -75,7 +75,7 @@ pub extern "C" fn z_internal_query_check(query: &z_owned_query_t) -> bool {
 /// Borrows the query.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_query_loan(this_: &'static z_owned_query_t) -> &z_loaned_query_t {
+pub unsafe extern "C" fn z_query_loan(this_: &'static z_owned_query_t) -> &'static z_loaned_query_t {
     this_
         .as_rust_type_ref()
         .as_ref()
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn z_query_loan(this_: &'static z_owned_query_t) -> &z_loa
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn z_query_loan_mut(
     this_: &'static mut z_owned_query_t,
-) -> &mut z_loaned_query_t {
+) -> &'static mut z_loaned_query_t {
     this_
         .as_rust_type_mut()
         .as_mut()

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -75,7 +75,9 @@ pub extern "C" fn z_internal_query_check(query: &z_owned_query_t) -> bool {
 /// Borrows the query.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn z_query_loan(this_: &'static z_owned_query_t) -> &'static z_loaned_query_t {
+pub unsafe extern "C" fn z_query_loan(
+    this_: &'static z_owned_query_t,
+) -> &'static z_loaned_query_t {
     this_
         .as_rust_type_ref()
         .as_ref()

--- a/src/querying_subscriber.rs
+++ b/src/querying_subscriber.rs
@@ -204,7 +204,6 @@ pub unsafe extern "C" fn ze_querying_subscriber_get(
     selector: &z_loaned_keyexpr_t,
     options: Option<&mut z_get_options_t>,
 ) -> result::z_result_t {
-    unsafe impl Sync for z_get_options_t {}
     let sub = this.as_rust_type_ref();
     let session = sub.1;
     let selector = selector.as_rust_type_ref().clone();

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -13,15 +13,15 @@
 //
 use std::mem::MaybeUninit;
 
-use async_std::task;
 use zenoh::{
     config::{WhatAmI, WhatAmIMatcher},
     scouting::Hello,
 };
+use zenoh_runtime::ZRuntime;
 
 pub use crate::opaque_types::{z_loaned_hello_t, z_moved_hello_t, z_owned_hello_t};
 use crate::{
-    result::{self, Z_OK},
+    result,
     transmute::{IntoCType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_closure_hello_call, z_closure_hello_loan, z_id_t, z_moved_closure_hello_t, z_moved_config_t,
     z_owned_string_array_t, z_view_string_t, CString, CStringView, ZVector,
@@ -190,8 +190,12 @@ pub extern "C" fn z_scout(
 ) -> result::z_result_t {
     let callback = callback.take_rust_type();
     let options = options.cloned().unwrap_or_default();
-    let what =
-        WhatAmIMatcher::try_from(options.what as u8).unwrap_or(WhatAmI::Router | WhatAmI::Peer);
+
+    let Ok(what) = WhatAmIMatcher::try_from(options.what as u8) else {
+        tracing::error!("Invalid WhatAmIMatcher value: {:?}", options.what);
+        return result::Z_EINVAL;
+    };
+
     #[allow(clippy::unnecessary_cast)] // Required for multi-target
     let timeout = options.timeout_ms;
     let Some(config) = config.take_rust_type() else {
@@ -199,20 +203,27 @@ pub extern "C" fn z_scout(
         return result::Z_EINVAL;
     };
 
-    task::block_on(async move {
-        let scout = zenoh::scout(what, config)
+    ZRuntime::Application.block_in_place(async move {
+        let res = zenoh::scout(what, config)
             .callback(move |h| {
                 let mut owned_h = Some(h);
                 z_closure_hello_call(z_closure_hello_loan(&callback), unsafe {
                     owned_h.as_mut().unwrap_unchecked().as_loaned_c_type_mut()
                 })
             })
-            .await
-            .unwrap();
-        async_std::task::sleep(std::time::Duration::from_millis(timeout)).await;
-        std::mem::drop(scout);
-    });
-    Z_OK
+            .await;
+
+        match res {
+            Ok(_) => {
+                tokio::time::sleep(std::time::Duration::from_millis(timeout)).await;
+                result::Z_OK
+            }
+            Err(e) => {
+                tracing::error!("{}", e);
+                result::Z_EGENERIC
+            }
+        }
+    })
 }
 
 /// Constructs a non-owned non-null-terminated string from the kind of zenoh entity.

--- a/src/session.rs
+++ b/src/session.rs
@@ -85,7 +85,7 @@ pub extern "C" fn z_open(
     _options: Option<&z_open_options_t>,
 ) -> result::z_result_t {
     let this = this.as_rust_type_mut_uninit();
-    let Some(config) = config.take_rust_type().take() else {
+    let Some(config) = config.take_rust_type() else {
         tracing::error!("Config not provided");
         this.write(None);
         return result::Z_EINVAL;

--- a/src/shm/buffer/zshm.rs
+++ b/src/shm/buffer/zshm.rs
@@ -36,7 +36,7 @@ pub extern "C" fn z_shm_from_mut(
     this_: &mut MaybeUninit<z_owned_shm_t>,
     that: &mut z_moved_shm_mut_t,
 ) {
-    let shm: Option<ZShm> = that.take_rust_type().take().map(|val| val.into());
+    let shm: Option<ZShm> = that.take_rust_type().map(|val| val.into());
     this_.as_rust_type_mut_uninit().write(shm);
 }
 

--- a/src/shm/cleanup.rs
+++ b/src/shm/cleanup.rs
@@ -23,6 +23,7 @@ use zenoh::shm::cleanup_orphaned_shm_segments;
 /// There is no ideal signal to trigger this cleanup, so by default, zenoh triggers it in the following moments:
 /// - first POSIX SHM segment creation
 /// - process exit via exit() call or return from maint function
+///
 /// It is OK to additionally trigger this function at any time, but be aware that this can be costly.
 ///
 /// For non-linux platforms this function currently does nothing


### PR DESCRIPTION
Fix clippy warnings.

What is left out: 
```
$ cargo +stable clippy --all-features --all-targets --fix --lib -p zenoh-c --allow-dirty
   Compiling zenoh-c v1.2.1 (/Users/luca/Repository/eclipse-zenoh-c)
warning: manually constructing a nul-terminated string
  --> src/config.rs:33:53
   |
33 | pub static Z_CONFIG_MODE_KEY: &c_char = unsafe { &*(b"mode\0".as_ptr() as *const c_char) };
   |                                                     ^^^^^^^^^ help: use a `c""` literal: `c"mode"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals
   = note: `#[warn(clippy::manual_c_str_literals)]` on by default

warning: manually constructing a nul-terminated string
  --> src/config.rs:36:17
   |
36 |     unsafe { &*(b"connect/endpoints\0".as_ptr() as *const c_char) };
   |                 ^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"connect/endpoints"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals

warning: manually constructing a nul-terminated string
  --> src/config.rs:39:17
   |
39 |     unsafe { &*(b"listen/endpoints\0".as_ptr() as *const c_char) };
   |                 ^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"listen/endpoints"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals

warning: manually constructing a nul-terminated string
  --> src/config.rs:42:17
   |
42 |     unsafe { &*(b"transport/auth/usrpwd/user\0".as_ptr() as *const c_char) };
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"transport/auth/usrpwd/user"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals

warning: manually constructing a nul-terminated string
  --> src/config.rs:45:17
   |
45 |     unsafe { &*(b"transport/auth/usrpwd/password\0".as_ptr() as *const c_char) };
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"transport/auth/usrpwd/password"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals

warning: manually constructing a nul-terminated string
  --> src/config.rs:48:17
   |
48 |     unsafe { &*(b"scouting/multicast/enabled\0".as_ptr() as *const c_char) };
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"scouting/multicast/enabled"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals

warning: manually constructing a nul-terminated string
  --> src/config.rs:51:17
   |
51 |     unsafe { &*(b"scouting/multicast/interface\0".as_ptr() as *const c_char) };
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"scouting/multicast/interface"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals

warning: manually constructing a nul-terminated string
  --> src/config.rs:54:17
   |
54 |     unsafe { &*(b"scouting/multicast/address\0".as_ptr() as *const c_char) };
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"scouting/multicast/address"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals

warning: manually constructing a nul-terminated string
  --> src/config.rs:57:17
   |
57 |     unsafe { &*(b"scouting/timeout\0".as_ptr() as *const c_char) };
   |                 ^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"scouting/timeout"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals

warning: manually constructing a nul-terminated string
  --> src/config.rs:60:17
   |
60 |     unsafe { &*(b"scouting/delay\0".as_ptr() as *const c_char) };
   |                 ^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"scouting/delay"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals

warning: manually constructing a nul-terminated string
  --> src/config.rs:63:17
   |
63 |     unsafe { &*(b"timestamping/enabled\0".as_ptr() as *const c_char) };
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"timestamping/enabled"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals

warning: manually constructing a nul-terminated string
  --> src/config.rs:66:17
   |
66 |     unsafe { &*(b"transport/shared_memory/enabled\0".as_ptr() as *const c_char) };
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"transport/shared_memory/enabled"`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals

warning: `zenoh-c` (lib test) generated 12 warnings
warning: `zenoh-c` (lib) generated 12 warnings (12 duplicates)
```

In order to fix the above problem, https://github.com/p-avital/validated-struct-macros-rs/pull/2 should be merged and [validated-struct-macros-rs](https://github.com/p-avital/validated-struct-macros-rs) be released with updated dependencies.