### PR TITLE
ci: run apt-get update before install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Install build deps
         if: ${{ matrix.build.target == 'x86_64-unknown-linux-musl'}}
         run: |
+          sudo apt-get update
           sudo apt-get install -y musl-tools
           wget https://github.com/ZettaScaleLabs/muslcc/raw/refs/heads/main/x86_64-linux-musl-cross.tgz?download= -O x86_64-linux-musl-cross.tgz
           tar xvfz x86_64-linux-musl-cross.tgz
@@ -113,11 +114,15 @@ jobs:
 
       - name: Install build deps
         if: ${{ matrix.build.target == 'arm-unknown-linux-gnueabi'}}
-        run: sudo apt-get install -y gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
 
       - name: Install build deps
         if: ${{ matrix.build.target == 'arm-unknown-linux-gnueabihf'}}
-        run: sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
 
       - name: Install build deps
         if: ${{ matrix.build.target == 'armv7-unknown-linux-gnueabihf'}}
@@ -128,7 +133,9 @@ jobs:
 
       - name: Install build deps
         if: ${{ matrix.build.target == 'aarch64-unknown-linux-gnu'}}
-        run: sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
       - name: Install build deps
         if: ${{ matrix.build.target == 'aarch64-unknown-linux-musl'}}
@@ -140,6 +147,7 @@ jobs:
       - name: Install build deps
         if: ${{ matrix.build.target == 'x86_64-pc-windows-gnu'}}
         run: |
+          sudo apt-get update
           sudo apt-get install -y mingw-w64
 
       - name: Compute package name


### PR DESCRIPTION
Fix https://github.com/eclipse-zenoh/zenoh-c/actions/runs/19913046919/job/57085962971