### PR TITLE
CMP0111 requires IMPORTED_LOCATION or IMPORTED_IMPLIB being set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,24 +272,40 @@ add_custom_target(cargo ALL DEPENDS "${libs}")
 #
 
 function(set_target_imported_locations target libr libd)
+	set(_loc_debug  ${cargo_binary_dir_debug}/${libd})
+	set(_loc_release ${cargo_binary_dir_release}/${libr})
+	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+		set(_loc "${_loc_debug}")
+	else()
+		set(_loc "${_loc_release}")
+	endif()
 	set_target_properties(${target}
 		PROPERTIES
 		IMPORTED_GLOBAL TRUE
-		IMPORTED_LOCATION_DEBUG ${cargo_binary_dir_debug}/${libd}
-		IMPORTED_LOCATION_RELEASE ${cargo_binary_dir_release}/${libr}
-		IMPORTED_LOCATION_MINSIZEREL ${cargo_binary_dir_release}/${libr}
-		IMPORTED_LOCATION_RELWITHDEBINFO ${cargo_binary_dir_release}/${libr}
+		IMPORTED_LOCATION ${_loc}
+		IMPORTED_LOCATION_DEBUG ${_loc_debug}
+		IMPORTED_LOCATION_RELEASE ${_loc_release}
+		IMPORTED_LOCATION_MINSIZEREL ${_loc_release}
+		IMPORTED_LOCATION_RELWITHDEBINFO ${_loc_release}
 	)
 endfunction()
 
 function(set_target_imported_implib target libr libd)
+	set(_loc_debug  ${cargo_binary_dir_debug}/${libd})
+	set(_loc_release ${cargo_binary_dir_release}/${libr})
+	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+		set(_loc "${_loc_debug}")
+	else()
+		set(_loc "${_loc_release}")
+	endif()
 	set_target_properties(${target}
 		PROPERTIES
 		IMPORTED_GLOBAL TRUE
-		IMPORTED_IMPLIB_DEBUG ${cargo_binary_dir_debug}/${libd}
-		IMPORTED_IMPLIB_RELEASE ${cargo_binary_dir_release}/${libr}
-		IMPORTED_IMPLIB_MINSIZEREL ${cargo_binary_dir_release}/${libr}
-		IMPORTED_IMPLIB_RELWITHDEBINFO ${cargo_binary_dir_release}/${libr}
+		IMPORTED_IMPLIB ${_loc}
+		IMPORTED_IMPLIB_DEBUG ${_loc_debug}
+		IMPORTED_IMPLIB_RELEASE ${_loc_release}
+		IMPORTED_IMPLIB_MINSIZEREL ${_loc_release}
+		IMPORTED_IMPLIB_RELWITHDEBINFO ${_loc_release}
 	)
 endfunction()
 


### PR DESCRIPTION
When using `zenohc` via cmake's `FetchContent` mechanism,
I get the following warnings:

```
CMake Warning (dev) in build/_deps/zenohc-src/CMakeLists.txt:
  Policy CMP0111 is not set: An imported target missing its location property
  fails during generation.  Run "cmake --help-policy CMP0111" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  IMPORTED_LOCATION or IMPORTED_IMPLIB not set for imported target
  "zenohc_shared".
```

and on linking,

```
ninja: error: 'zenohc_shared-NOTFOUND', needed by 'myexecutable', missing and no known rule to make it
```

Apparently, the `IMPORTED_LOCATION` is really needed ;)
This change sets the correct library and makes the linking work fine for me.

Please note: While a generator expression would be nicer, we sadly have to evaluate the expression at configure-time.