### PR TITLE
encoding test update

### DIFF
--- a/src/collections.rs
+++ b/src/collections.rs
@@ -449,12 +449,17 @@ pub use crate::opaque_types::{
     z_loaned_string_t, z_moved_string_t, z_owned_string_t, z_view_string_t,
 };
 
-#[derive(Clone)]
-pub struct CString(CSlice);
-pub struct CStringOwned(CString);
-pub struct CStringView(CString);
 
-impl Gravestone for CString {
+// The wrappers which provides string-related interfaces to memory slice `CSlice`
+// Unlike the standard `std:ffi::CString` these structures doesn't provide
+// any guarantees about null-termination
+
+#[derive(Clone)]
+pub struct CStringInner(CSlice);
+pub struct CStringOwned(CStringInner);
+pub struct CStringView(CStringInner);
+
+impl Gravestone for CStringInner {
     fn gravestone() -> Self {
         Self(CSlice::gravestone())
     }
@@ -465,7 +470,7 @@ impl Gravestone for CString {
 
 impl Gravestone for CStringOwned {
     fn gravestone() -> Self {
-        Self(CString::gravestone())
+        Self(CStringInner::gravestone())
     }
     fn is_gravestone(&self) -> bool {
         self.0.is_gravestone()
@@ -474,23 +479,23 @@ impl Gravestone for CStringOwned {
 
 impl Gravestone for CStringView {
     fn gravestone() -> Self {
-        Self(CString::gravestone())
+        Self(CStringInner::gravestone())
     }
     fn is_gravestone(&self) -> bool {
         self.0.is_gravestone()
     }
 }
 
-impl CString {
+impl CStringInner {
     pub fn new_borrowed_from_slice(slice: &[u8]) -> Self {
-        CString(CSlice::new_borrowed_from_slice(slice))
+        CStringInner(CSlice::new_borrowed_from_slice(slice))
     }
 }
 
 impl CStringOwned {
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn new(data: *const libc::c_char, len: usize) -> Result<Self, z_result_t> {
-        Ok(CStringOwned(CString(CSlice::new_owned(data as _, len)?)))
+        Ok(CStringOwned(CStringInner(CSlice::new_owned(data as _, len)?)))
     }
 
     #[allow(clippy::missing_safety_doc)]
@@ -500,7 +505,7 @@ impl CStringOwned {
         drop: Option<extern "C" fn(data: *mut c_void, context: *mut c_void)>,
         context: *mut c_void,
     ) -> Result<Self, z_result_t> {
-        Ok(CStringOwned(CString(CSlice::new(
+        Ok(CStringOwned(CStringInner(CSlice::new(
             data as _, len, drop, context,
         )?)))
     }
@@ -509,14 +514,14 @@ impl CStringOwned {
 impl CStringView {
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn new_borrowed(data: *const libc::c_char, len: usize) -> Result<Self, z_result_t> {
-        Ok(CStringView(CString(CSlice::new_borrowed(data as _, len)?)))
+        Ok(CStringView(CStringInner(CSlice::new_borrowed(data as _, len)?)))
     }
     pub fn new_borrowed_from_slice(slice: &[u8]) -> Self {
-        CStringView(CString::new_borrowed_from_slice(slice))
+        CStringView(CStringInner::new_borrowed_from_slice(slice))
     }
 }
 
-impl Deref for CString {
+impl Deref for CStringInner {
     type Target = CSlice;
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -524,20 +529,20 @@ impl Deref for CString {
 }
 
 impl Deref for CStringOwned {
-    type Target = CString;
+    type Target = CStringInner;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
 impl Deref for CStringView {
-    type Target = CString;
+    type Target = CStringInner;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl AsRef<CSlice> for CString {
+impl AsRef<CSlice> for CStringInner {
     fn as_ref(&self) -> &CSlice {
         &self.0
     }
@@ -558,12 +563,12 @@ impl AsRef<CSlice> for CStringView {
 impl From<String> for CStringOwned {
     fn from(value: String) -> Self {
         let slice = Box::leak(value.into_boxed_str());
-        CStringOwned(CString(CSlice::wrap(slice.as_ptr(), slice.len())))
+        CStringOwned(CStringInner(CSlice::wrap(slice.as_ptr(), slice.len())))
     }
 }
 
-impl From<CString> for CSlice {
-    fn from(value: CString) -> Self {
+impl From<CStringInner> for CSlice {
+    fn from(value: CStringInner) -> Self {
         value.0
     }
 }
@@ -576,7 +581,7 @@ impl From<CStringOwned> for CSlice {
 
 decl_c_type!(
     owned(z_owned_string_t, CStringOwned),
-    loaned(z_loaned_string_t, CString),
+    loaned(z_loaned_string_t, CStringInner),
     view(z_view_string_t, CStringView),
 );
 
@@ -764,7 +769,7 @@ pub extern "C" fn z_string_clone(
 ) {
     let slice = this.as_rust_type_ref().clone_to_owned();
     dst.as_rust_type_mut_uninit()
-        .write(CStringOwned(CString(slice.0)));
+        .write(CStringOwned(CStringInner(slice.0)));
 }
 
 // Converts loaned string into loaned slice (with terminating 0 character).
@@ -782,7 +787,7 @@ pub extern "C" fn z_string_is_empty(this_: &z_loaned_string_t) -> bool {
 pub use crate::opaque_types::{
     z_loaned_string_array_t, z_moved_string_array_t, z_owned_string_array_t,
 };
-pub type ZVector = Vec<CString>;
+pub type ZVector = Vec<CStringInner>;
 decl_c_type!(
     owned(z_owned_string_array_t, ZVector),
     loaned(z_loaned_string_array_t),
@@ -877,7 +882,7 @@ pub extern "C" fn z_string_array_push_by_copy(
 ) -> usize {
     let this = this.as_rust_type_mut();
     let v = value.as_rust_type_ref();
-    this.push(CString(v.clone_to_owned().into()));
+    this.push(CStringInner(v.clone_to_owned().into()));
 
     this.len()
 }
@@ -892,7 +897,7 @@ pub extern "C" fn z_string_array_push_by_alias(
 ) -> usize {
     let this = this.as_rust_type_mut();
     let v = value.as_rust_type_ref();
-    this.push(CString(v.clone_to_borrowed()));
+    this.push(CStringInner(v.clone_to_borrowed()));
 
     this.len()
 }

--- a/src/scouting.rs
+++ b/src/scouting.rs
@@ -24,7 +24,7 @@ use crate::{
     result,
     transmute::{IntoCType, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_closure_hello_call, z_closure_hello_loan, z_id_t, z_moved_closure_hello_t, z_moved_config_t,
-    z_owned_string_array_t, z_view_string_t, CString, CStringView, ZVector,
+    z_owned_string_array_t, z_view_string_t, CStringInner, CStringView, ZVector,
 };
 decl_c_type!(
     owned(z_owned_hello_t, option Hello ),
@@ -119,7 +119,7 @@ pub extern "C" fn z_hello_locators(
     let this = this.as_rust_type_ref();
     let mut locators = ZVector::with_capacity(this.locators().len());
     for l in this.locators().iter() {
-        locators.push(CString::new_borrowed_from_slice(l.as_str().as_bytes()));
+        locators.push(CStringInner::new_borrowed_from_slice(l.as_str().as_bytes()));
     }
     locators_out.as_rust_type_mut_uninit().write(locators);
 }

--- a/src/zbytes.rs
+++ b/src/zbytes.rs
@@ -34,7 +34,7 @@ use crate::{
     result::{self, z_result_t, Z_EINVAL, Z_EIO, Z_OK},
     transmute::{Gravestone, LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
     z_loaned_slice_t, z_loaned_string_t, z_moved_bytes_t, z_moved_slice_t, z_moved_string_t,
-    z_owned_slice_t, z_owned_string_t, z_view_slice_t, CSlice, CSliceOwned, CSliceView, CString,
+    z_owned_slice_t, z_owned_string_t, z_view_slice_t, CSlice, CSliceOwned, CSliceView, CStringInner,
     CStringOwned,
 };
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
@@ -260,8 +260,8 @@ impl From<CSliceOwned> for ZBytes {
         ZBytes::from(value)
     }
 }
-impl From<CString> for ZBytes {
-    fn from(value: CString) -> Self {
+impl From<CStringInner> for ZBytes {
+    fn from(value: CStringInner) -> Self {
         let value: CSlice = value.into();
         ZBytes::from(value)
     }

--- a/tests/z_api_encoding_test.c
+++ b/tests/z_api_encoding_test.c
@@ -8,6 +8,15 @@
 #undef NDEBUG
 #include <assert.h>
 
+#define assert_str_eq(expected, actual_str) \
+    do { \
+        const char* _expected = (expected); \
+        const z_loaned_string_t* _actual = (actual_str); \
+        size_t _expected_len = strlen(_expected); \
+        assert(z_string_len(_actual) == _expected_len); \
+        assert(strncmp(_expected, z_string_data(_actual), _expected_len) == 0); \
+    } while(0)
+
 void test_null_encoding(void) {
     z_owned_encoding_t e;
     z_internal_encoding_null(&e);
@@ -21,7 +30,7 @@ void test_encoding_without_id(void) {
     assert(z_internal_encoding_check(&e1));
     z_owned_string_t s;
     z_encoding_to_string(z_encoding_loan(&e1), &s);
-    assert(strncmp("my_encoding", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    assert_str_eq("my_encoding", z_string_loan(&s));
     z_encoding_drop(z_move(e1));
     z_string_drop(z_move(s));
 
@@ -30,7 +39,7 @@ void test_encoding_without_id(void) {
     assert(z_internal_encoding_check(&e2));
 
     z_encoding_to_string(z_encoding_loan(&e2), &s);
-    assert(strncmp("my_e", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    assert_str_eq("my_e", z_string_loan(&s));
     z_encoding_drop(z_move(e2));
     z_string_drop(z_move(s));
 }
@@ -41,16 +50,16 @@ void test_encoding_with_id(void) {
     assert(z_internal_encoding_check(&e1));
     z_owned_string_t s;
     z_encoding_to_string(z_encoding_loan(&e1), &s);
-    assert(strncmp("zenoh/string;utf8", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    assert_str_eq("zenoh/string;utf8", z_string_loan(&s));
     z_encoding_drop(z_move(e1));
     z_string_drop(z_move(s));
 
     z_owned_encoding_t e2;
-    z_encoding_from_substr(&e2, "zenoh/string;utf8", 15);
+    z_encoding_from_substr(&e2, "zenoh/string;utf8", 17);
     assert(z_internal_encoding_check(&e2));
 
     z_encoding_to_string(z_encoding_loan(&e2), &s);
-    assert(strncmp("zenoh/string;utf8", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    assert_str_eq("zenoh/string;utf8", z_string_loan(&s));
     z_encoding_drop(z_move(e2));
     z_string_drop(z_move(s));
 
@@ -59,7 +68,7 @@ void test_encoding_with_id(void) {
     assert(z_internal_encoding_check(&e3));
 
     z_encoding_to_string(z_encoding_loan(&e3), &s);
-    assert(strncmp("custom_id;custom_schema", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    assert_str_eq("custom_id;custom_schema", z_string_loan(&s));
     z_encoding_drop(z_move(e3));
     z_string_drop(z_move(s));
 
@@ -68,7 +77,7 @@ void test_encoding_with_id(void) {
     assert(z_internal_encoding_check(&e4));
 
     z_encoding_to_string(z_encoding_loan(&e4), &s);
-    assert(strncmp("custom_id;custom", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    assert_str_eq("custom_id;custom", z_string_loan(&s));
     z_encoding_drop(z_move(e4));
     z_string_drop(z_move(s));
 }
@@ -79,16 +88,16 @@ void test_with_schema(void) {
     z_encoding_set_schema_from_str(z_encoding_loan_mut(&e), "my_schema");
 
     z_owned_string_t s;
-    z_encoding_to_string(z_encoding_loan_mut(&e), &s);
+    z_encoding_to_string(z_encoding_loan(&e), &s);
 
-    assert(strncmp("my_schema", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    assert_str_eq("zenoh/bytes;my_schema", z_string_loan(&s));
     z_encoding_drop(z_move(e));
 
     z_encoding_clone(&e, z_encoding_zenoh_string());
     z_encoding_set_schema_from_substr(z_encoding_loan_mut(&e), "my_schema", 3);
 
     z_encoding_to_string(z_encoding_loan(&e), &s);
-    assert(strncmp("my_", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    assert_str_eq("zenoh/string;my_", z_string_loan(&s));
     z_encoding_drop(z_move(e));
     z_string_drop(z_move(s));
 }
@@ -96,11 +105,11 @@ void test_with_schema(void) {
 void test_constants() {
     z_owned_string_t s;
     z_encoding_to_string(z_encoding_zenoh_bytes(), &s);
-    assert(strncmp("zenoh/bytes", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    assert_str_eq("zenoh/bytes", z_string_loan(&s));
     z_string_drop(z_move(s));
 
     z_encoding_to_string(z_encoding_zenoh_string(), &s);
-    assert(strncmp("zenoh/string", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+    assert_str_eq("zenoh/string", z_string_loan(&s));
 
     z_string_drop(z_move(s));
 }
@@ -118,6 +127,6 @@ int main(int argc, char **argv) {
     test_encoding_without_id();
     test_encoding_with_id();
     test_constants();
-    // test_with_schema();
+    test_with_schema();
     test_equals();
 }


### PR DESCRIPTION
Test fix for https://github.com/eclipse-zenoh/zenoh-c/issues/1035:
- tests updated accordingly to zenoh api: "with_schema" adds schema to exising encoding, doesn't replace it
- string length compare added to test to fix false positive results

Rust code:
- renamed struct `CString` to `CStringInternal` to avoid confusion with `std::ffi::CString`