### PR TITLE
Fix build with panic="abort"

### DIFF
--- a/src/platform/synchronization.rs
+++ b/src/platform/synchronization.rs
@@ -12,7 +12,7 @@ use crate::{
     transmute::{LoanedCTypeRef, RustTypeRef, RustTypeRefUninit, TakeRustType},
 };
 
-decl_c_type!(
+decl_c_type_inequal!(
     owned(z_owned_mutex_t, option(Mutex<()>, Option<MutexGuard<'static, ()>>)),
     loaned(z_loaned_mutex_t),
 );


### PR DESCRIPTION
When building with `panic="abort"` and `std` built from source, the size of `Mutex<()>` varies when wrapped in `Option<>` or not such that the owned and loaned types have different sizes.

This is specifically due to the [`poison` flag field in `Mutex`](https://github.com/rust-lang/rust/blob/28f1c807911c63f08d98e7b468cfcf15a441e34b/library/std/src/sync/poison/mutex.rs#L177) getting [compiled out when the `panic` mode is not set to `"unwind"`](https://github.com/rust-lang/rust/blob/master/library/std/src/sync/poison.rs#L89-L92). This field's omission pushes the size of the struct to the edge of the 16 byte boundary such that niche optimization no longer has bits to fiddle with after aligning to 8 bytes.

The build fails as follows:

```
note: evaluation panicked: Size mismatch: type z_loaned_mutex_t has size 16 while type z_owned_mutex_t has size 24
```

To address, we switch to `decl_c_type_inequal!` which seems to be safe since we shouldn't be `reinterpret_cast()`-ing this type and `zenoh-cpp` doesn't seem to ever reference it.