### PR TITLE
build: allow overriding the cargo command via the CARGO_COMMAND environment variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,14 @@ if(NOT("${_INTERNAL_ZENOHC_BUILD_TARGET}" STREQUAL ""))
 	message(STATUS "Build target: ${_INTERNAL_ZENOHC_BUILD_TARGET} (from ${_INTERNAL_ZENOHC_BUILD_TARGET_SOURCE})")
 endif()
 declare_cache_var(ZENOHC_CARGO_CHANNEL "" STRING "Cargo channel parameter. Should be '+stable', '+nightly' or empty value")
+# The cargo command to use can be overridden with the CARGO_COMMAND environment variable
+# (same variable as used by colcon-cargo), e.g. with 'cargo-1.91' package on Ubuntu. Defaults to 'cargo'.
+if(NOT("$ENV{CARGO_COMMAND}" STREQUAL ""))
+	set(cargo_executable "$ENV{CARGO_COMMAND}")
+	message(STATUS "Cargo command: ${cargo_executable} (from ENV{CARGO_COMMAND})")
+else()
+	set(cargo_executable "cargo")
+endif()
 declare_cache_var(ZENOHC_MSRV_1_75 FALSE BOOL "Ensure that zenoh-c can be built with Rust 1.75 by pinning dependencies to compatible versions")
 if (ZENOHC_MSRV_1_75)
 	message(STATUS "Due to ZENOHC_MSRV_1_75 setting the ZENOHC_COPY_SOURCE_CARGO_LOCK and ZENOHC_BUILD_IN_SOURCE_TREE cache variables are forcibly set to FALSE to avoid build failures due to incompatible source Cargo.lock file")
@@ -281,8 +289,8 @@ file(GLOB_RECURSE rust_sources "Cargo.toml.in" "src/*.rs" "build.rs" "splitguide
 add_custom_command(
 	OUTPUT ${libs}
 	COMMAND ${CMAKE_COMMAND} -E echo \"RUSTFLAGS = $$RUSTFLAGS\"
-	COMMAND ${CMAKE_COMMAND} -E echo \"cargo ${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}\"
-	COMMAND ${CMAKE_COMMAND} -E env OPAQUE_TYPES_BUILD_DIR=${CMAKE_BINARY_DIR}/opaque-types cargo ${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}
+	COMMAND ${CMAKE_COMMAND} -E echo \"${cargo_executable} ${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}\"
+	COMMAND ${CMAKE_COMMAND} -E env OPAQUE_TYPES_BUILD_DIR=${CMAKE_BINARY_DIR}/opaque-types ${cargo_executable} ${ZENOHC_CARGO_CHANNEL} build ${cargo_flags}
 	VERBATIM
 	COMMAND_EXPAND_LISTS
 	DEPENDS "${rust_sources}"

--- a/README.md
+++ b/README.md
@@ -219,6 +219,39 @@ To build on a system with preinstalled Rust of some old version if `cargo` doesn
 cmake ../zenoh-c -DZENOHC_MSRV_1_75=TRUE
 ```
 
+## Selecting the cargo command
+
+By default the build invokes the `cargo` command found in the `PATH`. It can be overridden with the
+`CARGO_COMMAND` environment variable (the same variable as used by
+[colcon-cargo](https://github.com/colcon/colcon-cargo)). This is useful when Rust is installed via
+distribution packages providing versioned commands, such as the Ubuntu `cargo-1.91` package:
+
+```bash
+CARGO_COMMAND=cargo-1.91 cmake ../zenoh-c
+cmake --build .
+```
+
+The variable is read at cmake configuration time and baked into the generated build rules, so it has
+to be set when running `cmake` to configure the project. The same variable is also honored by the
+internal `build.rs` invocations of cargo.
+
+> :warning: `CARGO_COMMAND` selects the cargo executable, not the rustc executable: the compiler is
+> the one that the selected cargo resolves for itself. A cargo installed from distribution packages
+> resolves the matching rustc of its own toolchain, but on a system managed by
+> [rustup](https://rustup.rs) do **not** point `CARGO_COMMAND` at a toolchain binary such as
+> `~/.rustup/toolchains/<toolchain>/bin/cargo`. This bypasses the rustup proxies, leaving
+> `RUSTUP_TOOLCHAIN` unset, and the `rustc` proxy then resolves a toolchain independently for each
+> crate being compiled: dependencies from the registry get the rustup default toolchain, while
+> crates whose sources are covered by a `rust-toolchain.toml` get the pinned one. The build ends up
+> mixing rustc versions and fails with
+> `error[E0514]: found crate ... compiled by an incompatible version of rustc`. To select a rustup
+> toolchain, set `RUSTUP_TOOLCHAIN=<toolchain>`, run the build under `rustup run <toolchain> ...`,
+> or use the [`ZENOHC_CARGO_CHANNEL`](#minimal-supported-rust-version) option.
+>
+> :warning: [rust-toolchain.toml](rust-toolchain.toml) is a rustup feature. When `CARGO_COMMAND`
+> designates a cargo that is not managed by rustup, the version pinned by that file is ignored and
+> the build uses the toolchain of the selected cargo.
+
 ## Zenoh features support (enabling/disabling protocols, etc)
 
 It's necessary sometimes to build zenoh-c library with set of features different from default. For example: enable TCP and UDP only. This can be done by changing `ZENOHC_CARGO_FLAGS` parameter for cmake (notice ";" instead of space due to cmake peculiarities)

--- a/buildrs/opaque_types_generator.rs
+++ b/buildrs/opaque_types_generator.rs
@@ -123,7 +123,13 @@ fn produce_opaque_types_data() -> (String, PathBuf) {
         feature_args.push(feature);
     }
 
-    let mut command = std::process::Command::new("cargo");
+    // The cargo command can be overridden with the CARGO_COMMAND environment variable
+    // (same variable as used by colcon-cargo), e.g. 'cargo-1.91' on Ubuntu.
+    // Otherwise fall back on CARGO (set by cargo itself when running build scripts), then on 'cargo'.
+    let cargo_command = std::env::var("CARGO_COMMAND")
+        .or_else(|_| std::env::var("CARGO"))
+        .unwrap_or_else(|_| "cargo".to_string());
+    let mut command = std::process::Command::new(cargo_command);
 
     // Preserve the toolchain channel if one was specified (e.g., +1.75)
     if let Ok(toolchain) = std::env::var("RUSTUP_TOOLCHAIN") {

--- a/buildrs/opaque_types_generator.rs
+++ b/buildrs/opaque_types_generator.rs
@@ -126,10 +126,11 @@ fn produce_opaque_types_data() -> (String, PathBuf) {
     // The cargo command can be overridden with the CARGO_COMMAND environment variable
     // (same variable as used by colcon-cargo), e.g. 'cargo-1.91' on Ubuntu.
     // Otherwise fall back on CARGO (set by cargo itself when running build scripts), then on 'cargo'.
-    let cargo_command = std::env::var("CARGO_COMMAND")
-        .or_else(|_| std::env::var("CARGO"))
-        .unwrap_or_else(|_| "cargo".to_string());
-    let mut command = std::process::Command::new(cargo_command);
+    // let cargo_command = std::env::var("CARGO_COMMAND")
+    //     .or_else(|_| std::env::var("CARGO"))
+    //     .unwrap_or_else(|_| "cargo".to_string());
+    // let mut command = std::process::Command::new(cargo_command);
+    let mut command = std::process::Command::new("cargo");
 
     // Preserve the toolchain channel if one was specified (e.g., +1.75)
     if let Ok(toolchain) = std::env::var("RUSTUP_TOOLCHAIN") {

--- a/buildrs/opaque_types_generator.rs
+++ b/buildrs/opaque_types_generator.rs
@@ -128,9 +128,7 @@ fn produce_opaque_types_data() -> (String, PathBuf) {
     // In this case the toolchain is ignored, since the toolchain is already baked into the cargo command.
     // Otherwise fall back to the default cargo command and toolchain.
     let mut command = match std::env::var("CARGO_COMMAND") {
-        Ok(cargo_command) if !cargo_command.is_empty() => {
-            std::process::Command::new(cargo_command)
-        },
+        Ok(cargo_command) if !cargo_command.is_empty() => std::process::Command::new(cargo_command),
         _ => {
             let mut command = std::process::Command::new("cargo");
             // Preserve the toolchain channel if one was specified (e.g., +1.75)

--- a/buildrs/opaque_types_generator.rs
+++ b/buildrs/opaque_types_generator.rs
@@ -125,17 +125,21 @@ fn produce_opaque_types_data() -> (String, PathBuf) {
 
     // The cargo command can be overridden with the CARGO_COMMAND environment variable
     // (same variable as used by colcon-cargo), e.g. 'cargo-1.91' on Ubuntu.
-    // Otherwise fall back on CARGO (set by cargo itself when running build scripts), then on 'cargo'.
-    // let cargo_command = std::env::var("CARGO_COMMAND")
-    //     .or_else(|_| std::env::var("CARGO"))
-    //     .unwrap_or_else(|_| "cargo".to_string());
-    // let mut command = std::process::Command::new(cargo_command);
-    let mut command = std::process::Command::new("cargo");
-
-    // Preserve the toolchain channel if one was specified (e.g., +1.75)
-    if let Ok(toolchain) = std::env::var("RUSTUP_TOOLCHAIN") {
-        command.arg(format!("+{}", toolchain));
-    }
+    // In this case the toolchain is ignored, since the toolchain is already baked into the cargo command.
+    // Otherwise fall back to the default cargo command and toolchain.
+    let mut command = match std::env::var("CARGO_COMMAND") {
+        Ok(cargo_command) if !cargo_command.is_empty() => {
+            std::process::Command::new(cargo_command)
+        },
+        _ => {
+            let mut command = std::process::Command::new("cargo");
+            // Preserve the toolchain channel if one was specified (e.g., +1.75)
+            if let Ok(toolchain) = std::env::var("RUSTUP_TOOLCHAIN") {
+                command.arg(format!("+{}", toolchain));
+            }
+            command
+        }
+    };
 
     command
         .arg("build")


### PR DESCRIPTION
## Description

### What does this PR do?

Makes the cargo executable used by the build configurable through the `CARGO_COMMAND`
environment variable, defaulting to `cargo` when unset.

- **`CMakeLists.txt`**: resolves `cargo_executable` from `$ENV{CARGO_COMMAND}`, logs it at
  configuration time, and uses it in the `add_custom_command` that builds the Rust sources.
- **`buildrs/opaque_types_generator.rs`**: the nested cargo invocation generating the opaque
  types resolves its command from `CARGO_COMMAND`, then `CARGO` (set by cargo for build
  scripts), then `cargo`. Otherwise the inner build would silently fall back to the `PATH`.
- **`README.md`**: new "Selecting the cargo command" section.

The `CARGO_COMMAND` variable name matches
[colcon-cargo](https://github.com/colcon/colcon-cargo/blob/main/colcon_cargo/task/cargo/__init__.py),
so a single setting drives both tools in a colcon workspace.

### Why is this change needed?

When Rust comes from distribution packages instead of rustup, cargo is often only available
under a versioned name. For instance on Ubuntu Noble, `cargo-1.91` installs `/usr/bin/cargo-1.91` while
`/usr/bin/cargo` is 1.75. There was no way to tell the build which one to use;
`ZENOHC_CARGO_CHANNEL` only helps with a rustup-managed toolchain.

Once ROS 2 allows installing `cargo-x.y` packages through `rosdep`, the zenoh-c build will be
able to be configured to use them, and then supporting Rust 1.75 (`ZENOHC_MSRV_1_75`) will no longer
be necessary.
