### PR TITLE
chore: Sync Cargo.toml.in with Cargo.toml

### DIFF
--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -78,18 +78,18 @@ tokio = "*"
 unwrap-infallible = "0.1.5"
 const_format = "0.2.32"
 flume = "*"
-zenoh = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "release/1.10.0", default-features = false, features = ["internal"] }
-zenoh-ext = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "release/1.10.0", default-features = false, features=["internal"] }
-zenoh-runtime = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "release/1.10.0" }
-zenoh-util = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "release/1.10.0" }
-@COMMENT_PINNED_DEPS@zenoh-pinned-deps-1-75 = { version = "1.9.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features = ["internal"] }
+zenoh-ext = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features=["internal"] }
+zenoh-runtime = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh-util = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+@COMMENT_PINNED_DEPS@zenoh-pinned-deps-1-75 = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 
 [target.'cfg(unix)'.dependencies]
 ctor = "0.4.1"
 
 [build-dependencies]
-zenoh = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "release/1.10.0", default-features = false, features = ["internal"] }
-@COMMENT_PINNED_DEPS@zenoh-pinned-deps-1-75 = { version = "1.9.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features = ["internal"] }
+@COMMENT_PINNED_DEPS@zenoh-pinned-deps-1-75 = { version = "1.10.0", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 cbindgen = "0.29.0"
 fs2 = "0.4.3"
 regex = "1.11.1"


### PR DESCRIPTION
- Update the post-release branch from the bot with correct Cargo.toml.in after running `ci/scripts/sync-cargo-toml-in.bash`
- merge-release-branch.yml has been fixed in https://github.com/eclipse-zenoh/ci/pull/472 to correctly do this on the next release