### PR TITLE
fix: add cargo generate-lockfile to bump-and-tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,7 @@ jobs:
         run: cargo metadata --locked --format-version=1
 
       - name: Validate opaque-types lockfile
-        run: cargo metadata --locked --format-version=1 \
-          --manifest-path build-resources/opaque-types/Cargo.toml
+        run: cargo metadata --locked --format-version=1 --manifest-path build-resources/opaque-types/Cargo.toml
 
       - name: Build with locked dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,26 @@ jobs:
             exit 1
           fi
 
+  check_lockfiles:
+    name: Check Cargo.lock files are in sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate root lockfile
+        run: cargo metadata --locked --format-version=1
+
+      - name: Validate opaque-types lockfile
+        run: cargo metadata --locked --format-version=1 \
+          --manifest-path build-resources/opaque-types/Cargo.toml
+
+      - name: Build with locked dependencies
+        run: |
+          mkdir -p build && cd build
+          cmake .. -DZENOHC_CARGO_FLAGS:STRING="--locked" -DCMAKE_BUILD_TYPE=Release
+          cmake --build . --config Release
+
   check_rust:
     name: Check zenoh-c using Rust 1.75
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -273,7 +273,7 @@ checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "proc-macro2",
  "quote",
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -756,7 +756,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -765,6 +765,9 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "filepath"
@@ -807,6 +810,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-sink",
  "spin 0.9.8",
 ]
 
@@ -1042,6 +1057,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,12 +1272,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1356,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1416,9 +1437,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -1438,9 +1459,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -1587,7 +1608,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "libc",
  "memoffset",
@@ -1599,7 +1620,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -1855,7 +1876,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -2114,7 +2135,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2175,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2241,7 +2262,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2334,7 +2355,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "once_cell",
  "serde",
  "serde_derive",
@@ -2392,7 +2413,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
@@ -2401,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",
@@ -2474,9 +2495,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2573,7 +2594,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2669,7 +2690,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -2696,7 +2717,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -2709,7 +2730,7 @@ version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "core-foundation",
  "core-foundation-sys",
@@ -3047,7 +3068,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "libc",
  "log",
@@ -3146,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -3239,7 +3260,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -3272,7 +3293,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
@@ -3520,9 +3541,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3617,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3630,9 +3651,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3640,9 +3661,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3653,9 +3674,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3677,7 +3698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3688,9 +3709,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -3706,18 +3727,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4129,7 +4150,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -4159,8 +4180,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4179,7 +4200,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4260,8 +4281,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -4269,7 +4290,7 @@ dependencies = [
  "bytes",
  "const_format",
  "flate2",
- "flume",
+ "flume 0.11.1",
  "futures",
  "git-version",
  "itertools",
@@ -4312,8 +4333,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-buffers"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "zenoh-collections",
 ]
@@ -4327,14 +4348,14 @@ dependencies = [
  "const_format",
  "ctor",
  "evalexpr",
- "flume",
+ "flume 0.12.0",
  "fs2",
  "fs_extra",
  "json5",
  "lazy_static",
  "libc",
  "phf 0.11.3",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "serde_yaml",
  "spin 0.9.8",
@@ -4349,8 +4370,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-codec"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "tracing",
  "uhlc",
@@ -4361,16 +4382,16 @@ dependencies = [
 
 [[package]]
 name = "zenoh-collections"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
 name = "zenoh-config"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -4394,8 +4415,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-core"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -4405,8 +4426,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-crypto"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "aes",
  "hmac",
@@ -4418,12 +4439,12 @@ dependencies = [
 
 [[package]]
 name = "zenoh-ext"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "bincode",
- "flume",
+ "flume 0.11.1",
  "futures",
  "leb128",
  "serde",
@@ -4437,8 +4458,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-keyexpr"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "getrandom 0.2.17",
  "hashbrown 0.16.1",
@@ -4452,8 +4473,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -4473,13 +4494,13 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-commons"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
- "flume",
+ "flume 0.11.1",
  "futures",
  "quinn",
  "quinn-proto",
@@ -4509,8 +4530,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "rustls-webpki",
@@ -4525,8 +4546,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic_datagram"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "rustls-webpki",
@@ -4541,8 +4562,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-serial"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "tokio",
@@ -4559,8 +4580,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tcp"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "socket2 0.5.10",
@@ -4576,8 +4597,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tls"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "base64",
@@ -4605,8 +4626,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-udp"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "libc",
@@ -4627,8 +4648,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-unixpipe"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -4649,8 +4670,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-unixsock_stream"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -4667,8 +4688,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-vsock"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "libc",
@@ -4685,8 +4706,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-ws"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4705,8 +4726,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-macros"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4716,8 +4737,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-plugin-trait"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "git-version",
  "libloading",
@@ -4733,8 +4754,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-protocol"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -4748,16 +4769,16 @@ dependencies = [
 
 [[package]]
 name = "zenoh-result"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "zenoh-runtime"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4770,8 +4791,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-shm"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -4799,8 +4820,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-stats"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "ahash",
  "prometheus-client",
@@ -4812,8 +4833,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-sync"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -4826,8 +4847,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-task"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "futures",
  "tokio",
@@ -4839,12 +4860,12 @@ dependencies = [
 
 [[package]]
 name = "zenoh-transport"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
- "flume",
+ "flume 0.11.1",
  "futures",
  "lazy_static",
  "lz4_flex",
@@ -4875,12 +4896,12 @@ dependencies = [
 
 [[package]]
 name = "zenoh-util"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "const_format",
- "flume",
+ "flume 0.11.1",
  "home",
  "humantime",
  "lazy_static",

--- a/build-resources/opaque-types/Cargo.lock
+++ b/build-resources/opaque-types/Cargo.lock
@@ -172,9 +172,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -217,9 +217,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -605,7 +605,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -875,6 +875,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,12 +1090,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1183,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1243,9 +1249,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -1265,9 +1271,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -1408,7 +1414,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "libc",
  "memoffset",
@@ -1420,7 +1426,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -1682,7 +1688,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -1899,7 +1905,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1960,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2026,7 +2032,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2107,7 +2113,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "once_cell",
  "serde",
  "serde_derive",
@@ -2161,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",
@@ -2234,9 +2240,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2333,7 +2339,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2429,7 +2435,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -2456,7 +2462,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -2469,7 +2475,7 @@ version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "core-foundation",
  "core-foundation-sys",
@@ -2794,7 +2800,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "libc",
  "log",
@@ -2893,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -2986,7 +2992,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -3019,7 +3025,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
@@ -3255,9 +3261,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3352,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3365,9 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3375,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3388,9 +3394,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3412,7 +3418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3423,9 +3429,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -3441,18 +3447,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3864,7 +3870,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -3894,8 +3900,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -3914,7 +3920,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -3995,8 +4001,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -4047,16 +4053,16 @@ dependencies = [
 
 [[package]]
 name = "zenoh-buffers"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "zenoh-collections",
 ]
 
 [[package]]
 name = "zenoh-codec"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "tracing",
  "uhlc",
@@ -4067,16 +4073,16 @@ dependencies = [
 
 [[package]]
 name = "zenoh-collections"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
 name = "zenoh-config"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -4100,8 +4106,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-core"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -4111,8 +4117,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-crypto"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "aes",
  "hmac",
@@ -4124,8 +4130,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-ext"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4143,8 +4149,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-keyexpr"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "getrandom 0.2.17",
  "hashbrown 0.16.1",
@@ -4158,8 +4164,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -4179,8 +4185,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-commons"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "base64",
@@ -4215,8 +4221,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "rustls-webpki",
@@ -4231,8 +4237,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic_datagram"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "rustls-webpki",
@@ -4247,8 +4253,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-serial"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "tokio",
@@ -4265,8 +4271,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tcp"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "socket2 0.5.10",
@@ -4282,8 +4288,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tls"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "base64",
@@ -4311,8 +4317,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-udp"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "libc",
@@ -4333,8 +4339,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-unixpipe"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -4355,8 +4361,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-unixsock_stream"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -4373,8 +4379,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-vsock"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "libc",
@@ -4391,8 +4397,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-ws"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4411,8 +4417,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-macros"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4422,8 +4428,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-plugin-trait"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "git-version",
  "libloading",
@@ -4439,8 +4445,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-protocol"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -4454,16 +4460,16 @@ dependencies = [
 
 [[package]]
 name = "zenoh-result"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "zenoh-runtime"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4476,8 +4482,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-shm"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "advisory-lock",
  "async-trait",
@@ -4505,8 +4511,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-stats"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "ahash",
  "prometheus-client",
@@ -4518,8 +4524,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-sync"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -4532,8 +4538,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-task"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "futures",
  "tokio",
@@ -4545,8 +4551,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-transport"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -4581,8 +4587,8 @@ dependencies = [
 
 [[package]]
 name = "zenoh-util"
-version = "1.8.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#91c230a8eef604c642bd4285c4374786000aa6a8"
+version = "1.9.0"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#bfcab2644f7624b4f7bb7fa0db7781b858cd6888"
 dependencies = [
  "async-trait",
  "const_format",

--- a/ci/scripts/bump-and-tag.bash
+++ b/ci/scripts/bump-and-tag.bash
@@ -36,6 +36,8 @@ debian_version=$(to_debian_version "$version")
 toml_set_in_place Cargo.toml "package.metadata.deb.variants.libzenohc-dev.depends" "libzenohc (=$debian_version)"
 cargo_toml_in_set_debian_depends "libzenohc (=$debian_version)"
 
+# Show the changes to be committed
+git diff version.txt Cargo.toml Cargo.toml.in Cargo.lock
 git commit version.txt Cargo.toml Cargo.toml.in Cargo.lock -m "chore: Bump version to $version"
 
 # Select all package dependencies that match $bump_deps_pattern and bump them to $bump_deps_version
@@ -65,8 +67,13 @@ if [[ "$bump_deps_pattern" != '' ]]; then
     fi
   done
 
+  # Regenerate Cargo.lock for both Cargo.toml files
+  cargo generate-lockfile
+  cargo generate-lockfile --manifest-path build-resources/opaque-types/Cargo.toml
 
   if [[ -n $bump_deps_version || -n $bump_deps_branch ]]; then
+    # Show the changes to be committed
+    git diff Cargo.toml Cargo.toml.in Cargo.lock build-resources/opaque-types/Cargo.lock
     git commit Cargo.toml Cargo.toml.in Cargo.lock build-resources/opaque-types/Cargo.toml build-resources/opaque-types/Cargo.lock -m "chore: Bump $bump_deps_pattern version to $bump_deps_version"
   else
     echo "warn: no changes have been made to any dependencies matching $bump_deps_pattern"


### PR DESCRIPTION
In https://github.com/eclipse-zenoh/zenoh-c/pull/1201 the step to generate the new lockfile was removed and I failed to catch that during review.

This PR reintroduces the change and adds a CI guard to catch drift in the Cargo.lock

Fix https://github.com/eclipse-zenoh/zenoh-c/issues/1270