### PR TITLE
chore: brew trust messense/macos-cross-toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew tap messense/macos-cross-toolchains
+          brew trust messense/macos-cross-toolchains
           brew install armv7-unknown-linux-gnueabihf
           brew install mingw-w64
           brew install x86_64-unknown-linux-gnu


### PR DESCRIPTION
macos cross-compilation is failing due to failure to install the messense/macos-cross-toolchains 

Fix https://github.com/eclipse-zenoh/zenoh-c/actions/runs/28760309226/job/85274395015