### PR TITLE
refactor: take z_open options by mutable pointer

### DIFF
--- a/include/zenoh_commons.h
+++ b/include/zenoh_commons.h
@@ -4758,7 +4758,7 @@ z_result_t z_obtain_shm_provider(const struct z_loaned_session_t *this_,
 ZENOHC_API
 z_result_t z_open(struct z_owned_session_t *this_,
                   struct z_moved_config_t *config,
-                  const struct z_open_options_t *_options);
+                  struct z_open_options_t *_options);
 /**
  * Constructs the default value for `z_open_options_t`.
  */

--- a/src/session.rs
+++ b/src/session.rs
@@ -89,7 +89,7 @@ pub extern "C" fn z_open_options_default(this_: &mut MaybeUninit<z_open_options_
 pub extern "C" fn z_open(
     this: &mut MaybeUninit<z_owned_session_t>,
     config: &mut z_moved_config_t,
-    _options: Option<&z_open_options_t>,
+    _options: Option<&mut z_open_options_t>,
 ) -> result::z_result_t {
     let this = this.as_rust_type_mut_uninit();
     let Some(config) = config.take_rust_type() else {


### PR DESCRIPTION
`z_open_options_t` was introduced as the extension point for future session-open parameters, but `z_open` currently takes it as `const z_open_options_t *`.

Other options structs (`z_put_options_t`, `z_get_options_t`, ...) carry moved fields (`z_moved_encoding_t *`, `z_moved_bytes_t *`) that the function consumes and resets to NULL, which is only possible through a mutable pointer. This PR changes `z_open` to take `z_open_options_t *` now, while the struct is still empty, so that adding moved fields later (for example, callbacks that must be owned by the runtime) is not an API break.

Existing callers are unaffected: everything in-tree passes `NULL`, and zenoh-cpp passes a pointer to a non-const local. Only a caller holding a pointer-to-const would need to change.

https://claude.ai/code/session_01UsKXKnpwnnsBHpdfSXZicK
