### PR TITLE
Do not use callback mut for matching status and miss listener

### DIFF
--- a/src/advanced_publisher.rs
+++ b/src/advanced_publisher.rs
@@ -422,7 +422,7 @@ fn _advanced_publisher_matching_listener_declare_inner<'a>(
     let callback = callback.take_rust_type();
     let listener = publisher
         .matching_listener()
-        .callback_mut(move |matching_status| {
+        .callback(move |matching_status| {
             let status = z_matching_status_t {
                 matching: matching_status.matching(),
             };

--- a/src/advanced_subscriber.rs
+++ b/src/advanced_subscriber.rs
@@ -417,7 +417,7 @@ fn _advanced_subscriber_sample_miss_listener_declare_inner<'a>(
 ) -> zenoh_ext::SampleMissListenerBuilder<'a, Callback<zenoh_ext::Miss>> {
     let subscriber = subscriber.as_rust_type_ref();
     let callback = callback.take_rust_type();
-    let listener = subscriber.sample_miss_listener().callback_mut(move |miss| {
+    let listener = subscriber.sample_miss_listener().callback(move |miss| {
         let miss = ze_miss_t {
             source: miss.source().into_c_type(),
             nb: miss.nb(),

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -340,7 +340,7 @@ fn _publisher_matching_listener_declare_inner<'a>(
     let callback = callback.take_rust_type();
     let listener = publisher
         .matching_listener()
-        .callback_mut(move |matching_status| {
+        .callback(move |matching_status| {
             let status = z_matching_status_t {
                 matching: matching_status.matching(),
             };

--- a/src/querier.rs
+++ b/src/querier.rs
@@ -371,7 +371,7 @@ fn _querier_matching_listener_declare_inner<'a>(
     let callback = callback.take_rust_type();
     let listener = querier
         .matching_listener()
-        .callback_mut(move |matching_status| {
+        .callback(move |matching_status| {
             let status = z_matching_status_t {
                 matching: matching_status.matching(),
             };


### PR DESCRIPTION
Do not use callback_mut for matching status and miss listener.
resolves #1191 