### PR TITLE
Build: replace warning logs from build.rs with build-print::info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "build-print"
-version = "1.0.1"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e6738dfb11354886f890621b4a34c0b177f75538023f7100b608ab9adbd66b"
+checksum = "4a2128d00b7061b82b72844a351e80acd29e05afc60e9261e2ac90dca9ecc2ac"
 
 [[package]]
 name = "bumpalo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-print"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e6738dfb11354886f890621b4a34c0b177f75538023f7100b608ab9adbd66b"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4268,6 +4274,7 @@ dependencies = [
 name = "zenoh-c"
 version = "1.10.0"
 dependencies = [
+ "build-print",
  "cbindgen",
  "chrono",
  "const_format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ serde_yaml = "0.9.19"
 fs_extra = "1.3.0"
 evalexpr = "11.3.0" # Bumping to 12.x.x will cause 1.75 check fails
 phf = { version = "0.11.2", features = ["macros"] }
-build-print = "1.0.1"
+build-print = "0.1.1" # Bumping to 1.x.x will cause 1.75 check fails
 
 [lib]
 path = "src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ serde_yaml = "0.9.19"
 fs_extra = "1.3.0"
 evalexpr = "11.3.0" # Bumping to 12.x.x will cause 1.75 check fails
 phf = { version = "0.11.2", features = ["macros"] }
+build-print = "1.0.1"
 
 [lib]
 path = "src/lib.rs"

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -97,7 +97,7 @@ serde_yaml = "0.9.19"
 fs_extra = "1.3.0"
 evalexpr = "11.3.0" # Bumping to 12.x.x will cause 1.75 check fails
 phf = { version = "0.11.2", features = ["macros"] }
-build-print = "1.0.1"
+build-print = "0.1.1" # Bumping to 1.x.x will cause 1.75 check fails
 
 [lib]
 path = "@CARGO_PROJECT_DIR@src/lib.rs"

--- a/Cargo.toml.in
+++ b/Cargo.toml.in
@@ -97,6 +97,7 @@ serde_yaml = "0.9.19"
 fs_extra = "1.3.0"
 evalexpr = "11.3.0" # Bumping to 12.x.x will cause 1.75 check fails
 phf = { version = "0.11.2", features = ["macros"] }
+build-print = "1.0.1"
 
 [lib]
 path = "@CARGO_PROJECT_DIR@src/lib.rs"

--- a/build.rs
+++ b/build.rs
@@ -64,21 +64,21 @@ fn sync_opaque_types_lockfile() {
     let opaque_types_dir = get_build_rs_path().join("build-resources/opaque-types");
     let opaque_lock = opaque_types_dir.join("Cargo.lock");
 
-    println!(
-        "cargo:warning=Copying Cargo.lock from {} to {}",
+    build_print::info!(
+        "Opaque types: copying Cargo.lock from {} to {}",
         root_lock.display(),
         opaque_lock.display()
     );
 
     if let Err(err) = fs::copy(&root_lock, &opaque_lock) {
         panic!(
-            "Failed to copy Cargo.lock to {}: {}",
+            "Opaque types: failed to copy Cargo.lock to {}: {}",
             opaque_lock.display(),
             err
         );
     }
 
-    println!("cargo:warning=Successfully copied Cargo.lock");
+    build_print::info!("Opaque types: successfully copied Cargo.lock");
 }
 
 fn main() {


### PR DESCRIPTION
The `build.rs` script is making cargo to log at warning level some informative message regarding the `Cargo.lock` copy for opaque types build. Other projects building `zenoh-c` from sources may want to fail on warning logs, making those unable to build `zenoh-c` without a waorkaround.

This PR adds a build dependency to [build-print](https://github.com/sam0x17/build-print), replacing the `println!("cargo:warning=...")` with `build_print::info!("...")`


Fix #1325