### PR TITLE
Rust entrypoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ phf = { version = "0.11.2", features = ["macros"] }
 
 [lib]
 path = "src/lib.rs"
-name = "zenohcd"
+name = "zenohc"
 crate-type = ["cdylib", "staticlib"]
 doctest = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 chrono = "0.4.37"
+ctor = "0.4.1"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 libc = "0.2.139"
@@ -91,7 +92,7 @@ phf = { version = "0.11.2", features = ["macros"] }
 
 [lib]
 path = "src/lib.rs"
-name = "zenohc"
+name = "zenohcd"
 crate-type = ["cdylib", "staticlib"]
 doctest = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 chrono = "0.4.37"
-ctor = "0.4.1"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 libc = "0.2.139"
@@ -79,6 +78,9 @@ zenoh-ext = { version = "1.3.2", git = "https://github.com/eclipse-zenoh/zenoh.g
 zenoh-runtime = { version = "1.3.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-util = { version = "1.3.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 flume = "*"
+
+[target.'cfg(unix)'.dependencies]
+ctor = "0.4.1"
 
 [build-dependencies]
 zenoh = { version = "1.3.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features = ["internal"] }

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -64,6 +64,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 chrono = "0.4.37"
+ctor = "0.4.1"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 libc = "0.2.139"

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -64,7 +64,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 chrono = "0.4.37"
-ctor = "0.4.1"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 libc = "0.2.139"
@@ -79,6 +78,9 @@ zenoh-ext = { version = "1.3.2", git = "https://github.com/eclipse-zenoh/zenoh.g
 zenoh-runtime = { version = "1.3.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-util = { version = "1.3.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 flume = "*"
+
+[target.'cfg(unix)'.dependencies]
+ctor = "0.4.1"
 
 [build-dependencies]
 zenoh = { version = "1.3.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features = ["internal"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ mod serialization;
 // there will be no rusty `lang_start` entry point and our rusty code will run without some initialization
 // that is done there. In most of the cases this is OK, but sometimes lack of this initialization bites us.
 // This entry point is made as a replacement for our case and contains some necessary init.
+#[cfg(unix)]
 #[ctor::ctor]
 fn alternative_rusty_entry_point() {
     // See

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,26 @@ pub mod shm;
 
 mod serialization;
 
+// This is the entry point for zenoh-c
+// When compiling normal Rust executable, it includes rusty entry point `lang_start` that internally
+// calls `std::rt::init()` that is intended to initialize some of the internals for Rust and std.
+// However, when Rust library is used with non-rusty executable (this is exactly zenoh-c's case),
+// there will be no rusty `lang_start` entry point and our rusty code will run without some initialization
+// that is done there. In most of the cases this is OK, but sometimes lack of this initialization bites us.
+// This entry point is made as a replacement for our case and contains some necessary init.
+#[ctor::ctor]
+fn alternative_rusty_entry_point() {
+    // See
+    // https://github.com/eclipse-zenoh/zenoh-c/issues/294#issuecomment-2783671006
+    // and
+    // https://github.com/rust-lang/rust/issues/62569
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+    }
+
+    // TODO: do we need to call zenoh::try_init_log_from_env(); here???
+}
+
 /// Initializes the zenoh runtime logger, using rust environment settings.
 /// E.g.: `RUST_LOG=info` will enable logging at info level. Similarly, you can set the variable to `error` or `debug`.
 ///


### PR DESCRIPTION
Fixes #294 

Adds entrypoint `alternative_rusty_entry_point()` and installs SIGPIPE to be ignored there

Tested manually with static and shared library