### PR TITLE
ci: use different musl.cc mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,10 +197,10 @@ jobs:
           sudo apt-get install -y mingw-w64
           sudo apt-get install -y gcc-aarch64-linux-gnu
           sudo apt-get install -y g++-aarch64-linux-gnu
-          wget https://musl.cc/aarch64-linux-musl-cross.tgz
+          wget https://github.com/ZettaScaleLabs/muslcc/raw/refs/heads/main/aarch64-linux-musl-cross.tgz?download= -O aarch64-linux-musl-cross.tgz
           tar xvfz aarch64-linux-musl-cross.tgz
           echo "$(readlink -f aarch64-linux-musl-cross)/bin" >> "$GITHUB_PATH"
-          wget https://musl.cc/x86_64-linux-musl-cross.tgz
+          wget https://github.com/ZettaScaleLabs/muslcc/raw/refs/heads/main/x86_64-linux-musl-cross.tgz?download= -O x86_64-linux-musl-cross.tgz
           tar xvfz x86_64-linux-musl-cross.tgz
           echo "$(readlink -f x86_64-linux-musl-cross)/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
         if: ${{ matrix.build.target == 'x86_64-unknown-linux-musl'}}
         run: |
           sudo apt-get install -y musl-tools
-          wget https://musl.cc/x86_64-linux-musl-cross.tgz
+          wget https://github.com/ZettaScaleLabs/muslcc/raw/refs/heads/main/x86_64-linux-musl-cross.tgz?download= -O x86_64-linux-musl-cross.tgz
           tar xvfz x86_64-linux-musl-cross.tgz
           echo "$(readlink -f x86_64-linux-musl-cross)/bin" >> "$GITHUB_PATH"
 
@@ -133,7 +133,7 @@ jobs:
       - name: Install build deps
         if: ${{ matrix.build.target == 'aarch64-unknown-linux-musl'}}
         run: |
-          wget https://musl.cc/aarch64-linux-musl-cross.tgz
+          wget https://github.com/ZettaScaleLabs/muslcc/raw/refs/heads/main/aarch64-linux-musl-cross.tgz?download= -O aarch64-linux-musl-cross.tgz
           tar xvfz aarch64-linux-musl-cross.tgz
           echo "$(readlink -f aarch64-linux-musl-cross)/bin" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
ZettaScaleLabs/muslcc has a copy of the
[aarch64,x86_64]-linux-musl-cross.tgz so those can be used in the zenoh-c workflows which avoids hammering the upstream site.