### PR TITLE
replace extern const strings with macro defines

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -1399,18 +1399,6 @@ typedef struct ze_moved_serializer_t {
 ZENOHC_API extern const unsigned int Z_ROUTER;
 ZENOHC_API extern const unsigned int Z_PEER;
 ZENOHC_API extern const unsigned int Z_CLIENT;
-ZENOHC_API extern const char *Z_CONFIG_MODE_KEY;
-ZENOHC_API extern const char *Z_CONFIG_CONNECT_KEY;
-ZENOHC_API extern const char *Z_CONFIG_LISTEN_KEY;
-ZENOHC_API extern const char *Z_CONFIG_USER_KEY;
-ZENOHC_API extern const char *Z_CONFIG_PASSWORD_KEY;
-ZENOHC_API extern const char *Z_CONFIG_MULTICAST_SCOUTING_KEY;
-ZENOHC_API extern const char *Z_CONFIG_MULTICAST_INTERFACE_KEY;
-ZENOHC_API extern const char *Z_CONFIG_MULTICAST_IPV4_ADDRESS_KEY;
-ZENOHC_API extern const char *Z_CONFIG_SCOUTING_TIMEOUT_KEY;
-ZENOHC_API extern const char *Z_CONFIG_SCOUTING_DELAY_KEY;
-ZENOHC_API extern const char *Z_CONFIG_ADD_TIMESTAMP_KEY;
-ZENOHC_API extern const char *Z_CONFIG_SHARED_MEMORY_KEY;
 /**
  * @warning This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  * @brief Protocol identifier for POSIX SHM Protocol.

--- a/include/zenoh_constants.h
+++ b/include/zenoh_constants.h
@@ -18,3 +18,17 @@
 #define Z_QUERY_TARGET_DEFAULT Z_QUERY_TARGET_BEST_MATCHING
 #define Z_RELIABILITY_DEFAULT Z_RELIABILITY_RELIABLE
 #define Z_SAMPLE_KIND_DEFAULT Z_SAMPLE_KIND_PUT
+
+// config keys
+#define Z_CONFIG_MODE_KEY "mode"
+#define Z_CONFIG_CONNECT_KEY "connect/endpoints"
+#define Z_CONFIG_LISTEN_KEY "listen/endpoints"
+#define Z_CONFIG_USER_KEY "transport/auth/usrpwd/user"
+#define Z_CONFIG_PASSWORD_KEY "transport/auth/usrpwd/password"
+#define Z_CONFIG_MULTICAST_SCOUTING_KEY "scouting/multicast/enabled"
+#define Z_CONFIG_MULTICAST_INTERFACE_KEY "scouting/multicast/interface"
+#define Z_CONFIG_MULTICAST_IPV4_ADDRESS_KEY "scouting/multicast/address"
+#define Z_CONFIG_SCOUTING_DELAY_KEY "scouting/delay"
+#define Z_CONFIG_SCOUTING_TIMEOUT_KEY "scouting/timeout"
+#define Z_CONFIG_ADD_TIMESTAMP_KEY "timestamping/enabled"
+#define Z_CONFIG_SHARED_MEMORY_KEY "transport/shared_memory/enabled"

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,54 +29,6 @@ pub static Z_PEER: c_uint = WhatAmI::Peer as c_uint;
 #[no_mangle]
 pub static Z_CLIENT: c_uint = WhatAmI::Client as c_uint;
 
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_MODE_KEY: &c_char = unsafe { &*(b"mode\0".as_ptr() as *const c_char) };
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_CONNECT_KEY: &c_char =
-    unsafe { &*(b"connect/endpoints\0".as_ptr() as *const c_char) };
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_LISTEN_KEY: &c_char =
-    unsafe { &*(b"listen/endpoints\0".as_ptr() as *const c_char) };
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_USER_KEY: &c_char =
-    unsafe { &*(b"transport/auth/usrpwd/user\0".as_ptr() as *const c_char) };
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_PASSWORD_KEY: &c_char =
-    unsafe { &*(b"transport/auth/usrpwd/password\0".as_ptr() as *const c_char) };
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_MULTICAST_SCOUTING_KEY: &c_char =
-    unsafe { &*(b"scouting/multicast/enabled\0".as_ptr() as *const c_char) };
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_MULTICAST_INTERFACE_KEY: &c_char =
-    unsafe { &*(b"scouting/multicast/interface\0".as_ptr() as *const c_char) };
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_MULTICAST_IPV4_ADDRESS_KEY: &c_char =
-    unsafe { &*(b"scouting/multicast/address\0".as_ptr() as *const c_char) };
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_SCOUTING_TIMEOUT_KEY: &c_char =
-    unsafe { &*(b"scouting/timeout\0".as_ptr() as *const c_char) };
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_SCOUTING_DELAY_KEY: &c_char =
-    unsafe { &*(b"scouting/delay\0".as_ptr() as *const c_char) };
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_ADD_TIMESTAMP_KEY: &c_char =
-    unsafe { &*(b"timestamping/enabled\0".as_ptr() as *const c_char) };
-#[allow(clippy::all)] // For 1.75 compatibility
-#[no_mangle]
-pub static Z_CONFIG_SHARED_MEMORY_KEY: &c_char =
-    unsafe { &*(b"transport/shared_memory/enabled\0".as_ptr() as *const c_char) };
-
 pub use crate::opaque_types::{z_loaned_config_t, z_moved_config_t, z_owned_config_t};
 decl_c_type!(
     owned(z_owned_config_t, option Config),


### PR DESCRIPTION
replace extern const strings with macro defines since these constants are not correctly exported on windows
Resolves https://github.com/eclipse-zenoh/zenoh-cpp/issues/468