### PR TITLE
ci: use less ci resources and pin actions to SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,14 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main", "release/*", "!release/dry-run/*"]
   pull_request:
     branches: ["**"]
-  schedule:
-    - cron: "0 6 * * 1-5"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Run clang-format dry-run
         run: find include/ src/ tests/ examples/ -iname "*.h" -o -iname "*.c" | xargs clang-format -n -Werror
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install toml-cli2
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@9ee83daaa7b96a6fab930949ecf1122bba04a389  # 3.0.8
         with:
           tool: toml-cli2
         env:
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Validate root lockfile
         run: cargo metadata --locked --format-version=1
@@ -80,13 +80,13 @@ jobs:
 
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Update Rust 1.75.0 toolchain
         run: rustup update 1.75.0
 
       - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           cache-bin: false
 
@@ -109,7 +109,7 @@ jobs:
         unstable: [false, true]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install Rust toolchain
         run: rustup component add rustfmt clippy
@@ -137,8 +137,10 @@ jobs:
           cmake --build . --target install --config Release
 
       - name: Install valgrind
-        uses: taiki-e/install-action@valgrind
         if: matrix.os == 'ubuntu-latest'
+        uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b  # v2.87.4
+        with:
+          tool: valgrind
 
       - name: Run cmake tests with zenoh-c as dynamic library
         shell: bash
@@ -188,7 +190,7 @@ jobs:
 
       - name: Upload artifact
         if: ${{ matrix.unstable == 'false' && matrix.shm == 'false' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # 7.0.1
         with:
           # Artifact name
           name: zenoh-c-${{ matrix.os }}
@@ -206,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install dependencies
         run: |
@@ -249,7 +251,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install dependencies
         run: |
@@ -323,8 +325,8 @@ jobs:
   markdown_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v18
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff  # v24.2.0
         with:
           config: '.markdownlint.yaml'
           globs: '**/README.md'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
 
       - name: Checkout this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ steps.create-release-branch.outputs.branch }}
           token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
@@ -94,7 +94,7 @@ jobs:
     needs: tag
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ needs.tag.outputs.branch }}
           token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
@@ -194,7 +194,7 @@ jobs:
           zip -9 -j libzenohc-${{ inputs.version || '0.0.0' }}-${{ matrix.build.target }}-rpm.zip ./build/packages/*.rpm
 
       - name: Upload standalone archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           # Publish the artifact with zenoh-c (repo name) so it can be used by homebrew action
           name: zenoh-c-${{ inputs.version || '0.0.0' }}-${{ matrix.build.target }}-standalone.zip
@@ -202,14 +202,14 @@ jobs:
 
       - name: Upload DEB archive
         if: ${{ contains(matrix.build.target, 'linux') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: libzenohc-${{ inputs.version || '0.0.0' }}-${{ matrix.build.target }}-debian.zip
           path: libzenohc-${{ inputs.version || '0.0.0' }}-${{ matrix.build.target }}-debian.zip
 
       - name: Upload RPM archive
         if: ${{ contains(matrix.build.target, 'linux') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: libzenohc-${{ inputs.version || '0.0.0' }}-${{ matrix.build.target }}-rpm.zip
           path: libzenohc-${{ inputs.version || '0.0.0' }}-${{ matrix.build.target }}-rpm.zip

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repository provides a C binding based on the main [Zenoh implementation wri
 ## How to build it
 
 1. Make sure that [Rust](https://www.rust-lang.org) is available on your platform.
-   Please check [here](https://www.rust-lang.org/tools/install) to learn how to install it.
+   You can [install Rust](https://www.rust-lang.org/tools/install) using rustup.
    If you already have the Rust toolchain installed, make sure it is up-to-date with:
 
    ```bash
@@ -140,7 +140,7 @@ cmake ../zenoh-c/examples -DCMAKE_INSTALL_PREFIX=~/.local
 
 ## Running the Examples
 
-See information about running examples [here](./examples/README.md).
+See [documentation](./examples/README.md) about running examples.
 
 ## Documentation
 


### PR DESCRIPTION
- use less ci resources and align with zenoh repo
- pin actions to SHA
- fixed markdown lint errors