### PR TITLE
examples: parse numeric options strictly and fix --history typo

### DIFF
--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -294,8 +295,19 @@ z_query_target_t parse_query_target(const char* arg) {
     }
 }
 
+unsigned long parse_uint(const char* arg) {
+    char* end;
+    errno = 0;
+    unsigned long value = strtoul(arg, &end, 10);
+    if (errno != 0 || *arg < '0' || *arg > '9' || *end != '\0') {
+        printf("Invalid unsigned integer value [%s]\n", arg);
+        exit(-1);
+    }
+    return value;
+}
+
 z_priority_t parse_priority(const char* arg) {
-    int p = atoi(arg);
+    unsigned long p = parse_uint(arg);
     if (p < Z_PRIORITY_REAL_TIME || p > Z_PRIORITY_BACKGROUND) {
         printf("Unsupported priority value [%s]\n", arg);
         exit(-1);

--- a/examples/z_advanced_pub.c
+++ b/examples/z_advanced_pub.c
@@ -103,7 +103,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     struct args_t args;
     _Z_PARSE_ARG(args.keyexpr, "k", "key", (char*), (char*)DEFAULT_KEYEXPR);
     _Z_PARSE_ARG(args.value, "p", "payload", (char*), (char*)DEFAULT_VALUE);
-    _Z_PARSE_ARG(args.history, "i", "hisotry", atoi, DEFAULT_HISTORY);
+    _Z_PARSE_ARG(args.history, "i", "history", parse_uint, DEFAULT_HISTORY);
 
     parse_zenoh_common_args(argc, argv, config);
     const char* unknown_arg = check_unknown_opts(argc, argv);

--- a/examples/z_get.c
+++ b/examples/z_get.c
@@ -118,7 +118,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     struct args_t args;
     _Z_PARSE_ARG(args.selector, "s", "selector", (char*), (char*)DEFAULT_SELECTOR);
     _Z_PARSE_ARG(args.value, "p", "payload", (char*), (char*)DEFAULT_VALUE);
-    _Z_PARSE_ARG(args.timeout_ms, "o", "timeout", atoi, DEFAULT_TIMEOUT_MS);
+    _Z_PARSE_ARG(args.timeout_ms, "o", "timeout", parse_uint, DEFAULT_TIMEOUT_MS);
     _Z_PARSE_ARG(args.target, "t", "target", parse_query_target, z_query_target_default());
 
     parse_zenoh_common_args(argc, argv, config);

--- a/examples/z_get_liveliness.c
+++ b/examples/z_get_liveliness.c
@@ -86,7 +86,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     _Z_CHECK_HELP;
     struct args_t args;
     _Z_PARSE_ARG(args.keyexpr, "k", "key", (char*), (char*)DEFAULT_KEYEXPR);
-    _Z_PARSE_ARG(args.timeout_ms, "o", "timeout", atoi, DEFAULT_TIMEOUT_MS);
+    _Z_PARSE_ARG(args.timeout_ms, "o", "timeout", parse_uint, DEFAULT_TIMEOUT_MS);
 
     parse_zenoh_common_args(argc, argv, config);
     const char* arg = check_unknown_opts(argc, argv);

--- a/examples/z_get_shm.c
+++ b/examples/z_get_shm.c
@@ -146,7 +146,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     struct args_t args;
     _Z_PARSE_ARG(args.selector, "s", "selector", (char*), (char*)DEFAULT_SELECTOR);
     _Z_PARSE_ARG(args.value, "p", "payload", (char*), (char*)DEFAULT_VALUE);
-    _Z_PARSE_ARG(args.timeout_ms, "o", "timeout", atoi, DEFAULT_TIMEOUT_MS);
+    _Z_PARSE_ARG(args.timeout_ms, "o", "timeout", parse_uint, DEFAULT_TIMEOUT_MS);
     _Z_PARSE_ARG(args.target, "t", "target", parse_query_target, z_query_target_default());
 
     parse_zenoh_common_args(argc, argv, config);

--- a/examples/z_non_blocking_get.c
+++ b/examples/z_non_blocking_get.c
@@ -119,7 +119,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     struct args_t args;
     _Z_PARSE_ARG(args.selector, "s", "selector", (char*), (char*)DEFAULT_SELECTOR);
     _Z_PARSE_ARG(args.value, "p", "payload", (char*), (char*)DEFAULT_VALUE);
-    _Z_PARSE_ARG(args.timeout_ms, "o", "timeout", atoi, DEFAULT_TIMEOUT_MS);
+    _Z_PARSE_ARG(args.timeout_ms, "o", "timeout", parse_uint, DEFAULT_TIMEOUT_MS);
     _Z_PARSE_ARG(args.target, "t", "target", parse_query_target, z_query_target_default());
 
     parse_zenoh_common_args(argc, argv, config);

--- a/examples/z_ping.c
+++ b/examples/z_ping.c
@@ -131,8 +131,8 @@ void print_help() {
 struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     _Z_CHECK_HELP;
     struct args_t args;
-    _Z_PARSE_ARG(args.number_of_pings, "n", "samples", atoi, DEFAULT_PING_NB);
-    _Z_PARSE_ARG(args.warmup_ms, "w", "warmup", atoi, DEFAULT_WARMUP_MS);
+    _Z_PARSE_ARG(args.number_of_pings, "n", "samples", parse_uint, DEFAULT_PING_NB);
+    _Z_PARSE_ARG(args.warmup_ms, "w", "warmup", parse_uint, DEFAULT_WARMUP_MS);
     args.no_express = _Z_CHECK_FLAG("no-express");
 
     parse_zenoh_common_args(argc, argv, config);
@@ -147,7 +147,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
-    args.size = atoi(pos_args[0]);
+    args.size = parse_uint(pos_args[0]);
     free(pos_args);
     return args;
 }

--- a/examples/z_ping_shm.c
+++ b/examples/z_ping_shm.c
@@ -155,8 +155,8 @@ void print_help() {
 struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     _Z_CHECK_HELP;
     struct args_t args;
-    _Z_PARSE_ARG(args.number_of_pings, "n", "samples", atoi, DEFAULT_PING_NB);
-    _Z_PARSE_ARG(args.warmup_ms, "w", "warmup", atoi, DEFAULT_WARMUP_MS);
+    _Z_PARSE_ARG(args.number_of_pings, "n", "samples", parse_uint, DEFAULT_PING_NB);
+    _Z_PARSE_ARG(args.warmup_ms, "w", "warmup", parse_uint, DEFAULT_WARMUP_MS);
     args.no_express = _Z_CHECK_FLAG("no-express");
 
     parse_zenoh_common_args(argc, argv, config);
@@ -171,7 +171,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
-    args.size = atoi(pos_args[0]);
+    args.size = parse_uint(pos_args[0]);
     free(pos_args);
     return args;
 }

--- a/examples/z_pub_shm_thr.c
+++ b/examples/z_pub_shm_thr.c
@@ -101,7 +101,7 @@ void print_help() {
 struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     _Z_CHECK_HELP;
     struct args_t args;
-    _Z_PARSE_ARG(args.shared_memory_size_mb, "s", "shared-memory", atoi, DEFAULT_SHARED_MEMORY_SIZE);
+    _Z_PARSE_ARG(args.shared_memory_size_mb, "s", "shared-memory", parse_uint, DEFAULT_SHARED_MEMORY_SIZE);
 
     parse_zenoh_common_args(argc, argv, config);
     const char* arg = check_unknown_opts(argc, argv);
@@ -119,7 +119,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
-    args.size = atoi(pos_args[0]);
+    args.size = parse_uint(pos_args[0]);
     free(pos_args);
     return args;
 }

--- a/examples/z_pub_thr.c
+++ b/examples/z_pub_thr.c
@@ -106,7 +106,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
         free(pos_args);
         exit(-1);
     }
-    args.size = atoi(pos_args[0]);
+    args.size = parse_uint(pos_args[0]);
     free(pos_args);
     return args;
 }

--- a/examples/z_pull.c
+++ b/examples/z_pull.c
@@ -116,8 +116,8 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     _Z_CHECK_HELP;
     struct args_t args;
     _Z_PARSE_ARG(args.keyexpr, "k", "key", (char*), (char*)DEFAULT_KEYEXPR);
-    _Z_PARSE_ARG(args.size, "s", "size", atoi, DEFAULT_RING_BUFFER_SIZE);
-    _Z_PARSE_ARG(args.interval, "i", "interval", atoi, DEFAULT_PULL_INTERVAL);
+    _Z_PARSE_ARG(args.size, "s", "size", parse_uint, DEFAULT_RING_BUFFER_SIZE);
+    _Z_PARSE_ARG(args.interval, "i", "interval", parse_uint, DEFAULT_PULL_INTERVAL);
 
     parse_zenoh_common_args(argc, argv, config);
     const char* arg = check_unknown_opts(argc, argv);

--- a/examples/z_querier.c
+++ b/examples/z_querier.c
@@ -155,7 +155,7 @@ struct args_t parse_args(int argc, char** argv, z_owned_config_t* config) {
     struct args_t args;
     _Z_PARSE_ARG(args.selector, "s", "selector", (char*), (char*)DEFAULT_SELECTOR);
     _Z_PARSE_ARG(args.value, "p", "payload", (char*), (char*)DEFAULT_VALUE);
-    _Z_PARSE_ARG(args.timeout_ms, "o", "timeout", atoi, DEFAULT_TIMEOUT_MS);
+    _Z_PARSE_ARG(args.timeout_ms, "o", "timeout", parse_uint, DEFAULT_TIMEOUT_MS);
     _Z_PARSE_ARG(args.target, "t", "target", parse_query_target, z_query_target_default());
     args.add_matching_listener = _Z_CHECK_FLAG("add-matching-listener");
 

--- a/examples/z_sub_thr.c
+++ b/examples/z_sub_thr.c
@@ -134,8 +134,8 @@ void print_help() {
 args_t parse_args(int argc, char **argv, z_owned_config_t *config) {
     _Z_CHECK_HELP;
     args_t args;
-    _Z_PARSE_ARG(args.samples, "s", "samples", atoi, DEFAULT_MEASUREMENTS);
-    _Z_PARSE_ARG(args.num_messages, "n", "number", atoi, DEFAULT_MESSAGES);
+    _Z_PARSE_ARG(args.samples, "s", "samples", parse_uint, DEFAULT_MEASUREMENTS);
+    _Z_PARSE_ARG(args.num_messages, "n", "number", parse_uint, DEFAULT_MESSAGES);
 
     parse_zenoh_common_args(argc, argv, config);
     const char *arg = check_unknown_opts(argc, argv);


### PR DESCRIPTION
## Summary

Two findings from reviewing the example argument parsing.

**Strict numeric parsing.** Every numeric option in the examples goes through `atoi`, which accepts anything: `"abc"` becomes `0`, `"10x"` becomes `10`, and `"-5"` is stored into an `unsigned` field as a huge value. All 19 call sites are counts, sizes, durations, or priorities, so none legitimately takes a negative number or trailing garbage.

This adds `parse_uint` to `parse_args.h`, next to the existing `parse_query_target` / `parse_priority` converters: `strtoul` with `errno`, leading-sign, and trailing-character checks, exiting with a message on anything but a plain decimal unsigned integer. All `atoi` sites are routed through it, including the positional size argument of the ping and throughput examples. `parse_priority` uses it too, so `"1abc"` is no longer accepted as priority 1.

**`--history` typo.** `z_advanced_pub` registered its history-size option as `"hisotry"`, making it unreachable by the name printed in its own `--help`.

## Validation

- All examples build with `-DZENOHC_TREAT_WARNING_AS_ERROR=ON`, unstable API and shared memory enabled (the widest example set).
- On the built binaries:
  - `z_advanced_pub --history 5` accepted; `--hisotry` now reported as unknown
  - `z_get --timeout abc`, `z_ping --samples 10x`, `z_sub_thr --samples -5`, `z_ping xyz` (positional) → `Invalid unsigned integer value [...]`
  - `z_pub_thr --priority 1abc` → rejected (previously accepted as 1); `--priority 9` → still `Unsupported priority value`; `--priority 3` → runs
- Each example's diff is exactly its `atoi` lines — no formatting churn.
