### PR TITLE
examples: don't ignore return status code

### DIFF
--- a/examples/z_ping_shm.c
+++ b/examples/z_ping_shm.c
@@ -41,20 +41,33 @@ int main(int argc, char** argv) {
     z_condvar_init(&cond);
 
     z_owned_session_t session;
-    z_open(&session, z_move(config), NULL);
+    if (z_open(&session, z_move(config), NULL) < 0) {
+        printf("Unable to open session!\n");
+        exit(-1);
+    }
+
     z_view_keyexpr_t ping;
     z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_view_keyexpr_t pong;
     z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
-    z_owned_publisher_t pub;
     z_publisher_options_t opts;
     z_publisher_options_default(&opts);
     opts.is_express = !args.no_express;
-    z_declare_publisher(z_loan(session), &pub, z_loan(ping), &opts);
+
+    z_owned_publisher_t pub;
+    if (z_declare_publisher(z_loan(session), &pub, z_loan(ping), &opts) < 0) {
+        printf("Unable to declare publisher for key expression!\n");
+        exit(-1);
+    }
+
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, (void*)(&pub));
+
     z_owned_subscriber_t sub;
-    z_declare_subscriber(z_loan(session), &sub, z_loan(pong), z_move(respond), NULL);
+    if (z_declare_subscriber(z_loan(session), &sub, z_loan(pong), z_move(respond), NULL) < 0) {
+        printf("Unable to declare subscriber for key expression!\n");
+        exit(-1);
+    }
 
     // Create SHM Provider
     z_alloc_alignment_t alignment = {0};

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -65,7 +65,10 @@ int main(int argc, char** argv) {
     if (args.add_matching_listener) {
         z_owned_closure_matching_status_t callback;
         z_closure(&callback, matching_status_handler, NULL, NULL);
-        z_publisher_declare_background_matching_listener(z_loan(pub), z_move(callback));
+        if (z_publisher_declare_background_matching_listener(z_loan(pub), z_move(callback)) < 0) {
+            printf("Unable to declare background matching listener for key expression!\n");
+            exit(-1);
+        }
     }
 #endif
 

--- a/examples/z_pub_shm.c
+++ b/examples/z_pub_shm.c
@@ -62,7 +62,10 @@ int main(int argc, char** argv) {
     if (args.add_matching_listener) {
         z_owned_closure_matching_status_t callback;
         z_closure(&callback, matching_status_handler, NULL, NULL);
-        z_publisher_declare_background_matching_listener(z_loan(pub), z_move(callback));
+        if (z_publisher_declare_background_matching_listener(z_loan(pub), z_move(callback)) < 0) {
+            printf("Unable to declare background matching listener for key expression!\n");
+            exit(-1);
+        }
     }
 #endif
 

--- a/examples/z_querier.c
+++ b/examples/z_querier.c
@@ -84,7 +84,10 @@ int main(int argc, char** argv) {
     if (args.add_matching_listener) {
         z_owned_closure_matching_status_t callback;
         z_closure(&callback, matching_status_handler, NULL, NULL);
-        z_querier_declare_background_matching_listener(z_loan(querier), z_move(callback));
+        if (z_querier_declare_background_matching_listener(z_loan(querier), z_move(callback)) < 0) {
+            printf("Unable to declare background matching listener for key expression!\n");
+            exit(-1);
+        }
     }
 #endif
 


### PR DESCRIPTION
Handle the return codes in the following cases (at least):
- open session
- declare publisher
- declare subscriber

Other API calls should be handled as well later.