### PR TITLE
dependency on zenoh-pinned-deps-1-75 added

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ zenoh = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git",
 zenoh-ext = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features=["internal"] }
 zenoh-runtime = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-util = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh-pinned-deps-1-75 = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 flume = "*"
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -78,6 +78,7 @@ zenoh = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git",
 zenoh-ext = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features=["internal"] }
 zenoh-runtime = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-util = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh-pinned-deps-1-75 = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 flume = "*"
 
 [target.'cfg(unix)'.dependencies]

--- a/build-resources/opaque-types/Cargo.toml
+++ b/build-resources/opaque-types/Cargo.toml
@@ -35,6 +35,7 @@ zenoh-ext = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.g
     "internal",
 ] }
 zenoh-protocol = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh-pinned-deps-1-75 = { version = "1.6.2", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 const_format = "0.2.32"
 flume = "*"
 tokio = "*"


### PR DESCRIPTION
This fixes build with rust 1.75 with recent Cargo.lock from Zenoh
https://github.com/eclipse-zenoh/ci/actions/runs/18765427681/job/53539387743
