### PR TITLE
cmake: add USES_TERMINAL in custom command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ add_custom_command(
 	VERBATIM
 	COMMAND_EXPAND_LISTS
 	DEPENDS "${rust_sources}"
+	USES_TERMINAL
 )
 add_custom_target(cargo ALL DEPENDS "${libs}")
 


### PR DESCRIPTION
As the cargo build take long time when Ninja backend is used we have no informations on the build progress. It might be usefull for CI purpose and make smooth piping and parsing (as in Yocto integration).