### PR TITLE
ci: update release workflow to use latest runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,17 +80,17 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-24.04 }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-24.04 }
-          - { target: arm-unknown-linux-gnueabi, os: ubuntu-24.04 }
-          - { target: arm-unknown-linux-gnueabihf, os: ubuntu-24.04 }
-          - { target: armv7-unknown-linux-gnueabihf, os: macos-14 }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-24.04 }
-          - { target: aarch64-unknown-linux-musl, os: ubuntu-24.04 }
-          - { target: x86_64-apple-darwin, os: macos-14 }
-          - { target: aarch64-apple-darwin, os: macos-14 }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019 }
-          - { target: x86_64-pc-windows-gnu, os: ubuntu-24.04 }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-latest }
+          - { target: arm-unknown-linux-gnueabi, os: ubuntu-latest }
+          - { target: arm-unknown-linux-gnueabihf, os: ubuntu-latest }
+          - { target: armv7-unknown-linux-gnueabihf, os: macos-latest }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-latest }
+          - { target: aarch64-unknown-linux-musl, os: ubuntu-latest }
+          - { target: x86_64-apple-darwin, os: macos-latest }
+          - { target: aarch64-apple-darwin, os: macos-latest }
+          - { target: x86_64-pc-windows-msvc, os: windows-latest}
+          - { target: x86_64-pc-windows-gnu, os: ubuntu-latest }
     needs: tag
     steps:
       - name: Checkout this repository


### PR DESCRIPTION
More specifically the windows-2019 got deprecated which causes the release workflow to be cancelled.