### PR TITLE
fix: MSVC Error C2059

### DIFF
--- a/examples/z_advanced_pub.c
+++ b/examples/z_advanced_pub.c
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
     }
 
     printf("Press CTRL-C to quit...\n");
-    char buf[256] = {};
+    char buf[256] = {0};
     for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);
         sprintf(buf, "[%4d] %s", idx, args.value);

--- a/examples/z_pub.c
+++ b/examples/z_pub.c
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
     }
 
     printf("Press CTRL-C to quit...\n");
-    char buf[256] = {};
+    char buf[256] = {0};
     for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);
         sprintf(buf, "[%4d] %s", idx, args.value);

--- a/examples/z_querier.c
+++ b/examples/z_querier.c
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
     }
 
     printf("Press CTRL-C to quit...\n");
-    char buf[256] = {};
+    char buf[256] = {0};
     for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);
         sprintf(buf, "[%4d] %s", idx, args.value ? args.value : "");


### PR DESCRIPTION
The following syntax is fine in C++ but causes MSVC Error C2059 (syntax error) in C.
The standard way is to initialize it with `{0}`.

```c
char buf[256] = {};
```


```txt
Microsoft (R) Build Engine version 16.11.2+f32259642 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

C:\dev\zenoh-c\examples\z_pub.c(72,22): error C2059: syntax error: '}' [C:\dev\zenoh-c\build\examples\z_pub.vcxproj]
C:\dev\zenoh-c\examples\z_querier.c(91,22): error C2059: syntax error: '}' [C:\dev\zenoh-c\build\examples\z_querier.vcxproj]
```
