### PR TITLE
Respect BUILD_SHARED_LIBS during installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,14 @@ jobs:
           cmake --build . --target tests --config Release
           ctest -C Release --output-on-failure -E "(unit_z_api_alignment_test|build_z_build_shared)"
 
+      - name: Verify static installation
+        shell: bash
+        run: |
+          cd build
+          static_install="$PWD/static-install"
+          cmake --install . --config Release --prefix "$static_install"
+          cmake -DZENOHC_INSTALL_PREFIX="$static_install" -P ../tests/check_static_install.cmake
+
       - name: Build examples with zenoh-c
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ This repository provides a C binding based on the main [Zenoh implementation wri
    The result of installation is the header files in `include` directory, the library files in `lib` directory and cmake package configuration files for package `zenohc` in `lib/cmake` directory. The library later can be loaded with CMake command `find_package(zenohc)`.
    Add dependency in CMakeLists.txt on target
 
-   - `zenohc::shared` for linking dynamic library
-   - `zenohc::static` for linking static library
-   - `zenohc::lib` for linking static or dynamic library depending on boolean variable `BUILD_SHARED_LIBS`
+   - `zenohc::shared` for linking the dynamic library when installed with `BUILD_SHARED_LIBS=TRUE`
+   - `zenohc::static` for linking the static library when installed with `BUILD_SHARED_LIBS=FALSE`
+   - `zenohc::lib` for linking the installed library variant
 
 5. VScode
 

--- a/install/CMakeLists.txt
+++ b/install/CMakeLists.txt
@@ -10,23 +10,32 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 function(install_zenohc_lib configurations property_postfix package_name)
-    get_target_property(dylib_path zenohc::shared IMPORTED_LOCATION_${property_postfix})
-    get_target_property_if_set(implib_path zenohc::shared IMPORTED_IMPLIB_${property_postfix})
-    get_filename_component(DYLIB ${dylib_path} NAME)
-    get_filename_component(IMPLIB "${implib_path}" NAME)
-    # On Windows .dll need to be installed in ${CMAKE_INSTALL_BINDIR}, 
-    # while on Linux and macOS .so and .dylib need to be installed in ${CMAKE_INSTALL_LIBDIR}
-    if(WIN32)
-        set(ZENOHC_INSTALL_DYLIBDIR ${CMAKE_INSTALL_BINDIR})
+    set(ZENOHC_INSTALL_DYLIBDIR ${CMAKE_INSTALL_LIBDIR})
+    if(BUILD_SHARED_LIBS)
+        get_target_property(dylib_path zenohc::shared IMPORTED_LOCATION_${property_postfix})
+        get_target_property_if_set(implib_path zenohc::shared IMPORTED_IMPLIB_${property_postfix})
+        get_filename_component(DYLIB ${dylib_path} NAME)
+        get_filename_component(IMPLIB "${implib_path}" NAME)
+        # On Windows .dll need to be installed in ${CMAKE_INSTALL_BINDIR},
+        # while on Linux and macOS .so and .dylib need to be installed in ${CMAKE_INSTALL_LIBDIR}
+        if(WIN32)
+            set(ZENOHC_INSTALL_DYLIBDIR ${CMAKE_INSTALL_BINDIR})
+        endif()
+        install(FILES ${dylib_path} DESTINATION ${ZENOHC_INSTALL_DYLIBDIR} CONFIGURATIONS ${configurations} COMPONENT lib)
+        if(DEFINED implib_path)
+            install(FILES ${implib_path} DESTINATION ${CMAKE_INSTALL_LIBDIR} CONFIGURATIONS ${configurations} COMPONENT lib)
+        endif()
+        set(pkgconfig_library ${DYLIB})
     else()
-        set(ZENOHC_INSTALL_DYLIBDIR ${CMAKE_INSTALL_LIBDIR})
+        get_target_property(staticlib_path zenohc::static IMPORTED_LOCATION_${property_postfix})
+        get_target_property(NATIVE_STATIC_LIBS zenohc::static INTERFACE_LINK_LIBRARIES)
+        get_filename_component(STATICLIB ${staticlib_path} NAME)
+        install(FILES ${staticlib_path} DESTINATION ${CMAKE_INSTALL_LIBDIR} CONFIGURATIONS ${configurations} COMPONENT dev)
+        set(pkgconfig_library ${STATICLIB})
     endif()
-    install(FILES ${dylib_path} DESTINATION ${ZENOHC_INSTALL_DYLIBDIR} CONFIGURATIONS ${configurations} COMPONENT lib)
-    if(DEFINED implib_path)
-        install(FILES ${implib_path} DESTINATION ${CMAKE_INSTALL_LIBDIR} CONFIGURATIONS ${configurations} COMPONENT lib)
-    endif()
+
     if((APPLE OR UNIX))
-        get_filename_component(LIBNAME ${DYLIB} NAME_WE)
+        get_filename_component(LIBNAME ${pkgconfig_library} NAME_WE)
         string(REGEX REPLACE "^lib" "" LIBNAME ${LIBNAME})
         configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zenohc.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${package_name}_${property_postfix}.pc @ONLY)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${package_name}_${property_postfix}.pc 
@@ -36,11 +45,6 @@ function(install_zenohc_lib configurations property_postfix package_name)
             OPTIONAL
             COMPONENT dev)
     endif()
-
-    get_target_property(staticlib_path zenohc::static IMPORTED_LOCATION_${property_postfix})
-    get_target_property(NATIVE_STATIC_LIBS zenohc::static INTERFACE_LINK_LIBRARIES)
-    get_filename_component(STATICLIB ${staticlib_path} NAME)
-    install(FILES ${staticlib_path} DESTINATION ${CMAKE_INSTALL_LIBDIR} CONFIGURATIONS ${configurations} COMPONENT dev)
 
     set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${package_name}")
 

--- a/install/PackageConfig.cmake.in
+++ b/install/PackageConfig.cmake.in
@@ -18,32 +18,33 @@ set(ZENOHC_BUILD_WITH_UNSTABLE_API @ZENOHC_BUILD_WITH_UNSTABLE_API@)
 set(ZENOHC_BUILD_WITH_SHARED_MEMORY @ZENOHC_BUILD_WITH_SHARED_MEMORY@)
 
 
-if(NOT TARGET __zenohc_shared)
-    add_library(__zenohc_shared SHARED IMPORTED GLOBAL)
-    add_library(zenohc::shared ALIAS __zenohc_shared)
-    set_target_properties(__zenohc_shared PROPERTIES
-        INTERFACE_COMPILE_DEFINITION ZENOHC_DYN_LIB
-        IMPORTED_LOCATION "@PACKAGE_ZENOHC_INSTALL_DYLIBDIR@/@DYLIB@"
-        INTERFACE_INCLUDE_DIRECTORIES "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@"
-    )
-    if(NOT ("@IMPLIB@" STREQUAL ""))
-        set_property(TARGET __zenohc_shared PROPERTY IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@IMPLIB@")
+if(@BUILD_SHARED_LIBS@)
+    if(NOT TARGET __zenohc_shared)
+        add_library(__zenohc_shared SHARED IMPORTED GLOBAL)
+        add_library(zenohc::shared ALIAS __zenohc_shared)
+        set_target_properties(__zenohc_shared PROPERTIES
+            INTERFACE_COMPILE_DEFINITION ZENOHC_DYN_LIB
+            IMPORTED_LOCATION "@PACKAGE_ZENOHC_INSTALL_DYLIBDIR@/@DYLIB@"
+            INTERFACE_INCLUDE_DIRECTORIES "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@"
+        )
+        if(NOT ("@IMPLIB@" STREQUAL ""))
+            set_property(TARGET __zenohc_shared PROPERTY IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@IMPLIB@")
+        endif()
     endif()
-endif()
-if(NOT TARGET __zenohc_static)
-    add_library(__zenohc_static STATIC IMPORTED GLOBAL)
-    add_library(zenohc::static ALIAS __zenohc_static)
-    target_link_libraries(__zenohc_static INTERFACE @NATIVE_STATIC_LIBS@)
-    set_target_properties(__zenohc_static PROPERTIES
-        IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@STATICLIB@"
-        INTERFACE_INCLUDE_DIRECTORIES "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@"
-    )
-endif()
-
-if(NOT TARGET zenohc::lib)
-    if(@BUILD_SHARED_LIBS@)
+    if(NOT TARGET zenohc::lib)
         add_library(zenohc::lib ALIAS __zenohc_shared)
-    else()
+    endif()
+else()
+    if(NOT TARGET __zenohc_static)
+        add_library(__zenohc_static STATIC IMPORTED GLOBAL)
+        add_library(zenohc::static ALIAS __zenohc_static)
+        target_link_libraries(__zenohc_static INTERFACE @NATIVE_STATIC_LIBS@)
+        set_target_properties(__zenohc_static PROPERTIES
+            IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@STATICLIB@"
+            INTERFACE_INCLUDE_DIRECTORIES "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@"
+        )
+    endif()
+    if(NOT TARGET zenohc::lib)
         add_library(zenohc::lib ALIAS __zenohc_static)
     endif()
 endif()

--- a/tests/check_static_install.cmake
+++ b/tests/check_static_install.cmake
@@ -1,0 +1,15 @@
+if(NOT DEFINED ZENOHC_INSTALL_PREFIX)
+    message(FATAL_ERROR "ZENOHC_INSTALL_PREFIX is required")
+endif()
+
+if(WIN32)
+    set(shared_library "${ZENOHC_INSTALL_PREFIX}/bin/zenohc.dll")
+elseif(APPLE)
+    set(shared_library "${ZENOHC_INSTALL_PREFIX}/lib/libzenohc.dylib")
+else()
+    set(shared_library "${ZENOHC_INSTALL_PREFIX}/lib/libzenohc.so")
+endif()
+
+if(EXISTS "${shared_library}")
+    message(FATAL_ERROR "Static installation contains shared library: ${shared_library}")
+endif()


### PR DESCRIPTION
## Summary

- install only the library variant selected by `BUILD_SHARED_LIBS`
- generate an installed CMake package that exposes only targets backed by installed artifacts
- derive pkg-config metadata from the selected library
- add a cross-platform CI regression check for static installs
- clarify the installed target documentation

## Root cause

The build selected `zenohc::lib` according to `BUILD_SHARED_LIBS`, but `install_zenohc_lib()` unconditionally installed both the shared and static artifacts. The generated package config likewise declared both imported targets, even when one artifact should not be present.

## Validation

- reproduced the bug with `BUILD_SHARED_LIBS=OFF`
- verified a static install contains `libzenohc.a` and no `.dylib`
- verified a shared install contains `libzenohc.dylib` and no `.a`
- configured the examples against both installed package variants with `find_package(zenohc)`
- parsed the updated GitHub Actions workflow as YAML
- ran `git diff --check`

Fixes #1285
