### PR TITLE
fix: add ci check for rust 1.75

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,29 @@ jobs:
       - name: Run clang-format dry-run
         run: find include/ src/ tests/ examples/ -iname "*.h" -o -iname "*.c" | xargs clang-format -n -Werror
 
+  check_rust:
+    name: Check zenoh-c using Rust 1.75
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
+      - name: Update Rust 1.75.0 toolchain
+        run: rustup update 1.75.0
+
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+
+      - name: Check zenoh with rust 1.75.0
+        run: cargo +1.75.0 check --release --bins --lib
+
   build:
     name: "Build on ${{ matrix.os }} shm: ${{ matrix.shm }} unstable: ${{ matrix.unstable }}"
     runs-on: ${{ matrix.os }}
@@ -249,7 +272,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: [build, cross-compile-mac-os, cross-compile-ubuntu, markdown_lint]
+    needs: [check_rust, build, cross-compile-mac-os, cross-compile-ubuntu, markdown_lint]
     if: always()
     steps:
       - name: Check whether all jobs pass


### PR DESCRIPTION
With the toolchain bump proposed in https://github.com/eclipse-zenoh/zenoh-c/pull/933, we need to guarantee zenoh-c can still be built on rust 1.75