### PR TITLE
styles: remove the trailing spaces in cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,9 @@ status_print(project_version)
 #
 # There are 3 possible variants of placement generated Cargo.toml files:
 # 1. Build in source tree (in IDE usually), using single config generator (Ninja, Makefiles)
-#    
+#
 #    In this case Cargo.toml is placed at the root of source tree to make it visible for rust-analyzer. When release or debug
-#    configuration is selected, Cargo.toml is updated accordingly 
+#    configuration is selected, Cargo.toml is updated accordingly
 #
 # 2. Build in source tree (in IDE usually), using multi config generator (Visual Studio, Ninja Multi-Config)
 #
@@ -123,7 +123,7 @@ function(configure_cargo_toml cargo_toml_dir CARGO_PROJECT_VERSION CARGO_LIB_NAM
 			${CMAKE_CURRENT_SOURCE_DIR}/include/zenoh_memory.h
 			${CMAKE_CURRENT_SOURCE_DIR}/include/zenoh_constants.h
 			DESTINATION ${cargo_toml_dir}/include/)
-	endif()	
+	endif()
 	configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml.in" "${cargo_toml_dir}/Cargo.toml" @ONLY)
 endfunction()
 
@@ -215,9 +215,9 @@ set_genexpr_condition(libs DEBUG $<CONFIG:Debug> "${libsd}" "${libsr}")
 #
 
 # Combine "--release" and "--manifest-path" options under DEBUG condition to avoid passing empty parameter to cargo command line in `add_custom_command`, causing build failure
-# This empty item ($<IF:$<CONFIG:Debug>;,--release>) can't be filtered out by `list(FILTER ...)` because it becomes empty only on 
+# This empty item ($<IF:$<CONFIG:Debug>;,--release>) can't be filtered out by `list(FILTER ...)` because it becomes empty only on
 # build stage when generator expressions are evaluated.
-set_genexpr_condition(cargo_flags DEBUG $<CONFIG:Debug> 
+set_genexpr_condition(cargo_flags DEBUG $<CONFIG:Debug>
 	"--manifest-path=${cargo_toml_dir_debug}/Cargo.toml"
 	"--release;--manifest-path=${cargo_toml_dir_release}/Cargo.toml")
 set(cargo_flags ${cargo_flags} ${ZENOHC_CARGO_FLAGS})
@@ -327,4 +327,3 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
 	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${cargo_binary_dir}/examples)
 	add_subdirectory(examples)
 endif()
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -3629,7 +3629,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "tracing",
  "uhlc",
@@ -3678,12 +3678,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 
 [[package]]
 name = "zenoh-config"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "aes",
  "hmac",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3750,7 +3750,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "getrandom 0.2.15",
  "hashbrown 0.14.5",
@@ -3765,7 +3765,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "flume",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-serial"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3871,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3900,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixpipe"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-vsock"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "libc",
@@ -3977,7 +3977,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3997,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4008,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "git-version",
  "libloading",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "anyhow",
 ]
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -4085,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "futures",
  "tokio",
@@ -4112,7 +4112,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -4146,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "const_format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1783,7 +1783,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1881,13 +1881,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3650,7 +3649,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "phf",
- "rand 0.9.0",
+ "rand 0.9.1",
  "regex",
  "serde_yaml",
  "spin",
@@ -4178,16 +4177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
-dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -4195,17 +4185,6 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -3629,7 +3629,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "tracing",
  "uhlc",
@@ -3678,12 +3678,15 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "zenoh-config"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -3707,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3718,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "aes",
  "hmac",
@@ -3731,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3750,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "getrandom 0.2.15",
  "hashbrown 0.14.5",
@@ -3765,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3785,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "flume",
@@ -3809,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3836,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-serial"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3854,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3871,7 +3874,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3900,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3919,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixpipe"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -3941,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -3959,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-vsock"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "libc",
@@ -3977,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3997,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4008,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "git-version",
  "libloading",
@@ -4024,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -4038,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "anyhow",
 ]
@@ -4046,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4060,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -4085,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -4099,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "futures",
  "tokio",
@@ -4112,7 +4115,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -4146,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "const_format",

--- a/build-resources/opaque-types/Cargo.lock
+++ b/build-resources/opaque-types/Cargo.lock
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -3321,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3329,7 +3329,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "tracing",
  "uhlc",
@@ -3341,12 +3341,15 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "zenoh-config"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -3370,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3381,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "aes",
  "hmac",
@@ -3394,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3413,7 +3416,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "getrandom",
  "hashbrown 0.14.5",
@@ -3428,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3448,7 +3451,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "flume",
@@ -3472,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3499,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-serial"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3517,7 +3520,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3534,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3563,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3582,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixpipe"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -3604,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -3622,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-vsock"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "libc",
@@ -3640,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3660,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3671,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "git-version",
  "libloading",
@@ -3687,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "const_format",
  "rand",
@@ -3701,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "anyhow",
 ]
@@ -3709,7 +3712,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "lazy_static",
  "ron",
@@ -3723,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -3748,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -3762,7 +3765,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "futures",
  "tokio",
@@ -3775,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -3809,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#83b874e4255b9aba5398b152749a79c1947820f1"
 dependencies = [
  "async-trait",
  "const_format",

--- a/build-resources/opaque-types/Cargo.lock
+++ b/build-resources/opaque-types/Cargo.lock
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -3321,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3329,7 +3329,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "tracing",
  "uhlc",
@@ -3341,12 +3341,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 
 [[package]]
 name = "zenoh-config"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3381,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "aes",
  "hmac",
@@ -3394,7 +3394,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "getrandom",
  "hashbrown 0.14.5",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3448,7 +3448,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "flume",
@@ -3472,7 +3472,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-serial"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3517,7 +3517,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3534,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3563,7 +3563,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3582,7 +3582,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixpipe"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -3604,7 +3604,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-vsock"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "libc",
@@ -3640,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3671,7 +3671,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "git-version",
  "libloading",
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "const_format",
  "rand",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "anyhow",
 ]
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "lazy_static",
  "ron",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "futures",
  "tokio",
@@ -3775,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.3.3"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#9ad5304e593b4cd425a90e44bd5d70ba66836744"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#037c5466d9bbfb22dfc019bb491c3fe10237a2e0"
 dependencies = [
  "async-trait",
  "const_format",


### PR DESCRIPTION
There're couple unnecessary trailing spaces in CMakeLists.txt file. Remove them to make cmake formatter happy